### PR TITLE
improve meshing boundary generation

### DIFF
--- a/src/core/mesh/src/CMakeLists.txt
+++ b/src/core/mesh/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   core
   PRIVATE boundary.cpp
+          contour_map.cpp
           contours.cpp
           image_boundaries.cpp
           line_simplifier.cpp
@@ -10,6 +11,8 @@ target_sources(
   core_tests
   PUBLIC boundary.cpp
          boundary_t.cpp
+         contour_map.cpp
+         contour_map_t.cpp
          contours.cpp
          contours_t.cpp
          image_boundaries.cpp

--- a/src/core/mesh/src/contour_map.cpp
+++ b/src/core/mesh/src/contour_map.cpp
@@ -1,0 +1,78 @@
+#include "contour_map.hpp"
+#include <QColor>
+#include <QPoint>
+#include <QSize>
+#include <algorithm>
+#include <limits>
+#include <opencv2/core/cvdef.h>
+#include <opencv2/core/hal/interface.h>
+#include <opencv2/core/matx.hpp>
+#include <opencv2/imgproc.hpp>
+
+namespace mesh {
+
+ContourMap::ContourMap(const QSize &size,
+                       const std::vector<std::vector<cv::Point>> &contours)
+    : indices(size.height() + 2, size.width() + 2, CV_32SC1, cv::Scalar(-1)) {
+  int contourIndex{0};
+  for (const auto &contour : contours) {
+    for (const auto &pixel : contour) {
+      indices.at<int>(pixel.y + 1, pixel.x + 1) = contourIndex;
+    }
+    ++contourIndex;
+  }
+}
+
+std::size_t ContourMap::getContourIndex(const cv::Point &p) const {
+  auto i = indices.at<int>(p.y + 1, p.x + 1);
+  if (i == -1) {
+    return nullIndex;
+  }
+  return static_cast<std::size_t>(i);
+}
+
+// looks for an adjacent pixel that belongs to another contour
+// if found returns contour index, otherwise returns nullIndex
+std::size_t ContourMap::getAdjacentContourIndex(const cv::Point &p) const {
+  auto pci = getContourIndex(p);
+  for (const auto &dp : nn4) {
+    auto pp = p + dp;
+    if (auto nci = getContourIndex(pp); nci != pci && nci != nullIndex) {
+      return nci;
+    }
+  }
+  return nullIndex;
+}
+
+// if given a valid contourIndex:
+//  - returns true if there is an adjacent pixel to p from this contour
+// if given nullIndex as contourIndex:
+//  - returns true if *all* adjacent pixels are not part of another contour
+bool ContourMap::hasNeighbourWithThisIndex(const cv::Point &p,
+                                           std::size_t contourIndex) const {
+  if (contourIndex == nullIndex) {
+    auto pci = getContourIndex(p);
+    return std::all_of(nn4.cbegin(), nn4.cend(),
+                       [&p, pci, this](const auto &dp) {
+                         auto pp = p + dp;
+                         auto i = getContourIndex(pp);
+                         return i == pci || i == nullIndex;
+                       });
+  }
+  return std::any_of(nn4.cbegin(), nn4.cend(),
+                     [&p, contourIndex, this](const auto &dp) {
+                       auto pp = p + dp;
+                       auto i = static_cast<std::size_t>(getContourIndex(pp));
+                       return i == contourIndex;
+                     });
+}
+
+bool ContourMap::hasNeighbourWithThisIndex(const std::vector<cv::Point> &points,
+                                           std::size_t contourIndex) const {
+  return std::all_of(points.cbegin(), points.cend(),
+                     [this, contourIndex](const cv::Point &p) {
+                       return hasNeighbourWithThisIndex(p, contourIndex);
+                     });
+}
+
+} // namespace mesh

--- a/src/core/mesh/src/contour_map.hpp
+++ b/src/core/mesh/src/contour_map.hpp
@@ -1,0 +1,39 @@
+// ContourMap
+
+#pragma once
+
+#include "boundary.hpp"
+#include "mesh_types.hpp"
+#include <QImage>
+#include <QRgb>
+#include <array>
+#include <cstddef>
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/mat.inl.hpp>
+#include <opencv2/core/types.hpp>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mesh {
+
+class ContourMap {
+private:
+  inline const static std::array<cv::Point, 4> nn4{
+      cv::Point(1, 0), cv::Point(-1, 0), cv::Point(0, -1), cv::Point(0, 1)};
+  cv::Mat indices;
+
+public:
+  ContourMap(const QSize &size,
+             const std::vector<std::vector<cv::Point>> &contours);
+  std::size_t getContourIndex(const cv::Point &p) const;
+  std::size_t getAdjacentContourIndex(const cv::Point &p) const;
+  bool hasNeighbourWithThisIndex(const cv::Point &p,
+                                 std::size_t contourIndex) const;
+  bool hasNeighbourWithThisIndex(const std::vector<cv::Point> &points,
+                                 std::size_t contourIndex) const;
+  static constexpr std::size_t nullIndex{std::numeric_limits<std::size_t>::max()};
+};
+
+} // namespace mesh

