### PR TITLE
fix 274 worker thread

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,144 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -148,10 +148,10 @@ static void printSimulatorBenchmarks(const BenchmarkParams &params) {
         iter += iter;
         ++ln2iter;
         time.start();
-        sim.doTimestep(iter * dt);
-        if(!sim.errorMessage().empty()){
-            fmt::print("Simulation error: {}\n", sim.errorMessage());
-            exit(1);
+        sim.doTimesteps(iter * dt);
+        if (!sim.errorMessage().empty()) {
+          fmt::print("Simulation error: {}\n", sim.errorMessage());
+          exit(1);
         }
         elapsed_ms = time.elapsed();
       }

--- a/benchmark/pixel.cpp
+++ b/benchmark/pixel.cpp
@@ -118,7 +118,7 @@ static void printFixedTimestepPixel(const PixelParams &params) {
     QElapsedTimer time;
     long long elapsed_ms = 0;
     time.start();
-    std::size_t steps = sim.doTimestep(params.integration_time);
+    std::size_t steps = sim.doTimesteps(params.integration_time);
     elapsed_ms = time.elapsed();
     fmt::print("{:11.8f}\t{:20.16e}\t{:20.16e}\t{}\t{}\t{}\n", dt,
                sim.getConc(sim.getTimePoints().size() - 1,

--- a/cli/src/cli_simulate.cpp
+++ b/cli/src/cli_simulate.cpp
@@ -42,7 +42,7 @@ bool doSimulation(const Params &params) {
   fmt::print("# t = {} [img{}.png]\n", sim.getTimePoints().back(),
              sim.getTimePoints().size() - 1);
   while (sim.getTimePoints().back() < params.simulationTime) {
-    sim.doTimestep(params.imageInterval);
+    sim.doTimesteps(params.imageInterval);
     if (const auto &e = sim.errorMessage(); !e.empty()) {
       fmt::print("\n\nError during simulation: {}\n\n", e);
       return false;

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -217,7 +217,7 @@ std::vector<SimulationResult> Model::simulate(double simulationTime,
   }
   results.push_back(getSimulationResult(sim.get()));
   while (sim->getTimePoints().back() < simulationTime) {
-    sim->doTimestep(imageInterval);
+    sim->doTimesteps(imageInterval);
     if (const auto &e = sim->errorMessage(); !e.empty()) {
       throw SmeRuntimeError(fmt::format("Error during simulation: {}", e));
     }

--- a/src/core/common/src/symbolic.cpp
+++ b/src/core/common/src/symbolic.cpp
@@ -32,7 +32,7 @@ namespace SymEngine {
 #endif
 class muPrinter : public StrPrinter {
 protected:
-  virtual void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
+  void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
                           const RCP<const Basic> &b) override;
 };
 #ifdef __GNUC__

--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -6,6 +6,7 @@
 #include <QImage>
 #include <QRgb>
 #include <QSize>
+#include <atomic>
 #include <cstddef>
 #include <limits>
 #include <map>
@@ -47,6 +48,9 @@ private:
   // compartment->species
   std::vector<std::vector<double>> maxConcWholeSimulation;
   QSize imageSize;
+  std::atomic<bool> isRunning{false};
+  std::atomic<bool> stopRequested{false};
+  std::atomic<std::size_t> nCompletedTimesteps{0};
   void initModel(const model::Model &model);
   void updateConcentrations(double t);
 
@@ -56,7 +60,7 @@ public:
                       const Options &options = {});
   ~Simulation();
 
-  std::size_t doTimestep(double time);
+  std::size_t doTimesteps(double time, std::size_t nSteps = 1);
   const std::string &errorMessage() const;
   const std::vector<std::string> &getCompartmentIds() const;
   const std::vector<std::string> &
@@ -80,6 +84,10 @@ public:
   // map from name to vec<vec<double>> species concentration for python bindings
   std::map<std::string, std::vector<std::vector<double>>>
   getPyConcs(std::size_t timeIndex) const;
+  std::size_t getNCompletedTimesteps() const;
+  bool getIsRunning() const;
+  bool getIsStopping() const;
+  void requestStop();
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/basesim.hpp
+++ b/src/core/simulate/src/basesim.hpp
@@ -13,7 +13,8 @@ public:
   virtual std::size_t run(double time) = 0;
   virtual const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const = 0;
-  virtual const std::string& errorMessage() const = 0;
+  virtual const std::string &errorMessage() const = 0;
+  virtual void requestStop() = 0;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -267,6 +267,10 @@ DuneSim::getConcentrations(std::size_t compartmentIndex) const {
 
 const std::string &DuneSim::errorMessage() const { return currentErrorMessage; }
 
+void DuneSim::requestStop() {
+  SPDLOG_DEBUG("Not implemented - ignoring request");
+}
+
 void DuneSim::updateSpeciesConcentrations() {
   for (std::size_t iComp = 0; iComp < compartmentSpeciesIndex.size(); ++iComp) {
     std::size_t nSpecies = compartmentSpeciesIndex[iComp].size();

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -71,7 +71,8 @@ public:
   std::size_t run(double time) override;
   const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
-  virtual const std::string &errorMessage() const override;
+  const std::string &errorMessage() const override;
+  void requestStop() override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim.cpp
+++ b/src/core/simulate/src/pixelsim.cpp
@@ -314,6 +314,10 @@ std::size_t PixelSim::run(double time) {
       }
     }
     ++steps;
+    if (stopRequested.load(std::memory_order_relaxed)) {
+      SPDLOG_DEBUG("Stopping simulation early");
+      return steps;
+    }
   }
   SPDLOG_DEBUG("t={} integrated using {} steps ({:3.1f}% discarded)", time,
                steps + discardedSteps,
@@ -336,6 +340,10 @@ double PixelSim::getLowerOrderConcentration(std::size_t compartmentIndex,
 
 const std::string &PixelSim::errorMessage() const {
   return currentErrorMessage;
+}
+
+void PixelSim::requestStop() {
+  stopRequested.store(true, std::memory_order_relaxed);
 }
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -4,6 +4,7 @@
 
 #include "basesim.hpp"
 #include "simulate_options.hpp"
+#include <atomic>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -43,6 +44,7 @@ private:
   bool useTBB{false};
   std::size_t numMaxThreads{1};
   std::string currentErrorMessage;
+  std::atomic<bool> stopRequested{false};
 
 public:
   explicit PixelSim(
@@ -58,6 +60,7 @@ public:
                                     std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;
   virtual const std::string &errorMessage() const override;
+  virtual void requestStop() override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim_impl.hpp
+++ b/src/core/simulate/src/pixelsim_impl.hpp
@@ -26,13 +26,6 @@ class Membrane;
 
 namespace simulate {
 
-template <typename Body>
-void serial_for(std::size_t i0, std::size_t n, const Body &body) {
-  for (std::size_t i = i0; i < n; ++i) {
-    body(i);
-  }
-}
-
 class ReacEval {
 private:
   // symengine reaction expression

--- a/src/gui/tabs/tabreactions.hpp
+++ b/src/gui/tabs/tabreactions.hpp
@@ -20,13 +20,13 @@ class QTreeWidgetItem;
 class TabReactions : public QWidget {
   Q_OBJECT
 
- public:
+public:
   explicit TabReactions(model::Model &model, QLabelMouseTracker *mouseTracker,
                         QWidget *parent = nullptr);
   ~TabReactions();
   void loadModelData(const QString &selection = {});
 
- private:
+private:
   std::unique_ptr<Ui::TabReactions> ui;
   model::Model &model;
   QLabelMouseTracker *lblGeometry;

--- a/src/gui/tabs/tabsimulate.hpp
+++ b/src/gui/tabs/tabsimulate.hpp
@@ -5,6 +5,7 @@
 #include "plotwrapper.hpp"
 #include "simulate.hpp"
 #include <QWidget>
+#include <future>
 #include <memory>
 
 namespace Ui {
@@ -26,12 +27,12 @@ class TabSimulate : public QWidget {
 public:
   explicit TabSimulate(model::Model &doc, QLabelMouseTracker *mouseTracker,
                        QWidget *parent = nullptr);
-  ~TabSimulate();
+  ~TabSimulate() override;
   void loadModelData();
   void stopSimulation();
   void useDune(bool enable);
   void reset();
-  simulate::Options getOptions() const;
+  [[nodiscard]] simulate::Options getOptions() const;
   void setOptions(const simulate::Options &options);
 
 private:
@@ -50,7 +51,9 @@ private:
   std::vector<std::vector<std::size_t>> compartmentSpeciesToDraw;
   std::vector<PlotWrapperObservable> observables;
   std::vector<bool> obsVisible;
-  bool isSimulationRunning{false};
+  std::future<std::size_t> simSteps;
+  QTimer plotRefreshTimer;
+  QProgressDialog *progressDialog;
 
   void btnSimulate_clicked();
   void btnSliceImage_clicked();

--- a/src/gui/tabs/tabsimulate.ui
+++ b/src/gui/tabs/tabsimulate.ui
@@ -37,13 +37,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="6">
-      <widget class="QPushButton" name="btnStopSimulation">
-       <property name="text">
-        <string>Stop</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="lblCurrentTime">
        <property name="text">
@@ -68,16 +61,6 @@
       <widget class="QLabel" name="lblSimLength">
        <property name="text">
         <string>Simulation length:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="5">
-      <widget class="QPushButton" name="btnSimulate">
-       <property name="whatsThis">
-        <string>Run a simulation of the specified length, using the timestep 'dt' for the numerical integration</string>
-       </property>
-       <property name="text">
-        <string>Simulate</string>
        </property>
       </widget>
      </item>
@@ -127,10 +110,30 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="5" colspan="2">
+      <widget class="QPushButton" name="btnSimulate">
+       <property name="whatsThis">
+        <string>Run a simulation of the specified length, using the timestep 'dt' for the numerical integration</string>
+       </property>
+       <property name="text">
+        <string>Simulate</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtSimLength</tabstop>
+  <tabstop>txtSimInterval</tabstop>
+  <tabstop>btnSimulate</tabstop>
+  <tabstop>btnResetSimulation</tabstop>
+  <tabstop>hslideTime</tabstop>
+  <tabstop>btnSliceImage</tabstop>
+  <tabstop>btnExport</tabstop>
+  <tabstop>btnDisplayOptions</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/tabs/tabsimulate_t.cpp
+++ b/src/gui/tabs/tabsimulate_t.cpp
@@ -43,22 +43,42 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   sendKeyEvents(txtSimDt, {"End", "Backspace", "Backspace", "Backspace",
                            "Backspace", "0", ".", "1"});
   sendMouseClick(btnSimulate);
+  REQUIRE(btnSimulate->isEnabled() == false);
+  // simulation happens asynchronously - wait until finished
+  while(!btnSimulate->isEnabled()){
+    wait(100);
+  }
+  REQUIRE(btnSimulate->isEnabled() == true);
   REQUIRE(hslideTime->isEnabled() == true);
-  REQUIRE(hslideTime->maximum() == 2);
   REQUIRE(hslideTime->minimum() == 0);
 
   sendMouseClick(btnResetSimulation);
   REQUIRE(hslideTime->isEnabled() == true);
+  REQUIRE(btnSimulate->isEnabled() == true);
 
   // repeat simulation using Pixel simulator
   tab.useDune(false);
   sendMouseClick(btnSimulate);
+  REQUIRE(btnSimulate->isEnabled() == false);
+  while(!btnSimulate->isEnabled()){
+    wait(100);
+  }
   REQUIRE(hslideTime->isEnabled() == true);
   REQUIRE(hslideTime->maximum() == 2);
   REQUIRE(hslideTime->minimum() == 0);
 
   sendMouseClick(btnResetSimulation);
   REQUIRE(hslideTime->isEnabled() == true);
+
+  // repeat sim but click cancel straight away
+  // cancel simulation early
+  mwt.addUserAction({"Escape"});
+  mwt.start();
+  sendMouseClick(btnSimulate);
+  // wait until simulation stops
+  while(!btnSimulate->isEnabled()){
+    wait(100);
+  }
 
   // hide all species
   mwt.addUserAction({"Space"});


### PR DESCRIPTION
     - keep UI responsive while running simulation
      - display modal progress dialog with cancel button
        - prevents user from changing tabs / model while simulation is running
      - simulation now has some extra threadsafe (via atomics) functions
        - getNCompletedTimesteps() to see which data is available
        - requestCancel() to stop simulation early
        - getIsRunning() and getIsStopping()
      - note known bug: stopping simulation early then continuing may give a jump in the results, due to the partially completed step
