### PR TITLE
Fix importSampledFieldGeometry bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     # python wheel building can (and should) be disabled to speed up CI when working on a PR
     - BUILD_PYTHON_WHEELS=false
     - MSYS_URL='https://github.com/msys2/msys2-installer/releases/download/2020-09-03/msys2-base-x86_64-20200903.sfx.exe'
-    - CIBUILDWHEEL_VERSION=1.6.1
+    - CIBUILDWHEEL_VERSION=1.6.3
     # pypi TWINE_PASSWORD
     - secure: GFBxgbwP75qb0QW3jFO3e3fbfFLpYue+kUZGm3ArNZ9ExeXPGU3fxfxiBolEPnnPK98VlZZ8R0WBQptvWnaBN0tamt5r7OCXljQdpNgRF04MMa1gtbAEnuYjd6dHQ5CbdiEKxK4MnF28jJ+0wnw35E7YPGq357XWKwGFoG0HT9UenFd7HRbzsM0WmO7sog8bZYahYU+nyIDu6AVGlsc1b4XpVEu/pcuY2PexzYpV4wv+qVprRIeTwi2aFb4bmr3XcPZtyps3eiExLISHmz3mAuHIiNEt3wQA7Kjzsz93lm6DlGi3LSEXugfomGzg3oyHQC8oKKky/D6hHqnc9Jfow4Epj3aHvE4LP00TxDiyrjqvVGeCHa/RL/WIGJ/zZA4W7QTr2wvDOhw5EOuSmIW42tmOsOV4Zo/wr5d9A0r0VUfHhrsi1QUHmFFgTJXeTDyHYC32mvXy8EuaxLRFLBUVKE3gPfaYUgRafvx1Kn7H9WUmrpA7JAj2caMYD6UtKly1J6BFyTpPFlGgk3yxzVYgbeToOOrabQzGzYBuaxz6aysbyPra+rYF5SrJ/Dp4TPjfoE/1IIjmrbVpYEQGdfojnxxN6xnW7woPgq8IUDStw7iR83xyluWEtn1i1KlzRA8NMNdBHxgFWQ9rpE/DZikeJ8yb0FoEleMRjaE6G4C33rc=
 

--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -25,7 +25,7 @@ class ModelCompartments;
 class ModelMembranes;
 
 class ModelGeometry {
- private:
+private:
   double pixelWidth{1.0};
   QPointF physicalOrigin{QPointF(0, 0)};
   QSizeF physicalSize{QSizeF(0, 0)};
@@ -37,16 +37,16 @@ class ModelGeometry {
   libsbml::Model *sbmlModel{nullptr};
   ModelCompartments *modelCompartments{nullptr};
   ModelMembranes *modelMembranes{nullptr};
-  bool importDimensions(libsbml::Model *model);
+  bool importDimensions(const libsbml::Model *model);
   void writeDefaultGeometryToSBML();
   void updateMesh();
 
- public:
+public:
   ModelGeometry();
   explicit ModelGeometry(libsbml::Model *model, ModelCompartments *compartments,
                          ModelMembranes *membranes);
-  void importSampledFieldGeometry(libsbml::Model *model);
-  void importParametricGeometry(libsbml::Model *model);
+  void importSampledFieldGeometry(const libsbml::Model *model);
+  void importParametricGeometry(const libsbml::Model *model);
   void importSampledFieldGeometry(const QString &filename);
   void importGeometryFromImage(const QImage &img);
   void checkIfGeometryIsValid();
@@ -63,4 +63,4 @@ class ModelGeometry {
   void writeGeometryToSBML() const;
 };
 
-}  // namespace model
+} // namespace model

--- a/src/core/model/src/geometry_analytic.hpp
+++ b/src/core/model/src/geometry_analytic.hpp
@@ -14,8 +14,8 @@ namespace model {
 
 struct GeometrySampledField;
 
-GeometrySampledField importGeometryFromAnalyticGeometry(libsbml::Model *model,
-                                                        const QPointF &origin,
-                                                        const QSizeF &size);
+GeometrySampledField
+importGeometryFromAnalyticGeometry(const libsbml::Model *model,
+                                   const QPointF &origin, const QSizeF &size);
 
 } // namespace model

--- a/src/core/model/src/geometry_parametric.hpp
+++ b/src/core/model/src/geometry_parametric.hpp
@@ -26,7 +26,14 @@ class ModelCompartments;
 class ModelGeometry;
 class ModelMembranes;
 
+const libsbml::ParametricGeometry *
+getParametricGeometry(const libsbml::Geometry *geom);
+
 libsbml::ParametricGeometry *getParametricGeometry(libsbml::Geometry *geom);