--- a/src/core/mesh/src/contour_map_t.cpp
+++ b/src/core/mesh/src/contour_map_t.cpp
@@ -1,0 +1,83 @@
+#include "catch_wrapper.hpp"
+#include "contour_map.hpp"
+#include <QSize>
+
+SCENARIO("ContourMap",
+         "[core/mesh/contour_map][core/mesh][core][contour_map]") {
+  GIVEN("single contour") {
+    auto none = mesh::ContourMap::nullIndex;
+    QSize imgSize(10, 10);
+    std::vector<cv::Point> c0{{0, 0}, {1, 0}, {2, 0}, {2, 1},
+                              {2, 2}, {1, 2}, {0, 2}, {0, 1}};
+    std::vector<cv::Point> c1{{0, 3}, {1, 3}, {2, 3}};
+    std::vector<cv::Point> c2{{6, 6}, {6, 7}, {7, 8}};
+    mesh::ContourMap contourMap(imgSize, {c0, c1, c2});
+
+    // (9,9) not a contour - no neighbouring pixels from other contours
+    REQUIRE(contourMap.getContourIndex({9, 9}) == none);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({9, 9}, 0) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({9, 9}, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({9, 9}, 2) == false);
+    // all adjacent pixels are null
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({9, 9}, none) == true);
+    REQUIRE(contourMap.getAdjacentContourIndex({9, 9}) == none);
+
+    // (8,8) not a contour - (7,8) adjacent pixel is from c2
+    REQUIRE(contourMap.getContourIndex({8, 8}) == none);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({8, 8}, 0) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({8, 8}, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({8, 8}, 2) == true);
+    // not all adjacent pixels are null
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({8, 8}, none) == false);
+    REQUIRE(contourMap.getAdjacentContourIndex({8, 8}) == 2);
+
+    // (0,0) belongs to c0 - no adjacent pixels from other contours
+    REQUIRE(contourMap.getContourIndex({0, 0}) == 0);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({0, 0}, 0) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({0, 0}, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({0, 0}, 2) == false);
+    // all adjacent pixels are null (or also from c0)
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({0, 0}, none) == true);
+    REQUIRE(contourMap.getAdjacentContourIndex({0, 0}) == none);
+
+    // (2,2) belongs to c0 - (2,3) adjacent pixel is from c1
+    REQUIRE(contourMap.getContourIndex({2, 2}) == 0);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 2}, 0) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 2}, 1) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 2}, 2) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 2}, none) == false);
+    REQUIRE(contourMap.getAdjacentContourIndex({2, 2}) == 1);
+
+    // (2,3) belongs to c1 - (2,2) adjacent pixel is from c0
+    REQUIRE(contourMap.getContourIndex({2, 3}) == 1);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 3}, 0) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 3}, 1) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 3}, 2) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({2, 3}, none) == false);
+    REQUIRE(contourMap.getAdjacentContourIndex({2, 3}) == 0);
+
+    // (6,7) belongs to c2 - no adjacent pixels from other contours
+    REQUIRE(contourMap.getContourIndex({6, 7}) == 2);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({6, 7}, 0) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({6, 7}, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({6, 7}, 2) == true);
+    // all adjacent pixels are null (or also from c2)
+    REQUIRE(contourMap.hasNeighbourWithThisIndex({6, 7}, none) == true);
+    REQUIRE(contourMap.getAdjacentContourIndex({6, 7}) == none);
+
+    // some but not all pixels in c0 have neighbours from another contour
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c0, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c0, 2) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c0, none) == false);
+
+    // every pixel of c1 also has a pixel from c0 as a neighbour
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c1, 0) == true);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c1, 2) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c1, none) == false);
+
+    // c2 is completely isolated
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c2, 0) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c2, 1) == false);
+    REQUIRE(contourMap.hasNeighbourWithThisIndex(c2, none) == true);
+  }
+}

