### PR TITLE
improve mesh interior points code

### DIFF
--- a/src/core/mesh/inc/mesh.hpp
+++ b/src/core/mesh/inc/mesh.hpp
@@ -52,7 +52,6 @@ public:
   Mesh();
   // constructor to generate mesh from supplied image
   explicit Mesh(const QImage &image,
-                const std::vector<std::vector<QPointF>> &interiorPoints = {},
                 std::vector<std::size_t> maxPoints = {},
                 std::vector<std::size_t> maxTriangleArea = {},
                 double pixelWidth = 1.0,
@@ -75,6 +74,7 @@ public:
                                      std::size_t maxTriangleArea);
   std::size_t getCompartmentMaxTriangleArea(std::size_t compartmentIndex) const;
   const std::vector<std::size_t> &getCompartmentMaxTriangleArea() const;
+  const std::vector<std::vector<QPointF>>& getCompartmentInteriorPoints() const;
   void setPhysicalGeometry(double pixelWidth,
                            const QPointF &originPoint = QPointF(0, 0));
   // return vertices as an array of doubles for SBML

--- a/src/core/mesh/src/boundary.hpp
+++ b/src/core/mesh/src/boundary.hpp
@@ -40,6 +40,6 @@ public:
 
 std::vector<Boundary>
 constructBoundaries(const QImage &img,
-                    const std::vector<QRgb> &compartmentColours);
+                    const std::vector<QRgb> &compartmentColours, std::vector<std::vector<QPointF>>* interiorPoints = nullptr);
 
 } // namespace mesh

--- a/src/core/mesh/src/mesh_t.cpp
+++ b/src/core/mesh/src/mesh_t.cpp
@@ -16,8 +16,7 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][core][mesh]") {
     imgBoundary.emplace_back(img.width() - 1, img.height() - 1);
     imgBoundary.emplace_back(img.width() - 1, 0);
 
-    mesh::Mesh mesh(img, {{QPointF(8, 8)}}, {}, {999}, 1.0, QPointF(0, 0),
-                    std::vector<QRgb>{col});
+    mesh::Mesh mesh(img, {}, {999}, 1.0, QPointF(0, 0), std::vector<QRgb>{col});
 
     // check boundaries
     REQUIRE(mesh.getNumBoundaries() == 1);
@@ -164,7 +163,7 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][core][mesh]") {
     // flip y-axis to match (0,0) == bottom-left of meshing output
     img = img.mirrored(false, true);
 
-    mesh::Mesh mesh(img, {{QPointF(6, 6)}}, {}, {999}, 1.0, QPointF(0, 0),
+    mesh::Mesh mesh(img, {}, {999, 999}, 1.0, QPointF(0, 0),
                     std::vector<QRgb>{bgcol, col});
 
     // check boundaries image
@@ -177,7 +176,7 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][core][mesh]") {
     auto col1 = utils::indexedColours()[1].rgba();
     REQUIRE(boundaryImage.pixel(1, 1) == col0);
     REQUIRE(boundaryImage.pixel(4, 5) == col0);
-    REQUIRE(boundaryImage.pixel(72,96) == col0);
+    REQUIRE(boundaryImage.pixel(72, 96) == col0);
     REQUIRE(boundaryImage.pixel(72, 1) == col0);
     REQUIRE(boundaryImage.pixel(22, 76) == 0);
     // anti-aliasing means pixel may not have exactly the expected color:

--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -39,7 +39,6 @@ private:
   ModelMembranes *modelMembranes{nullptr};
   bool importDimensions(const libsbml::Model *model);
   void writeDefaultGeometryToSBML();
-  void updateMesh();
 
 public:
   ModelGeometry();
@@ -49,7 +48,7 @@ public:
   void importParametricGeometry(const libsbml::Model *model);
   void importSampledFieldGeometry(const QString &filename);
   void importGeometryFromImage(const QImage &img);
-  void checkIfGeometryIsValid();
+  void updateMesh();
   void clear();
   int getNumDimensions() const;
   double getPixelWidth() const;

