### PR TITLE
add support for DUNE newton parameters

### DIFF
--- a/src/core/simulate/inc/simulate_options.hpp
+++ b/src/core/simulate/inc/simulate_options.hpp
@@ -19,6 +19,8 @@ struct DuneOptions {
   double increase{1.5};
   double decrease{0.5};
   bool writeVTKfiles{false};
+  double newtonRelErr{1e-8};
+  double newtonAbsErr{1e-12};
 };
 
 enum class PixelIntegratorType { RK101, RK212, RK323, RK435 };

--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -115,6 +115,21 @@ static void addTimeStepping(IniFile &ini,
   ini.addValue("max_step", duneOptions.maxDt, doublePrecision);
   ini.addValue("decrease_factor", duneOptions.decrease, doublePrecision);
   ini.addValue("increase_factor", duneOptions.increase, doublePrecision);
+
+  ini.addSection("model", "time_stepping", "newton");
+  ini.addValue("reduction", duneOptions.newtonRelErr, doublePrecision);
+  ini.addValue("min_linear_reduction", 1e-3, doublePrecision);
+  ini.addValue("fixed_linear_reduction", "false");
+  ini.addValue("max_iterations", 40);
+  ini.addValue("absolute_limit", duneOptions.newtonAbsErr, doublePrecision);
+  ini.addValue("reassemble_threshold", 0.0, doublePrecision);
+  ini.addValue("keep_matrix", "true");
+  ini.addValue("force_iteration", "false");
+
+  ini.addSection("model", "time_stepping", "newton.linear_search");
+  ini.addValue("strategy", "hackbuschReusken");
+  ini.addValue("max_iterations", 10);
+  ini.addValue("damping_factor", 0.5, doublePrecision);
 }
 
 static void addLogging(IniFile &ini, bool forExternalUse) {

--- a/src/gui/dialogs/dialogsimulationoptions.cpp
+++ b/src/gui/dialogs/dialogsimulationoptions.cpp
@@ -89,6 +89,10 @@ void DialogSimulationOptions::setupConnections() {
           &DialogSimulationOptions::txtDuneDecrease_editingFinished);
   connect(ui->chkDuneVTK, &QCheckBox::stateChanged, this,
           &DialogSimulationOptions::chkDuneVTK_stateChanged);
+  connect(ui->txtDuneNewtonRel, &QLineEdit::editingFinished, this,
+          &DialogSimulationOptions::txtDuneNewtonRel_editingFinished);
+  connect(ui->txtDuneNewtonAbs, &QLineEdit::editingFinished, this,
+          &DialogSimulationOptions::txtDuneNewtonAbs_editingFinished);
   connect(ui->btnDuneReset, &QPushButton::clicked, this,
           &DialogSimulationOptions::resetDuneToDefaults);
   // Pixel tab
@@ -129,6 +133,8 @@ void DialogSimulationOptions::loadDuneOpts() {
   ui->txtDuneIncrease->setText(dblToQString(opt.dune.increase));
   ui->txtDuneDecrease->setText(dblToQString(opt.dune.decrease));
   ui->chkDuneVTK->setChecked(opt.dune.writeVTKfiles);
+  ui->txtDuneNewtonRel->setText(dblToQString(opt.dune.newtonRelErr));
+  ui->txtDuneNewtonAbs->setText(dblToQString(opt.dune.newtonAbsErr));
 }
 
 void DialogSimulationOptions::cmbDuneIntegrator_currentIndexChanged(int index) {
@@ -162,6 +168,16 @@ void DialogSimulationOptions::txtDuneDecrease_editingFinished() {
 
 void DialogSimulationOptions::chkDuneVTK_stateChanged() {
   opt.dune.writeVTKfiles = ui->chkDuneVTK->isChecked();
+}
+
+void DialogSimulationOptions::txtDuneNewtonRel_editingFinished() {
+  opt.dune.newtonRelErr = ui->txtDuneNewtonRel->text().toDouble();
+  loadDuneOpts();
+}
+
+void DialogSimulationOptions::txtDuneNewtonAbs_editingFinished() {
+  opt.dune.newtonAbsErr = ui->txtDuneNewtonAbs->text().toDouble();
+  loadDuneOpts();
 }
 
 void DialogSimulationOptions::resetDuneToDefaults() {

--- a/src/gui/dialogs/dialogsimulationoptions.hpp
+++ b/src/gui/dialogs/dialogsimulationoptions.hpp
@@ -30,6 +30,8 @@ private:
   void txtDuneIncrease_editingFinished();
   void txtDuneDecrease_editingFinished();
   void chkDuneVTK_stateChanged();
+  void txtDuneNewtonRel_editingFinished();
+  void txtDuneNewtonAbs_editingFinished();
   void resetDuneToDefaults();
   void loadPixelOpts();
   void cmbPixelIntegrator_currentIndexChanged(int index);

--- a/src/gui/dialogs/dialogsimulationoptions.ui
+++ b/src/gui/dialogs/dialogsimulationoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>626</width>
-    <height>529</height>
+    <width>659</width>
+    <height>619</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,17 +38,69 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="5" column="1">
-          <widget class="QLineEdit" name="txtDuneIncrease">
-           <property name="toolTip">
-            <string>The factor by which the timestep is increased after a successful integration step</string>
+         <item row="6" column="0">
+          <widget class="QLabel" name="lblDuneDecrease">
+           <property name="text">
+            <string>Decrease factor</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QLineEdit" name="txtDuneMinDt">
+         <item row="8" column="0">
+          <widget class="QLabel" name="lblDuneNewtonRel">
+           <property name="text">
+            <string>Newton relative error</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDuneDiscretization">
+           <item>
+            <property name="text">
+             <string>1st order FEM</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="lblDuneIncrease">
+           <property name="text">
+            <string>Increase factor</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblDuneDt">
+           <property name="text">
+            <string>Initial timestep</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
+          <widget class="QPushButton" name="btnDuneReset">
+           <property name="text">
+            <string>Reset to default values</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="chkDuneVTK">
            <property name="toolTip">
-            <string>The minimum allowed timestep</string>
+            <string>Output the simulation results in VTK files, which can be viewed using ParaView</string>
+           </property>
+           <property name="text">
+            <string>VTK (ParaView)</string>
            </property>
           </widget>
          </item>
@@ -99,19 +151,61 @@
            </item>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbDuneDiscretization">
-           <item>
-            <property name="text">
-             <string>1st order FEM</string>
-            </property>
-           </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="lblOutputFiles">
+           <property name="text">
+            <string>Output files</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lblDuneMinDt">
+         <item row="5" column="1">
+          <widget class="QLineEdit" name="txtDuneIncrease">
+           <property name="toolTip">
+            <string>The factor by which the timestep is increased after a successful integration step</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLineEdit" name="txtDuneDecrease">
+           <property name="toolTip">
+            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0" colspan="2">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLineEdit" name="txtDuneNewtonRel">
+           <property name="toolTip">
+            <string>The relative (to initial) size of defect at which the Newton iteration is considered to have converged</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLineEdit" name="txtDuneMaxDt">
+           <property name="toolTip">
+            <string>The maximum allowed timestep</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblDuneDiscretization">
            <property name="text">
-            <string>Min timestep</string>
+            <string>Discretization</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -128,6 +222,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="txtDuneDt">
+           <property name="toolTip">
+            <string>The initial timestep to use at the start of the simulation</string>
+           </property>
+          </widget>
+         </item>
          <item row="4" column="0">
           <widget class="QLabel" name="lblDuneMaxDt">
            <property name="text">
@@ -138,104 +239,37 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
-          <widget class="QPushButton" name="btnDuneReset">
-           <property name="text">
-            <string>Reset to default values</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="QCheckBox" name="chkDuneVTK">
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="txtDuneMinDt">
            <property name="toolTip">
-            <string>Output the simulation results in VTK files, which can be viewed using ParaView</string>
-           </property>
-           <property name="text">
-            <string>VTK (ParaView)</string>
+            <string>The minimum allowed timestep</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="0" colspan="2">
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="lblDuneDecrease">
+         <item row="3" column="0">
+          <widget class="QLabel" name="lblDuneMinDt">
            <property name="text">
-            <string>Decrease factor</string>
+            <string>Min timestep</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
-          <widget class="QLineEdit" name="txtDuneDecrease">
+         <item row="9" column="0">
+          <widget class="QLabel" name="lblDuneNewtonAbs">
+           <property name="text">
+            <string>Newton absolute error</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QLineEdit" name="txtDuneNewtonAbs">
            <property name="toolTip">
-            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lblDuneIncrease">
-           <property name="text">
-            <string>Increase factor</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblDuneDiscretization">
-           <property name="text">
-            <string>Discretization</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLineEdit" name="txtDuneMaxDt">
-           <property name="toolTip">
-            <string>The maximum allowed timestep</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="lblOutputFiles">
-           <property name="text">
-            <string>Output files</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lblDuneDt">
-           <property name="text">
-            <string>Initial timestep</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="txtDuneDt">
-           <property name="toolTip">
-            <string>The initial timestep to use at the start of the simulation</string>
+            <string>The absolute size of defect at which the Newton iteration is considered to have converged</string>
            </property>
           </widget>
          </item>
@@ -469,6 +503,8 @@
   <tabstop>txtDuneIncrease</tabstop>
   <tabstop>txtDuneDecrease</tabstop>
   <tabstop>chkDuneVTK</tabstop>
+  <tabstop>txtDuneNewtonRel</tabstop>
+  <tabstop>txtDuneNewtonAbs</tabstop>
   <tabstop>btnDuneReset</tabstop>
   <tabstop>cmbPixelIntegrator</tabstop>
   <tabstop>txtPixelRelErr</tabstop>

--- a/src/gui/dialogs/dialogsimulationoptions_t.cpp
+++ b/src/gui/dialogs/dialogsimulationoptions_t.cpp
@@ -18,6 +18,8 @@ SCENARIO(
   options.dune.increase = 1.11;
   options.dune.decrease = 0.77;
   options.dune.writeVTKfiles = true;
+  options.dune.newtonRelErr = 4e-4;
+  options.dune.newtonAbsErr = 9e-9;
   options.pixel.integrator = simulate::PixelIntegratorType::RK435;
   options.pixel.maxErr = {0.01, 4e-4};
   options.pixel.maxTimestep = 0.2;
@@ -39,6 +41,8 @@ SCENARIO(
     REQUIRE(options.dune.increase == dbl_approx(1.11));
     REQUIRE(options.dune.decrease == dbl_approx(0.77));
     REQUIRE(options.dune.writeVTKfiles == true);
+    REQUIRE(options.dune.newtonRelErr == dbl_approx(4e-4));
+    REQUIRE(options.dune.newtonAbsErr == dbl_approx(9e-9));
     REQUIRE(opt.pixel.integrator == simulate::PixelIntegratorType::RK435);
     REQUIRE(opt.pixel.maxErr.rel == dbl_approx(4e-4));
     REQUIRE(opt.pixel.maxErr.abs == dbl_approx(0.01));
@@ -52,7 +56,8 @@ SCENARIO(
     mwt.addUserAction({"Tab", "Tab", "Down", "Down", "9", "Tab", ".",
                        "4",   "Tab", "1",    "e",    "-", "1",   "2",
                        "Tab", "9",   "Tab",  "1",    ".", "2",   "Tab",
-                       "0",   ".",   "7",    "Tab",  " "});
+                       "0",   ".",   "7",    "Tab",  " ", "Tab", "1",
+                       "e",   "-",   "7",    "Tab",  "0"});
     mwt.start();
     dia.exec();
     auto opt = dia.getOptions();
@@ -63,10 +68,12 @@ SCENARIO(
     REQUIRE(opt.dune.increase == 1.2);
     REQUIRE(opt.dune.decrease == 0.7);
     REQUIRE(opt.dune.writeVTKfiles == false);
+    REQUIRE(opt.dune.newtonRelErr == dbl_approx(1e-7));
+    REQUIRE(opt.dune.newtonAbsErr == dbl_approx(0));
   }
   WHEN("user resets to Dune defaults") {
-    mwt.addUserAction(
-        {"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", " "});
+    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab",
+                       "Tab", "Tab", "Tab", " "});
     mwt.start();
     dia.exec();
     simulate::DuneOptions defaultOpts{};


### PR DESCRIPTION
  - add two more DUNE simulation options to GUI
    - Newton relative error=1e-8 -> `reduction` newton param
    - Newton absolute error=1e-12 -> `absolute_limit` newton param
  - write default values for all other newton params to ini file
  - resolves #378
