### PR TITLE
change "max over species" concentration image normalisation option

### DIFF
--- a/src/core/mesh/src/contours.cpp
+++ b/src/core/mesh/src/contours.cpp
@@ -161,6 +161,7 @@ static std::vector<Boundary> extractClosedLoopBoundaries(
         contour.clear();
         auto membraneIndex =
             getMembraneIndex(membraneName, membraneColourPairs).value_or(0);
+        SPDLOG_TRACE("  - membrane index '{}'", membraneIndex);
         auto boundary =
             Boundary(points, isLoop, isMembrane, membraneName, membraneIndex);
         if (boundary.isValid()) {

--- a/src/core/model/src/model_membranes.cpp
+++ b/src/core/model/src/model_membranes.cpp
@@ -149,7 +149,7 @@ void ModelMembranes::importMembraneIdsAndNames(const libsbml::Model *model) {
           const auto &compB = m.getCompartmentB()->getId();
           if ((compA == c1 && compB == c2) || (compA == c2 && compB == c1)) {
             auto mIndex = ids.indexOf(m.getId().c_str());
-            SPDLOG_TRACE("Found membrane[{}] '' in SBML document", mIndex, mId);
+            SPDLOG_TRACE("Found membrane[{}] '{}' in SBML document", mIndex, mId);
             m.setId(mId);
             SPDLOG_TRACE("  id -> '{}'", mId);
             ids[mIndex] = QString::fromStdString(m.getId());


### PR DESCRIPTION
  - only take visible species into account (used to include species that are not being shown)
  - take max over all species in model (used to do this separately for each compartment)
  - this new behaviour is more intuitive / less surprising for users
  - resolves #353
