### PR TITLE
improve line simplification

### DIFF
--- a/src/core/mesh/src/boundary_t.cpp
+++ b/src/core/mesh/src/boundary_t.cpp
@@ -15,6 +15,13 @@ SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][core][boundary]") {
         {3, 1},
         {1, 3},
     };
+    // 4-point approximation to loop
+    std::vector<QPoint> p4{
+        {0, 0},
+        {3, 1},
+        {1, 3},
+        {-1, 2},
+    };
     WHEN("Non-membrane") {
       mesh::Boundary boundary(points, true);
       REQUIRE(boundary.isLoop() == true);
@@ -30,8 +37,8 @@ SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][core][boundary]") {
       // automatically determine number of points
       auto nPoints = boundary.setMaxPoints();
       REQUIRE(boundary.getMaxPoints() == nPoints);
-      REQUIRE(nPoints == 3);
-      REQUIRE(boundary.getPoints() == p3);
+      REQUIRE(nPoints == 4);
+      REQUIRE(boundary.getPoints() == p4);
     }
     WHEN("Membrane") {
       mesh::Boundary boundary(points, true, true, "membrane");
@@ -49,8 +56,8 @@ SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][core][boundary]") {
       // automatically determine number of points
       auto nPoints = boundary.setMaxPoints();
       REQUIRE(boundary.getMaxPoints() == nPoints);
-      REQUIRE(nPoints == 3);
-      REQUIRE(boundary.getPoints() == p3);
+      REQUIRE(nPoints == 4);
+      REQUIRE(boundary.getPoints() == p4);
     }
   }
   GIVEN("Non-loop") {

--- a/src/core/mesh/src/contours.cpp
+++ b/src/core/mesh/src/contours.cpp
@@ -352,7 +352,7 @@ getDistanceToOtherPoints(std::size_t i0, const cv::Point &point,
       } else {
         dist[j] = cv::norm(lines[j / 2].points.back() - point);
       }
-      SPDLOG_WARN("  - line {}, front:{}, dist {}", j / 2, j % 2 == 0, dist[j]);
+      SPDLOG_DEBUG("  - line {}, front:{}, dist {}", j / 2, j % 2 == 0, dist[j]);
     }
   }
   return dist;
@@ -380,7 +380,7 @@ static void mergeEndPointTriplets(std::vector<ContourLine> &lines,
       }
     }
     ContourLine cl;
-    SPDLOG_WARN("  - adding line from ({},{}) to ({},{})", pStart.x, pStart.y,
+    SPDLOG_DEBUG("  - adding line from ({},{}) to ({},{})", pStart.x, pStart.y,
                 pEnd.x, pEnd.y);
     cl.points = drawStraightLine(pStart, pEnd, cvImg);
     lines.push_back(std::move(cl));
@@ -399,16 +399,16 @@ static void mergeEndPointTriplets(std::vector<ContourLine> &lines,
     if (i0 % 2 != 0) {
       point = lines[i0 / 2].points.back();
     }
-    SPDLOG_WARN("line {}, end point ({},{}), front: {}", i0 / 2, point.x,
+    SPDLOG_DEBUG("line {}, end point ({},{}), front: {}", i0 / 2, point.x,
                 point.y, i0 % 2 == 0);
     auto dist = getDistanceToOtherPoints(i0, point, lines, endPointIsMerged);
     // closest two end points:
     auto i1 = utils::min_element_index(dist);
-    SPDLOG_WARN("    -> closest point: line {} front: {} (dist: {})", i1 / 2,
+    SPDLOG_DEBUG("    -> closest point: line {} front: {} (dist: {})", i1 / 2,
                 i1 % 2 == 0, dist[i1]);
     dist[i1] = std::numeric_limits<double>::max();
     auto i2 = utils::min_element_index(dist);
-    SPDLOG_WARN("    -> next-closest point: line {} front: {} (dist: {})",
+    SPDLOG_DEBUG("    -> next-closest point: line {} front: {} (dist: {})",
                 i2 / 2, i2 % 2 == 0, dist[i2]);
     connectNewEndPoint(lines[i1 / 2].points, point, i1 % 2 == 0, cvImg);
     connectNewEndPoint(lines[i2 / 2].points, point, i2 % 2 == 0, cvImg);

--- a/src/core/mesh/src/line_simplifier.hpp
+++ b/src/core/mesh/src/line_simplifier.hpp
@@ -26,6 +26,7 @@ private:
   std::vector<std::size_t> priorities{};
   LineError getLineError(const std::vector<QPoint> &line) const;
   bool valid{true};
+  bool closedLoop{false};
 
 public:
   void getSimplifiedLine(std::vector<QPoint> &line,

--- a/src/core/mesh/src/line_simplifier_t.cpp
+++ b/src/core/mesh/src/line_simplifier_t.cpp
@@ -109,7 +109,7 @@ SCENARIO("Simplify Lines",
 
       // allow total deviation of 0.5 pixels
       ls.getSimplifiedLine(line, {0.5, 0});
-      REQUIRE(line.size() == 5);
+      REQUIRE(line.size() == 6);
 
       // allow average deviation of 0.1 pixels
       ls.getSimplifiedLine(line, {0, 0.1});
@@ -117,7 +117,7 @@ SCENARIO("Simplify Lines",
 
       // allow total deviation of 3 pixels
       ls.getSimplifiedLine(line, {3.0, 0});
-      REQUIRE(line.size() == 3);
+      REQUIRE(line.size() == 4);
 
       // allow average deviation of 1 pixel
       ls.getSimplifiedLine(line, {0, 1.0});

--- a/src/core/mesh/src/triangulate.cpp
+++ b/src/core/mesh/src/triangulate.cpp
@@ -215,7 +215,7 @@ getTriangleIndicesFromTriangulateio(const triangle::triangulateio &io) {
     auto compIndex = static_cast<std::size_t>(io.triangleattributelist[i]) - 1;
     triangleIndices[compIndex].push_back({{t0, t1, t2}});
   }
-  while (triangleIndices.back().empty()) {
+  while (!triangleIndices.empty() && triangleIndices.back().empty()) {
     // numberofregions may be larger than the actual number of compartments
     // if multiple regions have the same compartment index
     triangleIndices.pop_back();

--- a/src/gui/tabs/tabgeometry.ui
+++ b/src/gui/tabs/tabgeometry.ui
@@ -380,6 +380,9 @@
                <property name="minimum">
                 <number>2</number>
                </property>
+               <property name="maximum">
+                <number>999</number>
+               </property>
                <property name="value">
                 <number>12</number>
                </property>
@@ -466,7 +469,7 @@
              <item row="1" column="1" colspan="2">
               <widget class="QSpinBox" name="spinMaxTriangleArea">
                <property name="minimum">
-                <number>2</number>
+                <number>1</number>
                </property>
                <property name="maximum">
                 <number>9999</number>


### PR DESCRIPTION
- include implicit line closing last-point->first-point segment when calculating errors
- also add errors from any left over pixels
  - can occur if boundary intersects itself, i.e. the same pixel occurs more than once in a loop
  - in this case the error could be significantly underestimated
  - resolves #395

also

- in triangulate check vector is not empty before calling .back()