+
+const libsbml::ParametricObject *
+getParametricObject(const libsbml::Model *model,
+                    const std::string &compartmentID);
 
 libsbml::ParametricObject *
 getOrCreateParametricObject(libsbml::Model *model,
@@ -37,7 +44,7 @@ getInteriorPixelPoints(const ModelGeometry *modelGeometry,
                        const ModelCompartments *modelCompartments);
 
 std::unique_ptr<mesh::Mesh>
-importParametricGeometryFromSBML(libsbml::Model *model,
+importParametricGeometryFromSBML(const libsbml::Model *model,
                                  const ModelGeometry *modelGeometry,
                                  const ModelCompartments *modelCompartments,
                                  const ModelMembranes *modelMembranes);

--- a/src/core/model/src/geometry_sampled_field.cpp
+++ b/src/core/model/src/geometry_sampled_field.cpp
@@ -198,7 +198,8 @@ static std::vector<std::pair<std::string, QRgb>> getCompartmentIdAndColours(
   return compartmentIdAndColours;
 }
 
-GeometrySampledField importGeometryFromSampledField(libsbml::Geometry *geom) {
+GeometrySampledField
+importGeometryFromSampledField(const libsbml::Geometry *geom) {
   GeometrySampledField gsf;
   if (geom == nullptr) {
     return gsf;

--- a/src/core/model/src/geometry_sampled_field.hpp
+++ b/src/core/model/src/geometry_sampled_field.hpp
@@ -23,7 +23,8 @@ struct GeometrySampledField {
 libsbml::SampledFieldGeometry *
 getOrCreateSampledFieldGeometry(libsbml::Geometry *geom);
 
-GeometrySampledField importGeometryFromSampledField(libsbml::Geometry *geom);
+GeometrySampledField
+importGeometryFromSampledField(const libsbml::Geometry *geom);
 
 void exportSampledFieldGeometry(libsbml::Geometry *geom,
                                 const QImage &compartmentImage);

--- a/src/core/model/src/model_parameters.cpp
+++ b/src/core/model/src/model_parameters.cpp
@@ -93,6 +93,10 @@ static SpatialCoordinates importSpatialCoordinates(libsbml::Model *model) {
         "x", libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_X,
         model);
   }
+  if (xparam->getName().empty()) {
+    SPDLOG_INFO("  - using Id as Name");
+    xparam->setName(xparam->getId());
+  }
   xparam->setUnits(model->getLengthUnits());
   xparam->setValue(0);
   s.x.id = xparam->getId();
@@ -104,6 +108,10 @@ static SpatialCoordinates importSpatialCoordinates(libsbml::Model *model) {
     yparam = createSpatialCoordParam(
         "y", libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_Y,
         model);
+  }
+  if (yparam->getName().empty()) {
+    SPDLOG_INFO("  - using Id as Name");
+    yparam->setName(yparam->getId());
   }
   yparam->setUnits(model->getLengthUnits());
   yparam->setValue(0);

--- a/src/core/model/src/sbml_utils.hpp
+++ b/src/core/model/src/sbml_utils.hpp
@@ -17,6 +17,8 @@ class Species;
 class Parameter;
 } // namespace libsbml
 
+const libsbml::SampledFieldGeometry *
+getSampledFieldGeometry(const libsbml::Geometry *geom);
 libsbml::SampledFieldGeometry *getSampledFieldGeometry(libsbml::Geometry *geom);
 const libsbml::Geometry *getGeometry(const libsbml::Model *model);
 libsbml::Geometry *getOrCreateGeometry(libsbml::Model *model);
@@ -32,6 +34,10 @@ getAdjacentCompartments(const libsbml::Model *model,
                         const std::string &compartmentId);
 
 bool getIsSpeciesConstant(const libsbml::Species *spec);
+
+const libsbml::Parameter *
+getSpatialCoordinateParam(const libsbml::Model *model,
+                          libsbml::CoordinateKind_t kind);
 
 libsbml::Parameter *getSpatialCoordinateParam(libsbml::Model *model,
                                               libsbml::CoordinateKind_t kind);


### PR DESCRIPTION
  - previously wrote sampled field back to the libsbml::Model it was imported from
  - if this was not the same as the user model, the sampled field was not saved correctly
  - make function take input libsbml::Model as const parameter to avoid similar future bugs
  - also make these similar import functions take a const libsbml::Model:
    - importDimensions
    - importParametricGeometry
    - importSampledFieldGeometry
    - importGeometryFromAnalyticGeometry
    - importParametricGeometryFromSBML
    - importGeometryFromSampledField
  - resolves #347

also

  - remove superseded interior points code from analytic geometry import
