### PR TITLE
save display options to SBML document

### DIFF
--- a/src/core/common/inc/utils.hpp
+++ b/src/core/common/inc/utils.hpp
@@ -103,6 +103,9 @@ QStringList toQString(const std::vector<std::string> &v);
 QString dblToQStr(double x, int precision = 18);
 std::vector<QRgb> toStdVec(const QVector<QRgb> &q);
 
+std::vector<bool> toBool(const std::vector<int> &v);
+std::vector<int> toInt(const std::vector<bool> &v);
+
 template <typename T> std::vector<T> stringToVector(const std::string &str) {
   std::istringstream ss(str);
   return std::vector<T>(std::istream_iterator<T>(ss),
@@ -110,6 +113,9 @@ template <typename T> std::vector<T> stringToVector(const std::string &str) {
 }
 
 template <typename T> std::string vectorToString(const std::vector<T> &vec) {
+  if (vec.empty()) {
+    return {};
+  }
   std::stringstream ss;
   for (std::size_t i = 0; i < vec.size() - 1; ++i) {
     ss << std::scientific << std::setprecision(17) << vec[i] << " ";

--- a/src/core/common/src/utils.cpp
+++ b/src/core/common/src/utils.cpp
@@ -34,6 +34,28 @@ std::vector<QRgb> toStdVec(const QVector<QRgb> &q) {
   return v;
 }
 
+std::vector<bool> toBool(const std::vector<int> &v) {
+  std::vector<bool> r;
+  r.reserve(v.size());
+  for (auto i : v) {
+    r.push_back(i == 1);
+  }
+  return r;
+}
+
+std::vector<int> toInt(const std::vector<bool> &v) {
+  std::vector<int> r;
+  r.reserve(v.size());
+  for (auto b : v) {
+    if (b) {
+      r.push_back(1);
+    } else {
+      r.push_back(0);
+    }
+  }
+  return r;
+}
+
 const std::vector<QColor> indexedColours::colours = std::vector<QColor>{
     {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
     {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},

--- a/src/core/common/src/utils_t.cpp
+++ b/src/core/common/src/utils_t.cpp
@@ -59,6 +59,12 @@ SCENARIO("Utils", "[core/common/utils][core/common][core][utils]") {
       REQUIRE(v2s == s);
       REQUIRE(utils::stringToVector<int>(v2s) == v);
     }
+    WHEN("type: int, empty") {
+      auto v2s = utils::vectorToString(std::vector<int>{});
+      auto s2v = utils::stringToVector<int>("");
+      REQUIRE(v2s == "");
+      REQUIRE(s2v == std::vector<int>{});
+    }
     WHEN("type: QRgba") {
       std::vector<QRgb> v{0xffffffff, 0x00ffffff, 123, 8435122, 0xfffffffe, 0};
       std::string s("4294967295 16777215 123 8435122 4294967294 0");
@@ -74,6 +80,16 @@ SCENARIO("Utils", "[core/common/utils][core/common][core][utils]") {
       auto v2s = utils::vectorToString(v);
       REQUIRE(utils::stringToVector<double>(v2s) == v);
     }
+  }
+  GIVEN("int <-> bool") {
+    std::vector<bool> vb{true, true, false, true, false};
+    std::vector<int> vi{1, 1, 0, 1, 0};
+    auto vb2i = utils::toInt(vb);
+    auto vi2b = utils::toBool(vi);
+    REQUIRE(vb2i == vi);
+    REQUIRE(vi2b == vb);
+    REQUIRE(utils::toBool(vb2i) == vb);
+    REQUIRE(utils::toInt(vi2b) == vi);
   }
   GIVEN("QPointIndexer") {
     QSize size(20, 16);

--- a/src/core/model/inc/model.hpp
+++ b/src/core/model/inc/model.hpp
@@ -6,13 +6,8 @@
 
 #pragma once
 
-#include <QColor>
-#include <QImage>
-#include <QStringList>
-#include <memory>
-#include <optional>
-
 #include "model_compartments.hpp"
+#include "model_display_options.hpp"
 #include "model_functions.hpp"
 #include "model_geometry.hpp"
 #include "model_math.hpp"
@@ -21,6 +16,11 @@
 #include "model_reactions.hpp"
 #include "model_species.hpp"
 #include "model_units.hpp"
+#include <QColor>
+#include <QImage>
+#include <QStringList>
+#include <memory>
+#include <optional>
 
 // SBML forward declarations
 namespace libsbml {
@@ -113,5 +113,8 @@ public:
   std::string inlineExpr(const std::string &mathExpression) const;
 
   std::string getRateRule(const std::string &speciesID) const;
+
+  DisplayOptions getDisplayOptions() const;
+  void setDisplayOptions(const DisplayOptions &displayOptions);
 };
 } // namespace model

--- a/src/core/model/inc/model_display_options.hpp
+++ b/src/core/model/inc/model_display_options.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <vector>
+
+namespace model{
+
+struct DisplayOptions {
+  std::vector<bool> showSpecies;
+  bool showMinMax{true};
+  bool normaliseOverAllTimepoints{true};
+  bool normaliseOverAllSpecies{true};
+};
+
+}

--- a/src/core/model/src/CMakeLists.txt
+++ b/src/core/model/src/CMakeLists.txt
@@ -34,4 +34,5 @@ target_sources(
          model_parameters_t.cpp
          model_reactions_t.cpp
          model_species_t.cpp
-         model_units_t.cpp)
+         model_units_t.cpp
+         xml_annotation_t.cpp)

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -1,5 +1,4 @@
 #include "model.hpp"
-
 #include "id.hpp"
 #include "logger.hpp"
 #include "mesh.hpp"
@@ -184,6 +183,15 @@ std::string Model::getRateRule(const std::string &speciesID) const {
     return inlineExpr(rule->getFormula());
   }
   return {};
+}
+
+DisplayOptions Model::getDisplayOptions() const {
+  return getDisplayOptionsAnnotation(doc->getModel())
+      .value_or(DisplayOptions{});
+}
+
+void Model::setDisplayOptions(const DisplayOptions &displayOptions) {
+  addDisplayOptionsAnnotation(doc->getModel(), displayOptions);
 }
 
 } // namespace model

--- a/src/core/model/src/xml_annotation.hpp
+++ b/src/core/model/src/xml_annotation.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "model_display_options.hpp"
 #include <QRgb>
 #include <optional>
 #include <string>
@@ -10,7 +11,8 @@
 namespace libsbml {
 class ParametricGeometry;
 class Species;
-}  // namespace libsbml
+class Model;
+} // namespace libsbml
 
 namespace mesh {
 class Mesh;
@@ -27,11 +29,17 @@ struct MeshParamsAnnotationData {
 void removeMeshParamsAnnotation(libsbml::ParametricGeometry *pg);
 void addMeshParamsAnnotation(libsbml::ParametricGeometry *pg,
                              const mesh::Mesh *mesh);
-std::optional<MeshParamsAnnotationData> getMeshParamsAnnotationData(
-    const libsbml::ParametricGeometry *pg);
+std::optional<MeshParamsAnnotationData>
+getMeshParamsAnnotationData(const libsbml::ParametricGeometry *pg);
 
 void removeSpeciesColourAnnotation(libsbml::Species *species);
 void addSpeciesColourAnnotation(libsbml::Species *species, QRgb colour);
 std::optional<QRgb> getSpeciesColourAnnotation(const libsbml::Species *species);
 
-}  // namespace sbml
+void removeDisplayOptionsAnnotation(libsbml::Model *model);
+void addDisplayOptionsAnnotation(libsbml::Model *model,
+                                 const model::DisplayOptions &displayOptions);
+std::optional<model::DisplayOptions>
+getDisplayOptionsAnnotation(const libsbml::Model *model);
+
+} // namespace model

--- a/src/core/model/src/xml_annotation_t.cpp
+++ b/src/core/model/src/xml_annotation_t.cpp
@@ -1,0 +1,73 @@
+#include "catch_wrapper.hpp"
+#include "xml_annotation.hpp"
+#include <QFile>
+#include <sbml/SBMLTypes.h>
+#include <sbml/extension/SBMLDocumentPlugin.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+#include <sbml/packages/spatial/extension/SpatialExtension.h>
+
+SCENARIO("XML Annotations",
+         "[core/model/xml_annotation][core/"
+         "model][core][model][xml_annotation][xml][annotation]") {
+  QFile f(":/models/ABtoC.xml");
+  f.open(QIODevice::ReadOnly);
+  std::unique_ptr<libsbml::SBMLDocument> doc(
+      libsbml::readSBMLFromString(f.readAll().toStdString().c_str()));
+  GIVEN("Display Options annotations") {
+    auto *model = doc->getModel();
+    // model initially has no display options annotations
+    REQUIRE(model::getDisplayOptionsAnnotation(model).has_value() == false);
+
+    // create & save some options
+    model::DisplayOptions opts;
+    opts.showMinMax = false;
+    opts.showSpecies = {true, false, true, true, false};
+    opts.normaliseOverAllSpecies = true;
+    opts.normaliseOverAllTimepoints = false;
+    model::addDisplayOptionsAnnotation(model, opts);
+
+    auto newOpts = model::getDisplayOptionsAnnotation(model);
+    REQUIRE(newOpts.has_value());
+    REQUIRE(newOpts->showMinMax == opts.showMinMax);
+    REQUIRE(newOpts->showSpecies == opts.showSpecies);
+    REQUIRE(newOpts->normaliseOverAllSpecies == opts.normaliseOverAllSpecies);
+    REQUIRE(newOpts->normaliseOverAllTimepoints ==
+            opts.normaliseOverAllTimepoints);
+
+    // save sbml file
+    libsbml::writeSBMLToFile(doc.get(), "annotation.xml");
+
+    // save default display options
+    auto defOpts = model::DisplayOptions{};
+    model::addDisplayOptionsAnnotation(model, defOpts);
+    newOpts = model::getDisplayOptionsAnnotation(model);
+    REQUIRE(newOpts.has_value());
+    REQUIRE(newOpts->showMinMax == defOpts.showMinMax);
+    REQUIRE(newOpts->showSpecies == defOpts.showSpecies);
+    REQUIRE(newOpts->normaliseOverAllSpecies ==
+            defOpts.normaliseOverAllSpecies);
+    REQUIRE(newOpts->normaliseOverAllTimepoints ==
+            defOpts.normaliseOverAllTimepoints);
+
+    // remove the options annotations
+    model::removeDisplayOptionsAnnotation(model);
+    REQUIRE(model::getDisplayOptionsAnnotation(model).has_value() == false);
+
+    // remove is no-op if nothing to remove
+    model::removeDisplayOptionsAnnotation(model);
+    REQUIRE(model::getDisplayOptionsAnnotation(model).has_value() == false);
+
+    // load saved model with annotations
+    QFile f2("annotation.xml");
+    f2.open(QIODevice::ReadOnly);
+    std::unique_ptr<libsbml::SBMLDocument> doc2(
+        libsbml::readSBMLFromString(f2.readAll().toStdString().c_str()));
+    auto opts2 = model::getDisplayOptionsAnnotation(doc2->getModel());
+    REQUIRE(opts2.has_value());
+    REQUIRE(opts2->showMinMax == opts.showMinMax);
+    REQUIRE(opts2->showSpecies == opts.showSpecies);
+    REQUIRE(opts2->normaliseOverAllSpecies == opts.normaliseOverAllSpecies);
+    REQUIRE(opts2->normaliseOverAllTimepoints ==
+            opts.normaliseOverAllTimepoints);
+  }
+}

--- a/src/gui/dialogs/dialogdisplayoptions.cpp
+++ b/src/gui/dialogs/dialogdisplayoptions.cpp
@@ -28,17 +28,17 @@ static bool indexToBool(int value) {
 DialogDisplayOptions::DialogDisplayOptions(
     const QStringList &compartmentNames,
     const std::vector<QStringList> &speciesNames,
-    const std::vector<bool> &showSpecies, bool showMinMax,
-    bool normaliseOverAllTimepoints, bool normaliseOverAllSpecies,
+    const model::DisplayOptions &displayOptions,
     const std::vector<PlotWrapperObservable> &plotWrapperObservables,
     QWidget *parent)
     : QDialog(parent), ui{std::make_unique<Ui::DialogDisplayOptions>()},
-      nSpecies(showSpecies.size()), observables(plotWrapperObservables) {
+      nSpecies(displayOptions.showSpecies.size()),
+      observables(plotWrapperObservables) {
   ui->setupUi(this);
 
   auto *ls = ui->listSpecies;
   ls->clear();
-  auto iterChecked = showSpecies.cbegin();
+  auto iterChecked = displayOptions.showSpecies.cbegin();
   for (int iComp = 0; iComp < compartmentNames.size(); ++iComp) {
     auto *comp = new QTreeWidgetItem(ls, {compartmentNames[iComp]});
     comp->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
@@ -55,7 +55,7 @@ DialogDisplayOptions::DialogDisplayOptions(
     }
   }
   ls->expandAll();
-  ui->chkShowMinMaxRanges->setChecked(showMinMax);
+  ui->chkShowMinMaxRanges->setChecked(displayOptions.showMinMax);
   for (const auto &observable : observables) {
     auto *obs =
         new QTreeWidgetItem(ui->listObservables, {observable.expression});
@@ -65,9 +65,9 @@ DialogDisplayOptions::DialogDisplayOptions(
     ui->listObservables->addTopLevelItem(obs);
   }
   ui->cmbNormaliseOverAllTimepoints->setCurrentIndex(
-      boolToIndex(normaliseOverAllTimepoints));
+      boolToIndex(displayOptions.normaliseOverAllTimepoints));
   ui->cmbNormaliseOverAllSpecies->setCurrentIndex(
-      boolToIndex(normaliseOverAllSpecies));
+      boolToIndex(displayOptions.normaliseOverAllSpecies));
 
   connect(ui->listObservables, &QTreeWidget::currentItemChanged, this,
           &DialogDisplayOptions::listObservables_currentItemChanged);

--- a/src/gui/dialogs/dialogdisplayoptions.hpp
+++ b/src/gui/dialogs/dialogdisplayoptions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "model_display_options.hpp"
 #include <QDialog>
 #include <memory>
 
@@ -17,8 +18,7 @@ public:
   explicit DialogDisplayOptions(
       const QStringList &compartmentNames,
       const std::vector<QStringList> &speciesNames,
-      const std::vector<bool> &showSpecies, bool showMinMax,
-      bool normaliseOverAllTimepoints, bool normaliseOverAllSpecies,
+      const model::DisplayOptions &displayOptions,
       const std::vector<PlotWrapperObservable> &plotWrapperObservables,
       QWidget *parent = nullptr);
   ~DialogDisplayOptions();

--- a/src/gui/dialogs/dialogdisplayoptions_t.cpp
+++ b/src/gui/dialogs/dialogdisplayoptions_t.cpp
@@ -12,12 +12,15 @@ SCENARIO("DialogDisplayOptions",
     std::vector<QStringList> species;
     species.push_back({"s1_c1", "s2_c1"});
     species.push_back({"s1_c2", "s2_c2", "s3_c2"});
-    std::vector<bool> showSpecies{true, false, false, true, false};
-    DialogDisplayOptions dia(compartments, species, showSpecies, false, false,
-                             false, {});
+    model::DisplayOptions opts;
+    opts.showSpecies = {true, false, false, true, false};
+    opts.showMinMax = false;
+    opts.normaliseOverAllTimepoints = false;
+    opts.normaliseOverAllSpecies = false;
+    DialogDisplayOptions dia(compartments, species, opts, {});
     ModalWidgetTimer mwt;
     WHEN("user does nothing") {
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getShowMinMax() == false);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
@@ -26,9 +29,9 @@ SCENARIO("DialogDisplayOptions",
       mwt.addUserAction({"Space"});
       mwt.start();
       dia.exec();
-      showSpecies[0] = true;
-      showSpecies[1] = true;
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      opts.showSpecies[0] = true;
+      opts.showSpecies[1] = true;
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -38,9 +41,9 @@ SCENARIO("DialogDisplayOptions",
       mwt.addUserAction({"Space", "Space"});
       mwt.start();
       dia.exec();
-      showSpecies[0] = false;
-      showSpecies[1] = false;
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      opts.showSpecies[0] = false;
+      opts.showSpecies[1] = false;
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -48,8 +51,8 @@ SCENARIO("DialogDisplayOptions",
       mwt.addUserAction({"Down", "Space"});
       mwt.start();
       dia.exec();
-      showSpecies[0] = false;
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      opts.showSpecies[0] = false;
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -57,7 +60,7 @@ SCENARIO("DialogDisplayOptions",
       mwt.addUserAction({"Down", "Space", "Space"});
       mwt.start();
       dia.exec();
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -102,8 +105,8 @@ SCENARIO("DialogDisplayOptions",
       mwt.addUserAction({"Space", "Down", "Down", "Down", "Space"});
       mwt.start();
       dia.exec();
-      showSpecies = {true, true, true, true, true};
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      opts.showSpecies = {true, true, true, true, true};
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -112,8 +115,8 @@ SCENARIO("DialogDisplayOptions",
           {"Space", "Space", "Down", "Down", "Down", "Space", "Space"});
       mwt.start();
       dia.exec();
-      showSpecies = {false, false, false, false, false};
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      opts.showSpecies = {false, false, false, false, false};
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
@@ -123,15 +126,18 @@ SCENARIO("DialogDisplayOptions",
     std::vector<QStringList> species;
     species.push_back({"s1_c1", "s2_c1"});
     species.push_back({"s1_c2", "s2_c2", "s3_c2"});
-    std::vector<bool> showSpecies{true, false, false, true, false};
+    model::DisplayOptions opts;
+    opts.showSpecies = {true, false, false, true, false};
+    opts.showMinMax = false;
+    opts.normaliseOverAllTimepoints = false;
+    opts.normaliseOverAllSpecies = false;
     std::vector<PlotWrapperObservable> observables;
     observables.push_back({"1", "1", true});
     observables.push_back({"s1_c1*2", "s1_c1*2", true});
-    DialogDisplayOptions dia(compartments, species, showSpecies, false, false,
-                             false, observables);
+    DialogDisplayOptions dia(compartments, species, opts, observables);
     ModalWidgetTimer mwt;
     WHEN("user does nothing") {
-      REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getShowSpecies() == opts.showSpecies);
       REQUIRE(dia.getShowMinMax() == false);
       REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
       REQUIRE(dia.getNormaliseOverAllSpecies() == false);

--- a/src/gui/tabs/tabsimulate.hpp
+++ b/src/gui/tabs/tabsimulate.hpp
@@ -1,6 +1,7 @@
 // TabSimulate
 
 #pragma once
+#include "dialogdisplayoptions.hpp"
 #include "plotwrapper.hpp"
 #include "simulate.hpp"
 #include <QWidget>
@@ -41,17 +42,14 @@ private:
   std::unique_ptr<simulate::Simulation> sim;
   simulate::SimulatorType simType{simulate::SimulatorType::DUNE};
   simulate::Options simOptions;
+  model::DisplayOptions displayOptions;
   QVector<double> time;
   QVector<QImage> images;
   QStringList compartmentNames;
   std::vector<QStringList> speciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesToDraw;
-  bool normaliseImageIntensityOverAllTimepoints{true};
-  bool normaliseImageIntensityOverAllSpecies{true};
-  std::vector<bool> speciesVisible;
   std::vector<PlotWrapperObservable> observables;
   std::vector<bool> obsVisible;
-  bool plotShowMinMax{true};
   bool isSimulationRunning{false};
 
   void btnSimulate_clicked();


### PR DESCRIPTION
  - read/write simulation plot/image display options as xml annotation
  - TabSimulate reads them on loading of model
  - TabSimulate writes them to model when updated by user
  - on import, if showSpecies size doesn't match number of species, ignore it
  - resolves #351