--- a/src/core/mesh/src/contours.hpp
+++ b/src/core/mesh/src/contours.hpp
@@ -39,21 +39,4 @@ public:
   std::vector<Boundary> &getBoundaries();
 };
 
-class ContourMap {
-private:
-  inline const static std::array<cv::Point, 4> nn4{
-      cv::Point(1, 0), cv::Point(-1, 0), cv::Point(0, -1), cv::Point(0, 1)};
-  cv::Mat indices;
-
-public:
-  ContourMap(const QSize &size,
-             const std::vector<std::vector<cv::Point>> &contours);
-  std::size_t getContourIndex(const cv::Point &p) const;
-  std::size_t getAdjacentContourIndex(const cv::Point &p) const;
-  bool hasNeighbourWithThisIndex(const cv::Point &p,
-                                 std::size_t contourIndex) const;
-  bool hasNeighbourWithThisIndex(const std::vector<cv::Point> &points,
-                                 std::size_t contourIndex) const;
-};
-
 } // namespace mesh

--- a/src/core/mesh/src/contours_t.cpp
+++ b/src/core/mesh/src/contours_t.cpp
@@ -257,24 +257,123 @@ SCENARIO("Contours", "[core/mesh/contours][core/mesh][core][contours]") {
       REQUIRE(!b2.isMembrane());
     }
   }