--- a/src/core/model/src/geometry_parametric.cpp
+++ b/src/core/model/src/geometry_parametric.cpp
@@ -126,8 +126,7 @@ getInteriorPixelPoints(const ModelGeometry *modelGeometry,
 std::unique_ptr<mesh::Mesh>
 importParametricGeometryFromSBML(const libsbml::Model *model,
                                  const ModelGeometry *modelGeometry,
-                                 const ModelCompartments *modelCompartments,
-                                 const ModelMembranes *modelMembranes) {
+                                 const ModelCompartments *modelCompartments) {
   auto *geom = getGeometry(model);
   auto *parageom = getParametricGeometry(geom);
   if (parageom == nullptr) {
@@ -142,10 +141,8 @@ importParametricGeometryFromSBML(const libsbml::Model *model,
     // generate Mesh
     SPDLOG_INFO("  - re-generating mesh");
     return std::make_unique<mesh::Mesh>(
-        modelGeometry->getImage(),
-        getInteriorPixelPoints(modelGeometry, modelCompartments), mp.maxPoints,
-        mp.maxAreas, modelGeometry->getPixelWidth(),
-        modelGeometry->getPhysicalOrigin(),
+        modelGeometry->getImage(), mp.maxPoints, mp.maxAreas,
+        modelGeometry->getPixelWidth(), modelGeometry->getPhysicalOrigin(),
         utils::toStdVec(modelCompartments->getColours()));
   }
 

--- a/src/core/model/src/geometry_parametric.hpp
+++ b/src/core/model/src/geometry_parametric.hpp
@@ -46,8 +46,7 @@ getInteriorPixelPoints(const ModelGeometry *modelGeometry,
 std::unique_ptr<mesh::Mesh>
 importParametricGeometryFromSBML(const libsbml::Model *model,
                                  const ModelGeometry *modelGeometry,
-                                 const ModelCompartments *modelCompartments,
-                                 const ModelMembranes *modelMembranes);
+                                 const ModelCompartments *modelCompartments);
 
 void writeGeometryMeshToSBML(libsbml::Model *model, const mesh::Mesh *mesh,
                              const ModelCompartments &modelCompartments);

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -112,7 +112,7 @@ QString ModelCompartments::add(const QString &name) {
   colours.push_back(0);
   compartments.push_back(std::make_unique<geometry::Compartment>());
   createDefaultCompartmentGeometryIfMissing(sbmlModel);
-  modelGeometry->checkIfGeometryIsValid();
+  modelGeometry->updateMesh();
   modelMembranes->updateCompartments(compartments);
   modelMembranes->updateCompartmentNames(names, sbmlModel);
   return newName; // should be id?
@@ -180,7 +180,7 @@ bool ModelCompartments::remove(const QString &id) {
   }
   modelMembranes->updateCompartments(compartments);
   modelMembranes->updateCompartmentNames(names, sbmlModel);
-  modelGeometry->checkIfGeometryIsValid();
+  modelGeometry->updateMesh();
   return true;
 }
 
@@ -241,144 +241,6 @@ ModelCompartments::getInteriorPoints(const QString &id) const {
   return points;
 }
 
-static QImage makeMonoMask(const QImage &img, QRgb col) {
-  QImage mask{img.size(), QImage::Format_Mono};
-  mask.fill(0);
-  for (int x = 0; x < img.width(); ++x) {
-    for (int y = 0; y < img.height(); ++y) {
-      if (img.pixel(x, y) == col) {
-        mask.setPixel(x, y, 1);
-      }
-    }
-  }
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  mask.save(QString("CompartmentMask-%1.png").arg(col));
-#endif
-  return mask;
-}
-
-static std::optional<QPoint> findPixel(const QImage &img) {
-  for (int x = 0; x < img.width(); ++x) {
-    for (int y = 0; y < img.height(); ++y) {
-      if (img.pixelIndex(x, y) == 1) {
-        return QPoint{x, y};
-      }
-    }
-  }
-  return {};
-}
-
-static QImage findConnectedPixels(const QImage &img, const QPoint &pixel,
-                                  std::vector<QPoint> &pixels) {
-  QImage connectedImg{img.size(), QImage::Format_Mono};
-  connectedImg.fill(0);
-  connectedImg.setPixel(pixel, 1);
-  pixels.clear();
-  pixels.emplace_back(pixel);
-  std::size_t queueIndex{0};
-  while (queueIndex < pixels.size()) {
-    const auto &p = pixels[queueIndex];
-    for (const auto &dp :
-         {QPoint(1, 0), QPoint(-1, 0), QPoint(0, 1), QPoint(0, -1)}) {
-      auto np = p + dp;
-      if (img.valid(np) && img.pixelIndex(np) == 1 &&
-          connectedImg.pixelIndex(np) == 0) {
-        connectedImg.setPixel(np, 1);
-        pixels.push_back(np);
-      }
-    }
-    ++queueIndex;
-  }
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  connectedImg.save(QString("CompartmentConnectedTo-%1-%2.png")
-                        .arg(pixel.x())
-                        .arg(pixel.y()));
-#endif
-  return connectedImg;
-}
-
-static bool isOutsideBoundary(const QImage &img, const QPoint &pixel) {
-  return !img.valid(pixel) || (img.pixelIndex(pixel) == 0);
-}
-
-static int spiralPixelsToBoundary(const QImage &img, const QPoint &pixel) {
-  int count{0};
-  if (isOutsideBoundary(img, pixel)) {
-    return 0;
-  }
-  QPoint p{pixel};
-  int maxLen{std::max(img.width(), img.height())};
-  int direction{1};
-  for (int len = 1; len < maxLen; ++len) {
-    for (int i = 0; i < len; ++i) {
-      p.ry() += direction;
-      ++count;
-      if (isOutsideBoundary(img, p)) {
-        return count;
-      }
-    }
-    for (int i = 0; i < len; ++i) {
-      p.rx() += direction;
-      ++count;
-      if (isOutsideBoundary(img, p)) {
-        return count;
-      }
-    }
-    direction *= -1;
-  }
-  return count;
-}
-
-static QPointF findBestInteriorPoint(const QImage &img,
-                                     const std::vector<QPoint> &pixels) {
-  int maxSpiralDistance{-1};
-  QPoint bestPoint;
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  QImage heatmap(img.size(), QImage::Format_ARGB32);
-  heatmap.fill(0);
-#endif
-  for (const auto &pixel : pixels) {
-    auto c = spiralPixelsToBoundary(img, pixel);
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-    int green = (2 * 255 * c) / static_cast<int>(pixels.size());
-    green = green > 255 ? 255 : green;
-    heatmap.setPixel(pixel, qRgb(0, green, 0));
-#endif
-    if (c > maxSpiralDistance) {
-      maxSpiralDistance = c;
-      bestPoint = pixel;
-    }
-  }
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  heatmap.setPixel(bestPoint, qRgb(255, 0, 0));
-  heatmap.save(QString("CompartmentInteriorPoints-%1-%2.png")
-                   .arg(bestPoint.x())
-                   .arg(bestPoint.y()));
-#endif
-  return {static_cast<double>(bestPoint.x() + 0.5),
-          static_cast<double>(bestPoint.y() + 0.5)};
-}
-
-static std::vector<QPointF> findAllInteriorPoints(const QImage &img, QRgb col) {
-  std::vector<QPointF> interiorPoints;
-  std::vector<QPoint> pixels;
-  pixels.reserve(static_cast<std::size_t>(img.width() * img.height()));
-  auto mask = makeMonoMask(img, col);
-  auto pix = findPixel(mask);
-  while (pix.has_value()) {
-    // find all connnected pixels of same colour
-    auto connectedImg = findConnectedPixels(mask, pix.value(), pixels);
-    // find an interior point that is maximally distant from boundary
-    interiorPoints.push_back(findBestInteriorPoint(connectedImg, pixels));
-    // remove these connected pixels from image mask
-    for (const auto &p : pixels) {
-      mask.setPixel(p, 0);
-    }
-    pix = findPixel(mask);
-  }
-  return interiorPoints;
-}
-
 void ModelCompartments::setInteriorPoints(const QString &id,
                                           const std::vector<QPointF> &points) {
   SPDLOG_INFO("compartmentID: {}", id.toStdString());
@@ -397,19 +259,16 @@ void ModelCompartments::setInteriorPoints(const QString &id,
   }
   const auto &origin{modelGeometry->getPhysicalOrigin()};
   auto pixelWidth{modelGeometry->getPixelWidth()};
-  auto height{modelGeometry->getImage().height()};
   for (const auto &point : points) {
     SPDLOG_INFO("  - creating new interior point");
     SPDLOG_INFO("    - pixel point: ({},{})", point.x(), point.y());
     auto *ip = domain->createInteriorPoint();
-    // convert from QPoint with (0,0) in top-left to (0,0) in bottom-left
-    // and to physical units with pixelWidth and origin
+    // convert to physical units with pixelWidth and origin
     ip->setCoord1(origin.x() + pixelWidth * point.x());
-    ip->setCoord2(origin.y() + pixelWidth * (height - point.y()));
+    ip->setCoord2(origin.y() + pixelWidth * point.y());
     SPDLOG_INFO("    - physical point: ({},{})", ip->getCoord1(),
                 ip->getCoord2());
   }
-  modelGeometry->checkIfGeometryIsValid();
 }
 
 void ModelCompartments::setColour(const QString &id, QRgb colour) {
@@ -453,10 +312,7 @@ void ModelCompartments::setColour(const QString &id, QRgb colour) {
   modelSpecies->updateCompartmentGeometry(id);
   modelMembranes->updateCompartments(compartments);
   modelMembranes->updateCompartmentNames(names, sbmlModel);
-  auto interiorPoints =
-      findAllInteriorPoints(modelGeometry->getImage(), colour);
-  setInteriorPoints(id, interiorPoints);
-  modelGeometry->checkIfGeometryIsValid();
+  modelGeometry->updateMesh();
   modelReactions->makeReactionsSpatial(modelMembranes->getMembranes());
 }
 

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -315,7 +315,7 @@ SCENARIO("SBML: import SBML level 2 document",
     GIVEN("Compartment Colours") {
       QRgb col1 = 0xffaaaaaa;
       QRgb col2 = 0xff525252;
-      QRgb col3 = 17423;
+      QRgb col3 = 0xffffffff;
       WHEN("compartment colours have been assigned") {
         THEN("can get CompartmentID from colour") {
           REQUIRE(s.getCompartments().getIdFromColour(col1) == "compartment0");

--- a/src/gui/tabs/tabgeometry.cpp
+++ b/src/gui/tabs/tabgeometry.cpp
@@ -133,7 +133,6 @@ void TabGeometry::btnAddCompartment_clicked() {
   if (ok && !compartmentName.isEmpty()) {
     QString newCompartmentName = sbmlDoc.getCompartments().add(compartmentName);
     ui->tabCompartmentGeometry->setCurrentIndex(0);
-    sbmlDoc.getGeometry().checkIfGeometryIsValid();
     enableTabs();
     loadModelData(newCompartmentName);
     emit modelGeometryChanged();
@@ -157,7 +156,6 @@ void TabGeometry::btnRemoveCompartment_clicked() {
               ui->listCompartments->clearSelection();
               sbmlDoc.getCompartments().remove(compartmentId);
               ui->tabCompartmentGeometry->setCurrentIndex(0);
-              sbmlDoc.getGeometry().checkIfGeometryIsValid();
               enableTabs();
               loadModelData();
               emit modelGeometryChanged();


### PR DESCRIPTION
- interior points now found by Mesh, instead of being inputs to Mesh
- replace previous diy code with simpler and faster methods based on OpenCV routines
    - identify each contiguous blob using cv::connectedComponents()
    - repeatedly erode blob until all pixels are zero
    - use one of the last-to-be eroded pixels as interior point