### PR TITLE
update linux docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ To get started, download and run the GUI for your operating system
 
 Or take a look at the [documentation](https://spatial-model-editor.readthedocs.io/)
 
+*Note: on linux some additional system libraries are required that may not be installed by default. To install them:*
+
+*  Ubuntu/Debian: `sudo apt-get install libxcb-xinerama0`
+*  Fedora/RHEL/CentOS: `sudo yum install xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm`
+
 ![screenshot](docs/img/mesh.png)
 
 ## Contributing

--- a/docs/quickstart/get-started.rst
+++ b/docs/quickstart/get-started.rst
@@ -11,7 +11,13 @@ No installation required, just download and run the executable for your operatin
 *  |icon-windows|_ `windows <https://github.com/spatial-model-editor/spatial-model-editor/releases/latest/download/spatial-model-editor.exe>`_
 
 .. tip::
-   You may have to give permission before your operating system will run the executable: ``chmod +x spatial-model-editor`` on linux, right-click open on macOS, "More info"->"Run anyway" on windows.
+   You may have to give permission before your operating system will run the executable:
+   ``chmod +x spatial-model-editor`` on linux, right-click open on macOS, "More info"->"Run anyway" on windows.
+
+Note: on linux some additional system libraries are required that may not be installed by default. To install them:
+
+*  Ubuntu/Debian: ``sudo apt-get install libxcb-xinerama0``
+*  Fedora/RHEL/CentOS: ``sudo yum install xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm``
 
 .. |icon-linux| image:: ../img/icon-linux.png
 .. _icon-linux: https://github.com/spatial-model-editor/spatial-model-editor/releases/latest/download/spatial-model-editor


### PR DESCRIPTION
  - Qt depends on more xcb-related system libs as of 5.15
  - This means our linux binaries no longer run on many default linux installs
  - Add instructions to install the missing libs for common linux distros