-  GIVEN("a variety of geometry images: don't crash") {
-    for (int i = 1; i < 21; ++i) {
-      QString filename(QString(":/test/geometry/gt%1").arg(i));
+  GIVEN("two cells with some boundaries touching edge of image") {
+    QStringList filenames{"gt4.png", "gt10.png"};
+    for (const auto &filename : filenames) {
       CAPTURE(filename.toStdString());
-      QImage img(filename);
+      QImage img(QString(":/test/geometry/%1").arg(filename));
+
+      // single compartment: black (outer)
+      // pair of loop boundaries: single compartment with a hole in it
+      mesh::Contours cBlack(img, {qRgb(0, 0, 0)}, {});
+      REQUIRE(cBlack.getBoundaries().size() == 2);
+      REQUIRE(cBlack.getFixedPoints().empty());
+      for (const auto &b : cBlack.getBoundaries()) {
+        REQUIRE(b.isValid());
+        REQUIRE(b.isLoop());
+        REQUIRE(!b.isMembrane());
+      }
+
+      // two independent compartments: white (inner)
+      // 2 outer loop boundaries
+      mesh::Contours cWhite(img, {qRgb(255, 255, 255)}, {});
+      REQUIRE(cWhite.getBoundaries().size() == 2);
+      REQUIRE(cWhite.getFixedPoints().empty());
+      for(const auto &b : cWhite.getBoundaries()) {
+        REQUIRE(b.isValid());
+        REQUIRE(b.isLoop());
+        REQUIRE(!b.isMembrane());
+      }
+
+      // 3 compartments: black and white
+      // 3 non-loop boundary lines, of which 1 membrane + 1 loop membrane
+      QRgb col0 = qRgb(0, 0, 0);
+      QRgb col1 = qRgb(255, 255, 255);
+      std::vector<QRgb> compartments{{col0, col1}};
+      std::vector<std::pair<std::string, mesh::ColourPair>> membranes{
+          {"outside-cell", {col0, col1}}};
+      mesh::Contours c(img, compartments, membranes);
+      REQUIRE(c.getBoundaries().size() == 4);
+      REQUIRE(c.getFixedPoints().size() == 2);
+      int nValid{0};
+      int nLoops{0};
+      int nMembranes{0};
+      for(const auto &b : c.getBoundaries()){
+        nValid += static_cast<int>(b.isValid());
+        nLoops += static_cast<int>(b.isLoop());
+        nMembranes += static_cast<int>(b.isMembrane());
+      }
+      REQUIRE(nValid == 4);
+      REQUIRE(nLoops == 1);
+      REQUIRE(nMembranes == 2);
+    }
+  }
+  GIVEN("three cells with some boundaries touching edge of image") {
+    QStringList filenames{"gt15.png"};
+    for (const auto &filename : filenames) {
+      CAPTURE(filename.toStdString());
+      QImage img(QString(":/test/geometry/%1").arg(filename));
 
       // single compartment: black (outer)
       // single outer loop boundary
       mesh::Contours cBlack(img, {qRgb(0, 0, 0)}, {});
+      REQUIRE(cBlack.getBoundaries().size() == 1);
+      REQUIRE(cBlack.getFixedPoints().empty());
+      for (const auto &b : cBlack.getBoundaries()) {
+        REQUIRE(b.isValid());
+        REQUIRE(b.isLoop());
+        REQUIRE(!b.isMembrane());
+      }
+
+      // three independent compartments: white (inner)
+      // 3 outer loop boundaries
+      mesh::Contours cWhite(img, {qRgb(255, 255, 255)}, {});
+      REQUIRE(cWhite.getBoundaries().size() == 3);
+      REQUIRE(cWhite.getFixedPoints().empty());
+      for(const auto &b : cWhite.getBoundaries()) {
+        REQUIRE(b.isValid());
+        REQUIRE(b.isLoop());
+        REQUIRE(!b.isMembrane());
+      }
+
+      // 4 compartments: black and white
+      // 9 non-loop boundary lines, of which 3 membranes
+      QRgb col0 = qRgb(0, 0, 0);
+      QRgb col1 = qRgb(255, 255, 255);
+      std::vector<QRgb> compartments{{col0, col1}};
+      std::vector<std::pair<std::string, mesh::ColourPair>> membranes{
+          {"outside-cell", {col0, col1}}};
+      mesh::Contours c(img, compartments, membranes);
+      REQUIRE(c.getBoundaries().size() == 9);
+      REQUIRE(c.getFixedPoints().size() == 6);
+      int nValid{0};
+      int nLoops{0};
+      int nMembranes{0};
+      for(const auto &b : c.getBoundaries()){
+        nValid += static_cast<int>(b.isValid());
+        nLoops += static_cast<int>(b.isLoop());
+        nMembranes += static_cast<int>(b.isMembrane());
+      }
+      REQUIRE(nValid == 9);
+      REQUIRE(nLoops == 0);
+      REQUIRE(nMembranes == 3);
+    }
+  }
+  GIVEN("difficult images: at least don't crash") {
+    QStringList filenames{"gt2.png", "gt6.png", "gt7.png", "gt8.png", "gt14.png", "gt17.png"};
+    for (const auto &filename : filenames) {
+      CAPTURE(filename.toStdString());
+      QImage img(QString(":/test/geometry/%1").arg(filename));
+
+      // single compartment: black (outer)
+      mesh::Contours cBlack(img, {qRgb(0, 0, 0)}, {});
       REQUIRE_NOTHROW(cBlack.getBoundaries());
 
       // single compartment: white (inner)
-      // single outer loop boundary
       mesh::Contours cWhite(img, {qRgb(255, 255, 255)}, {});
       REQUIRE_NOTHROW(cWhite.getBoundaries());
 
       // two compartments: black and white
-      // three non-loop boundary lines, of which one membrane
       QRgb col0 = qRgb(0, 0, 0);
       QRgb col1 = qRgb(255, 255, 255);
       std::vector<QRgb> compartments{{col0, col1}};


### PR DESCRIPTION
  - strengthen closed loop criteria
    - previously we extracted a closed loop membrane boundary from a pair of contours A, B if every pixel of A has a neighbour from B
    - now we also require that the converse holds, i.e. every pixel of B must also have a neighbour from A
  - if end points are not a multiple of 3
    - most likely there was a single pixel contour that was discarded (all single pixel contours are discarded as they are produced as artefacts of the splitting process)
    - identify the likely location as the (non-loop) boundary line with the smallest distance between its end points
    - insert a straight line contour between these two points
    - there are certainly cases where this heuristic will fail, but it is an improvement on the previous behaviour
  - refactor mesh::ContourMap into separate .cpp/.hpp pair and add tests
  - resolves #392
