### PR TITLE
add micro benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,14 @@ set(SME_EXTRA_CORE_DEFS
     CACHE STRING "Optional additional defines for core")
 message(STATUS "SME_EXTRA_CORE_DEFS: ${SME_EXTRA_CORE_DEFS}")
 
+# compile benchmarks
+set(BUILD_BENCHMARKS
+    yes
+    CACHE BOOL "Build benchmarks")
+if(BUILD_BENCHMARKS)
+  add_subdirectory(benchmark)
+endif()
+
 include(CTest)
 if(BUILD_TESTING)
   find_package(Catch2 REQUIRED)
@@ -91,12 +99,4 @@ endif()
 # compile tests
 if(BUILD_TESTING)
   add_subdirectory(test)
-endif()
-
-# compile benchmarks
-set(BUILD_BENCHMARKS
-    yes
-    CACHE BOOL "Build benchmarks")
-if(BUILD_BENCHMARKS)
-  add_subdirectory(benchmark)
 endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,3 +25,11 @@ qt5_import_plugins(
   printsupport
   EXCLUDE_BY_TYPE
   sqldrivers)
+
+find_package(benchmark REQUIRED)
+add_executable(bench bench.cpp)
+target_link_libraries(
+  bench
+  PUBLIC ${SME_EXTRA_EXE_LIBS}
+         core_tests
+         benchmark::benchmark)

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -1,0 +1,16 @@
+#include "logger.hpp"
+#include <QtGlobal>
+#include <benchmark/benchmark.h>
+
+int main(int argc, char **argv) {
+  // load resources for sample images, models etc
+  Q_INIT_RESOURCE(resources);
+  Q_INIT_RESOURCE(test_resources);
+  // disable logging output
+  spdlog::set_level(spdlog::level::off);
+  // BENCHMARK_MAIN macro:
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=spatial-model-editor_spatial-model-editor
 sonar.organization=spatial-model-editor
 sonar.sources=src,cli,sme,benchmark
-sonar.exclusions=src/**/*_t.cpp,src/**/ext/**/*,src/core/resources/**/*,sme/test/*,sme/test/**/*
+sonar.exclusions=src/**/*_t.cpp,src/**/*_bench.cpp,src/**/ext/**/*,src/core/resources/**/*,sme/test/*,sme/test/**/*
 sonar.tests=test
 sonar.cfamily.build-wrapper-output=build/bw-output
 sonar.host.url=https://sonarcloud.io

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -77,6 +77,8 @@ if(SME_WITH_OPENMP)
   target_link_libraries(core PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
+find_package(benchmark REQUIRED)
+
 target_include_directories(core SYSTEM PRIVATE ${SYMENGINE_INCLUDE_DIRS})
 # set Logger level
 target_compile_definitions(

--- a/src/core/mesh/inc/mesh.hpp
+++ b/src/core/mesh/inc/mesh.hpp
@@ -10,8 +10,8 @@
 #include <QImage>
 #include <QPointF>
 #include <QRgb>
-#include <QString>
 #include <QSize>
+#include <QString>
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -51,8 +51,7 @@ private:
 public:
   Mesh();
   // constructor to generate mesh from supplied image
-  explicit Mesh(const QImage &image,
-                std::vector<std::size_t> maxPoints = {},
+  explicit Mesh(const QImage &image, std::vector<std::size_t> maxPoints = {},
                 std::vector<std::size_t> maxTriangleArea = {},
                 double pixelWidth = 1.0,
                 const QPointF &originPoint = QPointF(0, 0),
@@ -74,7 +73,7 @@ public:
                                      std::size_t maxTriangleArea);
   std::size_t getCompartmentMaxTriangleArea(std::size_t compartmentIndex) const;
   const std::vector<std::size_t> &getCompartmentMaxTriangleArea() const;
-  const std::vector<std::vector<QPointF>>& getCompartmentInteriorPoints() const;
+  const std::vector<std::vector<QPointF>> &getCompartmentInteriorPoints() const;
   void setPhysicalGeometry(double pixelWidth,
                            const QPointF &originPoint = QPointF(0, 0));
   // return vertices as an array of doubles for SBML
@@ -82,7 +81,8 @@ public:
   // return triangle indices as an array of ints for SBML
   std::vector<int>
   getTriangleIndicesAsFlatArray(std::size_t compartmentIndex) const;
-  const std::vector<std::vector<TriangulateTriangleIndex>> &getTriangleIndices() const;
+  const std::vector<std::vector<TriangulateTriangleIndex>> &
+  getTriangleIndices() const;
   const std::vector<std::vector<QTriangleF>> &getTriangles() const;
 
   std::pair<QImage, QImage>

--- a/src/core/mesh/src/CMakeLists.txt
+++ b/src/core/mesh/src/CMakeLists.txt
@@ -2,8 +2,10 @@ target_sources(
   core
   PRIVATE boundary.cpp
           contour_map.cpp
+          interior_point.cpp
           line_simplifier.cpp
           mesh.cpp
+          mesh_utils.cpp
           pixel_corner_iterator.cpp
           triangulate.cpp)
 target_sources(
@@ -12,10 +14,21 @@ target_sources(
          boundary_t.cpp
          contour_map.cpp
          contour_map_t.cpp
+         interior_point.cpp
+         interior_point_t.cpp
          line_simplifier.cpp
          line_simplifier_t.cpp
          mesh_t.cpp
+         mesh_utils.cpp
+         mesh_utils_t.cpp
          pixel_corner_iterator.cpp
          pixel_corner_iterator_t.cpp
          triangulate.cpp
          triangulate_t.cpp)
+target_sources(
+  bench
+  PUBLIC boundary_bench.cpp
+         interior_point_bench.cpp
+         line_simplifier_bench.cpp
+         mesh_bench.cpp
+         triangulate_bench.cpp)

--- a/src/core/mesh/src/boundary.hpp
+++ b/src/core/mesh/src/boundary.hpp
@@ -40,6 +40,6 @@ public:
 
 std::vector<Boundary>
 constructBoundaries(const QImage &img,
-                    const std::vector<QRgb> &compartmentColours, std::vector<std::vector<QPointF>>* interiorPoints = nullptr);
+                    const std::vector<QRgb> &compartmentColours);
 
 } // namespace mesh

--- a/src/core/mesh/src/boundary_bench.cpp
+++ b/src/core/mesh/src/boundary_bench.cpp
@@ -1,0 +1,30 @@
+#include "boundary.hpp"
+#include <QImage>
+#include <QPointF>
+#include <QRgb>
+#include <benchmark/benchmark.h>
+
+static void boundary_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0 = img.pixel(0, 0);
+  QRgb col1 = img.pixel(35, 20);
+  QRgb col2 = img.pixel(40, 50);
+  std::vector<mesh::Boundary> boundaries;
+  for (auto _ : state) {
+    boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
+  }
+}
+
+static void boundary_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 = img.pixel(50, 50);
+  QRgb col1 = img.pixel(40, 20);
+  QRgb col2 = img.pixel(21, 14);
+  std::vector<mesh::Boundary> boundaries;
+  for (auto _ : state) {
+    boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
+  }
+}
+
+BENCHMARK(boundary_concave_cell_nucleus_100x100);
+BENCHMARK(boundary_liver_cells_200x100);

--- a/src/core/mesh/src/boundary_t.cpp
+++ b/src/core/mesh/src/boundary_t.cpp
@@ -1,5 +1,6 @@
 #include "boundary.hpp"
 #include "catch_wrapper.hpp"
+#include "interior_point.hpp"
 #include "utils.hpp"
 #include <QImage>
 #include <QPoint>
@@ -87,14 +88,14 @@ SCENARIO("constructBoundaries",
     QRgb col = qRgb(0, 0, 0);
     img.fill(col);
     WHEN("no compartment colours") {
-      std::vector<std::vector<QPointF>> interiorPoints;
-      auto boundaries = mesh::constructBoundaries(img, {}, &interiorPoints);
+      auto interiorPoints{mesh::getInteriorPoints(img, {})};
+      auto boundaries = mesh::constructBoundaries(img, {});
       REQUIRE(boundaries.empty());
       REQUIRE(interiorPoints.empty());
     }
     WHEN("whole image is a compartment") {
-      std::vector<std::vector<QPointF>> interiorPoints;
-      auto boundaries = mesh::constructBoundaries(img, {col}, &interiorPoints);
+      auto interiorPoints{mesh::getInteriorPoints(img, {col})};
+      auto boundaries = mesh::constructBoundaries(img, {col});
       std::vector<QPoint> outer{{0, 0},
                                 {img.width(), 0},
                                 {img.width(), img.height()},
@@ -116,9 +117,8 @@ SCENARIO("constructBoundaries",
     QRgb col0 = img.pixel(0, 0);
     QRgb col1 = img.pixel(35, 20);
     QRgb col2 = img.pixel(40, 50);
-    std::vector<std::vector<QPointF>> interiorPoints;
-    auto boundaries =
-        mesh::constructBoundaries(img, {col0, col1, col2}, &interiorPoints);
+    auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
+    auto boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
 
     REQUIRE(boundaries.size() == 3);
     REQUIRE(interiorPoints.size() == 3);
@@ -143,9 +143,8 @@ SCENARIO("constructBoundaries",
     QRgb col0 = img.pixel(0, 0);
     QRgb col1 = img.pixel(33, 33);
     QRgb col2 = img.pixel(66, 66);
-    std::vector<std::vector<QPointF>> interiorPoints;
-    auto boundaries =
-        mesh::constructBoundaries(img, {col0, col1, col2}, &interiorPoints);
+    auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
+    auto boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
 
     REQUIRE(boundaries.size() == 4);
     REQUIRE(interiorPoints.size() == 3);
@@ -227,8 +226,10 @@ SCENARIO("constructBoundaries",
           CAPTURE(boundaryTestImage.description);
           CAPTURE(filename.toStdString());
           QImage img(filename);
-          auto boundaries = mesh::constructBoundaries(img, boundaryData.colours,
-                                                      &interiorPoints);
+          auto interiorPoints{
+              mesh::getInteriorPoints(img, boundaryData.colours)};
+          auto boundaries =
+              mesh::constructBoundaries(img, boundaryData.colours);
           REQUIRE(boundaries.size() == boundaryData.nBoundaries);
           REQUIRE(interiorPoints.size() == boundaryData.colours.size());
           for (std::size_t i = 0; i < interiorPoints.size(); ++i) {

--- a/src/core/mesh/src/interior_point.cpp
+++ b/src/core/mesh/src/interior_point.cpp
@@ -1,0 +1,71 @@
+#include "interior_point.hpp"
+#include "logger.hpp"
+#include "mesh_utils.hpp"
+#include <algorithm>
+#include <opencv2/imgproc.hpp>
+
+namespace mesh {
+
+static std::vector<QPointF> getInnerPoints(const cv::Mat &mask) {
+  std::vector<QPointF> interiorPoints;
+  cv::Mat label(mask.size(), CV_16U);
+  constexpr int connectivity{8};
+  int nLabels{cv::connectedComponents(mask, label, connectivity, CV_16U,
+                                      cv::CCL_DEFAULT)};
+  SPDLOG_TRACE("{} blobs", nLabels - 1);
+  // skip label 0: background
+  for (int i = 1; i < nLabels; ++i) {
+    cv::Mat blob{label == i};
+    // crop to region of interest: roi is a reference to a subset of the pixels in blob
+    auto rect{cv::boundingRect(blob)};
+    cv::Mat roi(blob, rect);
+    // get offset to ROI
+    cv::Size size;
+    cv::Point offset;
+    roi.locateROI(size, offset);
+    SPDLOG_TRACE("Blob {}:", i);
+    SPDLOG_TRACE("ROI size: ({},{})", roi.cols, roi.rows);
+    SPDLOG_TRACE("ROI offset: ({},{})", offset.x, offset.y);
+    // nearest-neighbour erosion kernel
+    auto kernel{cv::getStructuringElement(cv::MorphShapes::MORPH_CROSS, {3,3})};
+    cv::Point inner{};
+    auto p{getNonZeroPixel(roi)};
+    while (p.has_value()) {
+      inner = p.value();
+      SPDLOG_TRACE("  - ({},{})", inner.x, inner.y);
+      cv::erode(roi, roi, kernel, {-1, -1}, 1, cv::BORDER_CONSTANT, 0);
+      if (rect.width > 1 && rect.height > 1) {
+        // shrink ROI by a pixel in all directions
+        rect.x += 1;
+        rect.y += 1;
+        rect.width -= 2;
+        rect.height -= 2;
+        roi = cv::Mat(blob, rect);
+        p = getNonZeroPixel(roi);
+        if(p.has_value()){
+          ++offset.x;
+          ++offset.y;
+        }
+      } else {
+        p = {};
+      }
+    }
+    interiorPoints.push_back(
+        {static_cast<double>(inner.x + offset.x) + 0.5,
+         static_cast<double>(mask.rows - inner.y - offset.y) - 0.5});
+    SPDLOG_TRACE("  - ({},{})", interiorPoints.back().x(),
+                 interiorPoints.back().y());
+  }
+  return interiorPoints;
+}
+
+std::vector<std::vector<QPointF>>
+getInteriorPoints(const QImage &img, const std::vector<QRgb> &cols) {
+  std::vector<std::vector<QPointF>> interiorPoints;
+  for (auto col : cols) {
+    interiorPoints.push_back(getInnerPoints(makeBinaryMask(img, col)));
+  }
+  return interiorPoints;
+}
+
+} // namespace mesh

--- a/src/core/mesh/src/interior_point.hpp
+++ b/src/core/mesh/src/interior_point.hpp
@@ -1,0 +1,19 @@
+// InteriorPoint
+//  - takes an image and a vector of colours
+//  - for each colour
+//    - identifies each connected region of that colour
+//    - find an interior point for each connected region
+
+#pragma once
+#include <opencv2/core/types.hpp>
+#include <QImage>
+#include <QPointF>
+#include <vector>
+
+namespace mesh {
+
+std::vector<std::vector<QPointF>>
+getInteriorPoints(const QImage &img,
+                                    const std::vector<QRgb> &cols);
+
+} // namespace mesh

--- a/src/core/mesh/src/interior_point_bench.cpp
+++ b/src/core/mesh/src/interior_point_bench.cpp
@@ -1,0 +1,32 @@
+#include "interior_point.hpp"
+#include <QImage>
+#include <QPointF>
+#include <QRgb>
+#include <benchmark/benchmark.h>
+
+static void
+interior_points_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0 = img.pixel(0, 0);
+  QRgb col1 = img.pixel(35, 20);
+  QRgb col2 = img.pixel(40, 50);
+  std::vector<std::vector<QPointF>> interiorPoints;
+  for (auto _ : state) {
+    interiorPoints = mesh::getInteriorPoints(img, {col0, col1, col2});
+  }
+}
+
+static void
+interior_points_boundary_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 = img.pixel(50, 50);
+  QRgb col1 = img.pixel(40, 20);
+  QRgb col2 = img.pixel(21, 14);
+  std::vector<std::vector<QPointF>> interiorPoints;
+  for (auto _ : state) {
+    interiorPoints = mesh::getInteriorPoints(img, {col0, col1, col2});
+  }
+}
+
+BENCHMARK(interior_points_concave_cell_nucleus_100x100);
+BENCHMARK(interior_points_boundary_liver_cells_200x100);

--- a/src/core/mesh/src/interior_point_t.cpp
+++ b/src/core/mesh/src/interior_point_t.cpp
@@ -1,0 +1,17 @@
+#include "interior_point.hpp"
+#include "catch_wrapper.hpp"
+#include <QImage>
+#include <cmath>
+
+SCENARIO("InteriorPoint", "[core/mesh/interior_point][core/mesh][core][interior_point]") {
+  GIVEN("Single pixel") {
+    QImage img(1, 1,QImage::Format_RGB32);
+    QRgb col{qRgb(1,2,3)};
+    img.fill(col);
+    auto points{mesh::getInteriorPoints(img, {col})};
+    REQUIRE(points.size() == 1);
+    REQUIRE(points[0].size() == 1);
+    REQUIRE(points[0][0].x() == dbl_approx(0.5));
+    REQUIRE(points[0][0].y() == dbl_approx(0.5));
+  }
+}

--- a/src/core/mesh/src/line_simplifier_bench.cpp
+++ b/src/core/mesh/src/line_simplifier_bench.cpp
@@ -1,0 +1,37 @@
+#include <benchmark/benchmark.h>
+#include "boundary.hpp"
+#include "line_simplifier.hpp"
+#include <QPointF>
+#include <QRgb>
+#include <QImage>
+
+static void line_simplifier_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0 = img.pixel(0, 0);
+  QRgb col1 = img.pixel(35, 20);
+  QRgb col2 = img.pixel(40, 50);
+  auto boundaries{
+      mesh::constructBoundaries(img, {col0, col1, col2})};
+  for (auto _ : state) {
+    for(const auto& boundary : boundaries) {
+      auto l{mesh::LineSimplifier(boundary.getAllPoints(), boundary.isLoop())};
+    }
+  }
+}
+
+static void line_simplifier_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 = img.pixel(50, 50);
+  QRgb col1 = img.pixel(40, 20);
+  QRgb col2 = img.pixel(21, 14);
+  auto boundaries{
+      mesh::constructBoundaries(img, {col0, col1, col2})};
+  for (auto _ : state) {
+    for(const auto& boundary : boundaries) {
+      auto l{mesh::LineSimplifier(boundary.getAllPoints(), boundary.isLoop())};
+    }
+  }
+}
+
+BENCHMARK(line_simplifier_concave_cell_nucleus_100x100);
+BENCHMARK(line_simplifier_liver_cells_200x100);

--- a/src/core/mesh/src/mesh.cpp
+++ b/src/core/mesh/src/mesh.cpp
@@ -2,6 +2,7 @@
 #include "boundary.hpp"
 #include "logger.hpp"
 #include "triangulate.hpp"
+#include "interior_point.hpp"
 #include "utils.hpp"
 #include <QColor>
 #include <QGradient>
@@ -31,7 +32,8 @@ Mesh::Mesh(const QImage &image, std::vector<std::size_t> maxPoints,
       boundaryMaxPoints(std::move(maxPoints)),
       compartmentMaxTriangleArea(std::move(maxTriangleArea)) {
   boundaries = std::make_unique<std::vector<Boundary>>(
-      constructBoundaries(image, compartmentColours, &compartmentInteriorPoints));
+      constructBoundaries(image, compartmentColours));
+  compartmentInteriorPoints = getInteriorPoints(image, compartmentColours);
   SPDLOG_INFO("found {} boundaries", boundaries->size());
   for (const auto &boundary : *boundaries) {
     SPDLOG_INFO("  - {} points, loop={}", boundary.getPoints().size(),
@@ -199,106 +201,9 @@ const std::vector<std::vector<QTriangleF>> &Mesh::getTriangles() const {
   return triangles;
 }
 
-static std::size_t getOrInsertFPIndex(const QPoint &p,
-                                      std::vector<QPoint> &fps) {
-  // return index of item in points that matches p
-  SPDLOG_TRACE("looking for point ({}, {})", p.x(), p.y());
-  for (std::size_t i = 0; i < fps.size(); ++i) {
-    if (fps[i] == p) {
-      SPDLOG_TRACE("  -> found [{}] : ({}, {})", i, fps[i].x(), fps[i].y());
-      return i;
-    }
-  }
-  // if not found: add p to vector and return its index
-  SPDLOG_TRACE("  -> added new point");
-  fps.push_back(p);
-  return fps.size() - 1;
-}
-
-static TriangulateBoundaries
-constructTriangulateBoundaries(const std::vector<Boundary> &boundaries) {
-  TriangulateBoundaries tid;
-  std::size_t nPointsUpperBound = 0;
-  for (const auto &boundary : boundaries) {
-    nPointsUpperBound += boundary.getPoints().size();
-  }
-  tid.vertices.reserve(nPointsUpperBound);
-  // first add fixed points
-  std::vector<QPoint> fps;
-  fps.reserve(2 * boundaries.size());
-  for (const auto &boundary : boundaries) {
-    if (!boundary.isLoop()) {
-      getOrInsertFPIndex(boundary.getPoints().front(), fps);
-      getOrInsertFPIndex(boundary.getPoints().back(), fps);
-    }
-  }
-  for (const auto &fp : fps) {
-    SPDLOG_TRACE("- fp ({},{})", fp.x(), fp.y());
-    tid.vertices.emplace_back(fp);
-  }
-
-  // for each segment in each boundary line, add the QPoints if not already
-  // present, and add the pair of point indices to the list of segment indices
-  std::size_t currentIndex = tid.vertices.size() - 1;
-  for (const auto &boundary : boundaries) {
-    SPDLOG_TRACE("{}-point boundary", boundary.getPoints().size());
-    SPDLOG_TRACE("  - loop: {}", boundary.isLoop());
-    const auto &points = boundary.getPoints();
-    auto &segments = tid.boundaries.emplace_back();
-    // do first segment
-    if (boundary.isLoop()) {
-      tid.vertices.emplace_back(points[0]);
-      ++currentIndex;
-      tid.vertices.emplace_back(points[1]);
-      ++currentIndex;
-      segments.push_back({currentIndex - 1, currentIndex});
-    } else if (points.size() == 2) {
-      segments.push_back({getOrInsertFPIndex(points.front(), fps),
-                          getOrInsertFPIndex(points.back(), fps)});
-    } else {
-      tid.vertices.emplace_back(points[1]);
-      ++currentIndex;
-      segments.push_back(
-          {getOrInsertFPIndex(points.front(), fps), currentIndex});
-    }
-    // do intermediate segments
-    for (std::size_t j = 2; j < points.size() - 1; ++j) {
-      tid.vertices.emplace_back(points[j]);
-      ++currentIndex;
-      segments.push_back({currentIndex - 1, currentIndex});
-    }
-    // do last segment
-    if (boundary.isLoop()) {
-      ++currentIndex;
-      tid.vertices.emplace_back(points.back());
-      segments.push_back({currentIndex - 1, currentIndex});
-      // for loops: also connect last point to first point
-      segments.push_back({currentIndex, segments.front().start});
-    } else if (points.size() > 2) {
-      segments.push_back(
-          {currentIndex, getOrInsertFPIndex(points.back(), fps)});
-    }
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-    for (const auto &seg : segments) {
-      SPDLOG_TRACE("- seg {}->{} | ({},{})->({},{})", seg.start, seg.end,
-                   tid.vertices[seg.start].x(), tid.vertices[seg.start].y(),
-                   tid.vertices[seg.end].x(), tid.vertices[seg.end].y());
-    }
-#endif
-  }
-  return tid;
-}
-
 void Mesh::constructMesh() {
   try {
-    auto tid = constructTriangulateBoundaries(*boundaries);
-
-    // add interior point & max triangle area for each compartment
-    for (std::size_t i = 0; i < compartmentInteriorPoints.size(); ++i) {
-      tid.compartments.push_back(
-          {compartmentInteriorPoints[i],
-           static_cast<double>(compartmentMaxTriangleArea[i])});
-    }
+    auto tid{TriangulateBoundaries(*boundaries, compartmentInteriorPoints, compartmentMaxTriangleArea)};
     Triangulate triangulate(tid);
     vertices = triangulate.getPoints();
     triangleIndices = triangulate.getTriangleIndices();

--- a/src/core/mesh/src/mesh_bench.cpp
+++ b/src/core/mesh/src/mesh_bench.cpp
@@ -1,0 +1,30 @@
+#include "mesh.hpp"
+#include <QImage>
+#include <QPointF>
+#include <QRgb>
+#include <benchmark/benchmark.h>
+
+static void mesh_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0 = img.pixel(0, 0);
+  QRgb col1 = img.pixel(35, 20);
+  QRgb col2 = img.pixel(40, 50);
+  for (auto _ : state) {
+    auto m{
+        mesh::Mesh(img, {}, {10, 10, 10}, 1.0, {0.0, 0.0}, {col0, col1, col2})};
+  }
+}
+
+static void mesh_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 = img.pixel(50, 50);
+  QRgb col1 = img.pixel(40, 20);
+  QRgb col2 = img.pixel(21, 14);
+  for (auto _ : state) {
+    auto m{
+        mesh::Mesh(img, {}, {10, 10, 10}, 1.0, {0.0, 0.0}, {col0, col1, col2})};
+  }
+}
+
+BENCHMARK(mesh_concave_cell_nucleus_100x100);
+BENCHMARK(mesh_liver_cells_200x100);

--- a/src/core/mesh/src/mesh_utils.cpp
+++ b/src/core/mesh/src/mesh_utils.cpp
@@ -1,0 +1,36 @@
+#include "mesh_utils.hpp"
+#include <algorithm>
+
+namespace mesh {
+
+cv::Mat makeBinaryMask(const QImage &img, const std::vector<QRgb> &cols) {
+  cv::Mat m(img.height(), img.width(), CV_8UC1, cv::Scalar(0));
+  for (int y = 0; y < img.height(); ++y) {
+    for (int x = 0; x < img.width(); ++x) {
+      if (std::find(cols.cbegin(), cols.cend(), img.pixel(x, y)) !=
+          cols.cend()) {
+        m.at<uint8_t>(y, x) = 255;
+      }
+    }
+  }
+  return m;
+}
+
+cv::Mat makeBinaryMask(const QImage &img, QRgb col) {
+  return makeBinaryMask(img, {{col}});
+}
+
+std::optional<cv::Point> getNonZeroPixel(const cv::Mat &img) {
+  const int M{img.rows};
+  const int N{img.cols};
+  for (int m = 0; m < M; ++m) {
+    const uchar *row{img.ptr(m)};
+    for (int n = 0; n < N; ++n) {
+      if (row[n] > 0) {
+        return cv::Point(n, m);
+      }
+    }
+  }
+  return {};
+}
+} // namespace mesh

--- a/src/core/mesh/src/mesh_utils.hpp
+++ b/src/core/mesh/src/mesh_utils.hpp
@@ -1,0 +1,16 @@
+// Mesh utils
+
+#pragma once
+#include <QImage>
+#include <QRgb>
+#include <opencv2/core.hpp>
+#include <optional>
+#include <vector>
+
+namespace mesh {
+
+cv::Mat makeBinaryMask(const QImage &img, const std::vector<QRgb> &cols);
+cv::Mat makeBinaryMask(const QImage &img, QRgb col);
+std::optional<cv::Point> getNonZeroPixel(const cv::Mat &img);
+
+} // namespace mesh

--- a/src/core/mesh/src/mesh_utils_t.cpp
+++ b/src/core/mesh/src/mesh_utils_t.cpp
@@ -1,0 +1,32 @@
+#include "mesh_utils.hpp"
+#include "catch_wrapper.hpp"
+#include <QImage>
+#include <QPoint>
+#include <cmath>
+
+SCENARIO("MeshUtils", "[core/mesh/mesh_utils][core/mesh][core][mesh_utils]") {
+  GIVEN("makeBinaryMask: single colour") {
+    QImage img(10, 20,QImage::Format_RGB32);
+    QRgb bg{qRgb(1,2,3)};
+    QRgb fg{qRgb(21,22,32)};
+    img.fill(bg);
+    img.setPixel(3,6,fg);
+    img.setPixel(9,8, fg);
+
+    auto mask_fg{mesh::makeBinaryMask(img, fg)};
+    REQUIRE(mask_fg.cols == img.width());
+    REQUIRE(mask_fg.rows == img.height());
+    REQUIRE(mask_fg.at<uint8_t>(6,3) == 255);
+    REQUIRE(mask_fg.at<uint8_t>(8,9) == 255);
+    REQUIRE(mask_fg.at<uint8_t>(3,6) == 0);
+    REQUIRE(mask_fg.at<uint8_t>(9,8) == 0);
+
+    auto mask_bg{mesh::makeBinaryMask(img, bg)};
+    REQUIRE(mask_bg.cols == img.width());
+    REQUIRE(mask_bg.rows == img.height());
+    REQUIRE(mask_bg.at<uint8_t>(6,3) == 0);
+    REQUIRE(mask_bg.at<uint8_t>(8,9) == 0);
+    REQUIRE(mask_bg.at<uint8_t>(3,6) == 255);
+    REQUIRE(mask_bg.at<uint8_t>(9,8) == 255);
+  }
+}

--- a/src/core/mesh/src/triangulate.cpp
+++ b/src/core/mesh/src/triangulate.cpp
@@ -1,4 +1,5 @@
 #include "triangulate.hpp"
+#include "boundary.hpp"
 #include "logger.hpp"
 #include "triangle.hpp"
 #include "utils.hpp"
@@ -190,6 +191,103 @@ static bool appendUnassignedTriangleCentroids(const triangle::triangulateio &io,
     }
   }
   return foundUnassignedTriangles;
+}
+
+static std::size_t getOrInsertFPIndex(const QPoint &p,
+                                      std::vector<QPoint> &fps) {
+  // return index of item in points that matches p
+  SPDLOG_TRACE("looking for point ({}, {})", p.x(), p.y());
+  for (std::size_t i = 0; i < fps.size(); ++i) {
+    if (fps[i] == p) {
+      SPDLOG_TRACE("  -> found [{}] : ({}, {})", i, fps[i].x(), fps[i].y());
+      return i;
+    }
+  }
+  // if not found: add p to vector and return its index
+  SPDLOG_TRACE("  -> added new point");
+  fps.push_back(p);
+  return fps.size() - 1;
+}
+
+TriangulateBoundaries::TriangulateBoundaries() = default;
+
+TriangulateBoundaries::TriangulateBoundaries(
+    const std::vector<Boundary> &inputBoundaries,
+    const std::vector<std::vector<QPointF>> &interiorPoints,
+    const std::vector<std::size_t> &maxTriangleAreas) {
+  std::size_t nPointsUpperBound = 0;
+  for (const auto &boundary : inputBoundaries) {
+    nPointsUpperBound += boundary.getPoints().size();
+  }
+  vertices.reserve(nPointsUpperBound);
+  // first add fixed points
+  std::vector<QPoint> fps;
+  fps.reserve(2 * inputBoundaries.size());
+  for (const auto &boundary : inputBoundaries) {
+    if (!boundary.isLoop()) {
+      getOrInsertFPIndex(boundary.getPoints().front(), fps);
+      getOrInsertFPIndex(boundary.getPoints().back(), fps);
+    }
+  }
+  for (const auto &fp : fps) {
+    SPDLOG_TRACE("- fp ({},{})", fp.x(), fp.y());
+    vertices.emplace_back(fp);
+  }
+
+  // for each segment in each boundary line, add the QPoints if not already
+  // present, and add the pair of point indices to the list of segment indices
+  std::size_t currentIndex = vertices.size() - 1;
+  for (const auto &boundary : inputBoundaries) {
+    SPDLOG_TRACE("{}-point boundary", boundary.getPoints().size());
+    SPDLOG_TRACE("  - loop: {}", boundary.isLoop());
+    const auto &points = boundary.getPoints();
+    auto &segments = boundaries.emplace_back();
+    // do first segment
+    if (boundary.isLoop()) {
+      vertices.emplace_back(points[0]);
+      ++currentIndex;
+      vertices.emplace_back(points[1]);
+      ++currentIndex;
+      segments.push_back({currentIndex - 1, currentIndex});
+    } else if (points.size() == 2) {
+      segments.push_back({getOrInsertFPIndex(points.front(), fps),
+                          getOrInsertFPIndex(points.back(), fps)});
+    } else {
+      vertices.emplace_back(points[1]);
+      ++currentIndex;
+      segments.push_back(
+          {getOrInsertFPIndex(points.front(), fps), currentIndex});
+    }
+    // do intermediate segments
+    for (std::size_t j = 2; j < points.size() - 1; ++j) {
+      vertices.emplace_back(points[j]);
+      ++currentIndex;
+      segments.push_back({currentIndex - 1, currentIndex});
+    }
+    // do last segment
+    if (boundary.isLoop()) {
+      ++currentIndex;
+      vertices.emplace_back(points.back());
+      segments.push_back({currentIndex - 1, currentIndex});
+      // for loops: also connect last point to first point
+      segments.push_back({currentIndex, segments.front().start});
+    } else if (points.size() > 2) {
+      segments.push_back(
+          {currentIndex, getOrInsertFPIndex(points.back(), fps)});
+    }
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
+    for (const auto &seg : segments) {
+      SPDLOG_TRACE("- seg {}->{} | ({},{})->({},{})", seg.start, seg.end,
+                   vertices[seg.start].x(), vertices[seg.start].y(),
+                   vertices[seg.end].x(), vertices[seg.end].y());
+    }
+#endif
+  }
+  // add interior point & max triangle area for each compartment
+  for (std::size_t i = 0; i < interiorPoints.size(); ++i) {
+    compartments.push_back(
+        {interiorPoints[i], static_cast<double>(maxTriangleAreas[i])});
+  }
 }
 
 Triangulate::Triangulate(const TriangulateBoundaries &boundaries) {

--- a/src/core/mesh/src/triangulate.hpp
+++ b/src/core/mesh/src/triangulate.hpp
@@ -17,6 +17,8 @@
 
 namespace mesh {
 
+class Boundary;
+
 struct TriangulateBoundarySegment {
   std::size_t start;
   std::size_t end;
@@ -31,6 +33,10 @@ struct TriangulateCompartment {
 };
 
 struct TriangulateBoundaries {
+  TriangulateBoundaries();
+  TriangulateBoundaries(const std::vector<Boundary> &inputBoundaries,
+                        const std::vector<std::vector<QPointF>> &interiorPoints,
+                        const std::vector<std::size_t> &maxTriangleAreas);
   std::vector<QPointF> vertices;
   std::vector<TriangulateBoundarySegments> boundaries;
   std::vector<TriangulateCompartment> compartments;
@@ -44,7 +50,8 @@ private:
 public:
   explicit Triangulate(const TriangulateBoundaries &boundaries);
   [[nodiscard]] const std::vector<QPointF> &getPoints() const;
-  [[nodiscard]] const std::vector<std::vector<TriangulateTriangleIndex>> &getTriangleIndices() const;
+  [[nodiscard]] const std::vector<std::vector<TriangulateTriangleIndex>> &
+  getTriangleIndices() const;
 };
 
 } // namespace mesh

--- a/src/core/mesh/src/triangulate_bench.cpp
+++ b/src/core/mesh/src/triangulate_bench.cpp
@@ -1,0 +1,38 @@
+#include "boundary.hpp"
+#include "interior_point.hpp"
+#include "triangulate.hpp"
+#include <QImage>
+#include <QPointF>
+#include <QRgb>
+#include <benchmark/benchmark.h>
+
+static void triangulate_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0 = img.pixel(0, 0);
+  QRgb col1 = img.pixel(35, 20);
+  QRgb col2 = img.pixel(40, 50);
+  auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
+  auto boundaries{mesh::constructBoundaries(img, {col0, col1, col2})};
+  auto tb{
+      mesh::TriangulateBoundaries(boundaries, interiorPoints, {10, 10, 10})};
+  for (auto _ : state) {
+    auto t{mesh::Triangulate(tb)};
+  }
+}
+
+static void triangulate_boundary_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 = img.pixel(50, 50);
+  QRgb col1 = img.pixel(40, 20);
+  QRgb col2 = img.pixel(21, 14);
+  auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
+  auto boundaries{mesh::constructBoundaries(img, {col0, col1, col2})};
+  for (auto _ : state) {
+    auto tb{
+        mesh::TriangulateBoundaries(boundaries, interiorPoints, {10, 10, 10})};
+    auto t{mesh::Triangulate(tb)};
+  }
+}
+
+BENCHMARK(triangulate_concave_cell_nucleus_100x100);
+BENCHMARK(triangulate_boundary_liver_cells_200x100);


### PR DESCRIPTION
- add a benchmark executable using Google Benchmark library
- X_bench.cpp contains benchmarks for X.cpp in the same way that X_t.cpp contains the tests
- add benchmarks for various functions in core/mesh
- resolves #409

some related core/mesh/src refactoring

- extract some static functions from boundary.x to interior_point.x and mesh_utils.x
- add corresponding tests for these functions
- improve interior_point performance by shrinking ROI as image is eroded
