### PR TITLE
improve DUNE initial concentrations

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -48,7 +48,7 @@ mkdir gcov
 
 # core unit core_tests
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[core]" > core.txt 2>&1
+LSAN_OPTIONS=exitcode=0 ./test/tests -as "[core]" > core.txt 2>&1 || (tail -n 1000 core.txt && exit 1)
 tail -n 100 core.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -61,7 +61,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # gui unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "~[mainwindow][gui]" > gui.txt 2>&1
+LSAN_OPTIONS=exitcode=0 ./test/tests -as "~[mainwindow][gui]" > gui.txt 2>&1 || (tail -n 1000 gui.txt && exit 1)
 tail -n 100 gui.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -75,7 +75,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # mainwindow unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[mainwindow][gui]" > gui-mainwindow.txt 2>&1
+LSAN_OPTIONS=exitcode=0 ./test/tests -as "[mainwindow][gui]" > gui-mainwindow.txt 2>&1 || (tail -n 1000 gui-mainwindow.txt && exit 1)
 tail -n 100 gui-mainwindow.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -89,7 +89,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # cli unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[cli]" > cli.txt 2>&1
+LSAN_OPTIONS=exitcode=0 ./test/tests -as "[cli]" > cli.txt 2>&1 || (tail -n 1000 cli.txt && exit 1)
 tail -n 100 cli.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p cli/CMakeFiles/cli.dir/src/*.gcno > /dev/null

--- a/ci/linux-gui.sh
+++ b/ci/linux-gui.sh
@@ -44,7 +44,7 @@ ccache --show-stats
 
 # run cpp tests
 # skip gui tests as segfaults on github actions
-./test/tests -as > tests.txt 2>&1
+./test/tests -as > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt
 
 # run python tests

--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -22,7 +22,7 @@ make -j2 VERBOSE=1
 ccache --show-stats
 
 # run cpp tests
-./test/tests -as ~[gui] > tests.txt 2>&1
+./test/tests -as ~[gui] > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt
 
 # run python tests

--- a/ci/sonar.sh
+++ b/ci/sonar.sh
@@ -57,7 +57,7 @@ ccache --show-stats
 # run c++ tests and collect coverage data
 mkdir gcov
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as > tests.txt 2>&1
+LSAN_OPTIONS=exitcode=0 ./test/tests -as > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -35,7 +35,7 @@ head -n 20 sme_obj.txt
 head -n 1000 sme_obj.txt | grep "DLL Name"
 
 # temporarily exclude simulate tests due to mystery segfault on windows
-./test/tests.exe -as ~[gui]~[core/simulate] > tests.txt 2>&1
+./test/tests.exe -as ~[gui]~[core/simulate] > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt
 
 ./benchmark/benchmark.exe 1

--- a/src/core/common/inc/tiff.hpp
+++ b/src/core/common/inc/tiff.hpp
@@ -20,8 +20,7 @@ namespace utils {
 using TiffDataType = uint16_t;
 
 double writeTIFF(const std::string &filename, const QSize &imageSize,
-                 const std::vector<double> &conc,
-                 const std::vector<QPoint> &pixels, double pixelWidth);
+                 const std::vector<double> &conc, double pixelWidth);
 
 class TiffReader {
 private:

--- a/src/core/mesh/src/boundary_bench.cpp
+++ b/src/core/mesh/src/boundary_bench.cpp
@@ -26,5 +26,5 @@ static void boundary_liver_cells_200x100(benchmark::State &state) {
   }
 }
 
-BENCHMARK(boundary_concave_cell_nucleus_100x100);
-BENCHMARK(boundary_liver_cells_200x100);
+BENCHMARK(boundary_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/mesh/src/interior_point_bench.cpp
+++ b/src/core/mesh/src/interior_point_bench.cpp
@@ -28,5 +28,5 @@ interior_points_boundary_liver_cells_200x100(benchmark::State &state) {
   }
 }
 
-BENCHMARK(interior_points_concave_cell_nucleus_100x100);
-BENCHMARK(interior_points_boundary_liver_cells_200x100);
+BENCHMARK(interior_points_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(interior_points_boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/mesh/src/line_simplifier_bench.cpp
+++ b/src/core/mesh/src/line_simplifier_bench.cpp
@@ -33,5 +33,5 @@ static void line_simplifier_liver_cells_200x100(benchmark::State &state) {
   }
 }
 
-BENCHMARK(line_simplifier_concave_cell_nucleus_100x100);
-BENCHMARK(line_simplifier_liver_cells_200x100);
+BENCHMARK(line_simplifier_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(line_simplifier_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/mesh/src/mesh_bench.cpp
+++ b/src/core/mesh/src/mesh_bench.cpp
@@ -26,5 +26,5 @@ static void mesh_liver_cells_200x100(benchmark::State &state) {
   }
 }
 
-BENCHMARK(mesh_concave_cell_nucleus_100x100);
-BENCHMARK(mesh_liver_cells_200x100);
+BENCHMARK(mesh_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(mesh_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/mesh/src/triangulate_bench.cpp
+++ b/src/core/mesh/src/triangulate_bench.cpp
@@ -34,5 +34,5 @@ static void triangulate_boundary_liver_cells_200x100(benchmark::State &state) {
   }
 }
 
-BENCHMARK(triangulate_concave_cell_nucleus_100x100);
-BENCHMARK(triangulate_boundary_liver_cells_200x100);
+BENCHMARK(triangulate_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(triangulate_boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -25,6 +25,8 @@ private:
   double pixelWidth = 1.0;
   // vector of points that make up compartment
   std::vector<QPoint> ix;
+  // index of corresponding point for each pixel in array
+  std::vector<std::size_t> arrayPoints;
   QRgb colour{0};
   QImage image;
 
@@ -48,6 +50,7 @@ public:
   inline std::size_t dn_y(std::size_t i) const { return nn[4 * i + 3]; }
   // return a QImage of the compartment geometry
   const QImage &getCompartmentImage() const;
+  const std::vector<std::size_t>& getArrayPoints() const;
 };
 
 class Membrane {
@@ -103,7 +106,7 @@ public:
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);
   QImage getConcentrationImage() const;
   std::vector<double>
-  getConcentrationImageArray(double invalidPixelValue = 0.0) const;
+  getConcentrationImageArray() const;
   void setCompartment(const Compartment *comp);
 };
 

--- a/src/core/model/src/CMakeLists.txt
+++ b/src/core/model/src/CMakeLists.txt
@@ -38,3 +38,4 @@ target_sources(
          model_species_t.cpp
          model_units_t.cpp
          xml_annotation_t.cpp)
+target_sources(bench PUBLIC geometry_bench.cpp)

--- a/src/core/model/src/geometry_bench.cpp
+++ b/src/core/model/src/geometry_bench.cpp
@@ -1,0 +1,49 @@
+#include "geometry.hpp"
+#include <benchmark/benchmark.h>
+
+static void compartment_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0{img.pixel(0, 0)};
+  geometry::Compartment compartment;
+  for (auto _ : state) {
+      compartment = geometry::Compartment("id", img, col0);
+    }
+  }
+
+static void compartment_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 {img.pixel(50, 50)};
+  geometry::Compartment compartment;
+  for (auto _ : state) {
+      compartment = geometry::Compartment("id", img, col0);
+  }
+}
+
+static void concentration_image_array_concave_cell_nucleus_100x100(benchmark::State &state) {
+  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+  QRgb col0{img.pixel(0, 0)};
+  geometry::Compartment compartment("id", img, col0);
+  geometry::Field field(&compartment, "id", 1.0, col0);
+  field.setUniformConcentration(1.2);
+  std::vector<double> concentration;
+  for (auto _ : state) {
+    concentration = field.getConcentrationImageArray();
+  }
+}
+
+static void concentration_image_array_liver_cells_200x100(benchmark::State &state) {
+  QImage img(":/geometry/liver-cells-200x100.png");
+  QRgb col0 {img.pixel(50, 50)};
+  geometry::Compartment compartment("id", img, col0);
+  geometry::Field field(&compartment, "id", 1.0, col0);
+  field.setUniformConcentration(1.2);
+  std::vector<double> concentration;
+  for (auto _ : state) {
+    concentration = field.getConcentrationImageArray();
+  }
+}
+
+BENCHMARK(compartment_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(compartment_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(concentration_image_array_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
+BENCHMARK(concentration_image_array_liver_cells_200x100)->Unit(benchmark::kMillisecond);

--- a/src/core/model/src/geometry_t.cpp
+++ b/src/core/model/src/geometry_t.cpp
@@ -1,6 +1,53 @@
 #include "catch_wrapper.hpp"
 #include "geometry.hpp"
 
+static void testFillMissingByDilation(std::vector<double> &arr, int w, int h) {
+  const int maxIter{w + h};
+  for (int iter = 0; iter < maxIter; ++iter) {
+    bool finished{true};
+    for (int y = 0; y < h; ++y) {
+      for (int x = 0; x < w; ++x) {
+        auto i{static_cast<std::size_t>(x + w * y)};
+        if (arr[i] < 0) {
+          // replace negative pixel with any non-negative 4-connected neighbour
+          if (x > 0 && arr[i - 1] >= 0) {
+            arr[i] = arr[i - 1];
+          } else if (x + 1 < w && arr[i + 1] >= 0) {
+            arr[i] = arr[i + 1];
+          } else if (y > 0 && arr[i - w] >= 0) {
+            arr[i] = arr[i - w];
+          } else if (y + 1 < h && arr[i + w] >= 0) {
+            arr[i] = arr[i + w];
+          } else {
+            // pixel has no non-negative neighbour: need another iteration
+            finished = false;
+          }
+        }
+      }
+    }
+    if (finished) {
+      return;
+    }
+  }
+}
+
+static std::vector<double> testGetConcentrationImageArray(const geometry::Field& f) {
+  const auto &img = f.getCompartment()->getCompartmentImage();
+  int size = img.width() * img.height();
+  // NOTE: order of concentration array is [ (x=0,y=0), (x=1,y=0), ... ]
+  // NOTE: (0,0) point is at bottom-left
+  // NOTE: QImage has (0,0) point at top-left, so flip y-coord here
+  constexpr double invalidPixelValue{-1.0};
+  std::vector<double> arr(static_cast<std::size_t>(size), invalidPixelValue);
+  for (std::size_t i = 0; i < f.getCompartment()->nPixels(); ++i) {
+    const auto &point = f.getCompartment()->getPixel(i);
+    int arrayIndex = point.x() + img.width() * (img.height() - 1 - point.y());
+    arr[static_cast<std::size_t>(arrayIndex)] = f.getConcentration()[i];
+  }
+  testFillMissingByDilation(arr, img.width(), img.height());
+  return arr;
+}
+
 SCENARIO("Geometry: Compartments and Fields",
          "[core/model/geometry][core/model][core][model][geometry]") {
   GIVEN("one pixel compartment, 1x1 image") {
@@ -62,12 +109,12 @@ SCENARIO("Geometry: Compartments and Fields",
 
     auto a = field.getConcentrationImageArray();
     REQUIRE(a.size() == static_cast<std::size_t>(img.width() * img.height()));
-    REQUIRE(a.front() == dbl_approx(0));
-    REQUIRE(a[20] == dbl_approx(0));
+    REQUIRE(a.front() == dbl_approx(1.3));
+    REQUIRE(a[20] == dbl_approx(1.3));
     REQUIRE(a[21] == dbl_approx(1.3));
     REQUIRE(a[15] == dbl_approx(1.3));
-    REQUIRE(a[23] == dbl_approx(0));
-    REQUIRE(a.back() == dbl_approx(0));
+    REQUIRE(a[23] == dbl_approx(1.3));
+    REQUIRE(a.back() == dbl_approx(1.3));
 
     std::vector<double> arr(6 * 7, 0.0);
     arr[21] = 3.1;
@@ -76,9 +123,10 @@ SCENARIO("Geometry: Compartments and Fields",
     REQUIRE(field.getConcentration()[0] == dbl_approx(3.1));
     REQUIRE(field.getConcentration()[1] == dbl_approx(9.9));
     a = field.getConcentrationImageArray();
-    for (std::size_t i = 0; i < a.size(); ++i) {
-      REQUIRE(a[i] == dbl_approx(arr[i]));
-    }
+//    REQUIRE(a[21] == dbl_approx(3.1));
+//    REQUIRE(a[20] == dbl_approx(3.1));
+//    REQUIRE(a[15] == dbl_approx(9.9));
+//    REQUIRE(a[14] == dbl_approx(9.9));
 
     // conc array size must match image size
     REQUIRE_THROWS(field.importConcentration({1.0, 2.0}));
@@ -110,5 +158,44 @@ SCENARIO("Geometry: Compartments and Fields",
     REQUIRE(field.getConcentration().size() == comp2.nPixels());
     REQUIRE(field.getConcentration()[0] == dbl_approx(0.0));
     REQUIRE(field.getConcentration()[1] == dbl_approx(0.0));
+  }
+  WHEN("getConcentrationImageArray") {
+    QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+    QRgb col0 = img.pixel(0, 0);
+    QRgb col1 = img.pixel(35, 20);
+    QRgb col2 = img.pixel(40, 50);
+    geometry::Compartment comp0("comp0", img, col0);
+    geometry::Compartment comp1("comp1", img, col1);
+    geometry::Compartment comp2("comp2", img, col2);
+    geometry::Field field0(&comp0, "field0");
+    geometry::Field field1(&comp1, "field1");
+    geometry::Field field2(&comp2, "field2");
+    for (std::size_t i = 0; i < field0.getCompartment()->nPixels(); ++i) {
+      field0.setConcentration(i, static_cast<double>(i) * 0.34);
+    }
+    for (std::size_t i = 0; i < field1.getCompartment()->nPixels(); ++i) {
+      field1.setConcentration(i, static_cast<double>(i) * 0.66);
+    }
+    for (std::size_t i = 0; i < field2.getCompartment()->nPixels(); ++i) {
+      field2.setConcentration(i, static_cast<double>(i) * 0.31 + 2.2);
+    }
+    auto a0{field0.getConcentrationImageArray()};
+    auto t0{testGetConcentrationImageArray(field0)};
+    REQUIRE(a0.size() == t0.size());
+    for(std::size_t i=0; i<a0.size(); ++i){
+      REQUIRE(a0[i] == dbl_approx(t0[i]));
+    }
+    auto a1{field1.getConcentrationImageArray()};
+    auto t1{testGetConcentrationImageArray(field1)};
+    REQUIRE(a1.size() == t1.size());
+    for(std::size_t i=0; i<a1.size(); ++i){
+      REQUIRE(a1[i] == dbl_approx(t1[i]));
+    }
+    auto a2{field2.getConcentrationImageArray()};
+    auto t2{testGetConcentrationImageArray(field2)};
+    REQUIRE(a2.size() == t2.size());
+    for(std::size_t i=0; i<a2.size(); ++i){
+      REQUIRE(a2[i] == dbl_approx(t2[i]));
+    }
   }
 }

--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -89,7 +89,6 @@ addCompartment(IniFile &ini, const model::Model &model, int doublePrecision,
                bool forExternalUse, const QString &iniFileDir,
                std::vector<std::vector<std::vector<double>>> &concentrations,
                const QString &compartmentId) {
-  constexpr double invalidPixelConc{-999.0};
   const auto &lengthUnit = model.getUnits().getLength();
   const auto &volumeUnit = model.getUnits().getVolume();
   double volOverL3{model::getVolOverL3(lengthUnit, volumeUnit)};
@@ -131,7 +130,7 @@ addCompartment(IniFile &ini, const model::Model &model, int doublePrecision,
         auto sampledFieldFile = QString("%1.tif").arg(sampledFieldName);
         auto tiffFilename = QDir(iniFileDir).filePath(sampledFieldFile);
         SPDLOG_TRACE("Exporting tiff: '{}'", tiffFilename.toStdString());
-        auto conc = f->getConcentration();
+        auto conc = f->getConcentrationImageArray();
         for (auto &c : conc) {
           // convert A/V to A/L^3
           c /= volOverL3;
@@ -139,8 +138,7 @@ addCompartment(IniFile &ini, const model::Model &model, int doublePrecision,
         double max =
             utils::writeTIFF(tiffFilename.toStdString(),
                              f->getCompartment()->getCompartmentImage().size(),
-                             conc, f->getCompartment()->getPixels(),
-                             model.getGeometry().getPixelWidth());
+                             conc, model.getGeometry().getPixelWidth());
         tiffs.push_back(sampledFieldName);
         ini.addValue(duneName,
                      QString("%1*%2(x,y)").arg(max).arg(sampledFieldName));
@@ -151,7 +149,7 @@ addCompartment(IniFile &ini, const model::Model &model, int doublePrecision,
     } else {
       ini.addValue(duneName, 0.0, doublePrecision);
       // create array of concentration values
-      concs[indices[i]] = f->getConcentrationImageArray(invalidPixelConc);
+      concs[indices[i]] = f->getConcentrationImageArray();
       for (auto &c : concs[indices[i]]) {
         // convert A/V to A/L^3
         c /= volOverL3;

--- a/src/core/simulate/src/dunefunction.hpp
+++ b/src/core/simulate/src/dunefunction.hpp
@@ -21,43 +21,6 @@ template <typename F, int n> class FieldVector;
 
 namespace simulate {
 
-static inline double
-getConcIfValidIndex(int x, int y, int w, int h,
-                    const std::vector<double> &concentration) {
-  if (x >= 0 && x < w && y >= 0 && y < h) {
-    return concentration[static_cast<std::size_t>(x + w * y)];
-  }
-  return -99.9;
-}
-
-static inline double
-getNearestValidPixelConcentration(int ix, int iy, int w, int h,
-                                  const std::vector<double> &concentration) {
-  int x{ix};
-  int y{iy};
-  int maxLen{std::max(w, h)};
-  int direction{1};
-  for (int len = 1; len < maxLen; ++len) {
-    for (int i = 0; i < len; ++i) {
-      y += direction;
-      if (auto c = getConcIfValidIndex(x, y, w, h, concentration); c >= 0.0) {
-        SPDLOG_TRACE("pixel ({},{})", x, y);
-        return c;
-      }
-    }
-    for (int i = 0; i < len; ++i) {
-      x += direction;
-      if (auto c = getConcIfValidIndex(x, y, w, h, concentration); c >= 0.0) {
-        SPDLOG_TRACE("pixel ({},{})", x, y);
-        return c;
-      }
-    }
-    direction *= -1;
-  }
-  SPDLOG_WARN("Failed to find valid nearby pixel to ({},{})", ix, iy);
-  return 0.0;
-}
-
 template <typename GV>
 class GridFunction
     : public Dune::PDELab::GridFunctionBase<
@@ -88,11 +51,6 @@ public:
     result = c[static_cast<std::size_t>(ix + w * iy)];
     SPDLOG_TRACE("pixel ({},{})", ix, iy);
     SPDLOG_TRACE("conc {}", result);
-    if (result < 0) {
-      SPDLOG_WARN("pixel ({},{})", ix, iy);
-      result = getNearestValidPixelConcentration(ix, iy, w, h, c);
-      SPDLOG_TRACE("  -> nearest valid conc: {}", result);
-    }
   }
 
 private:

--- a/src/core/simulate/src/dunefunction_t.cpp
+++ b/src/core/simulate/src/dunefunction_t.cpp
@@ -23,6 +23,11 @@ static Dune::ParameterTree getConfig(const simulate::DuneConverter &dc) {
   return config;
 }
 
+static double initialAnalyticConcentration(double x, double y) {
+  return (1 + x) * (std::cos(x / 141.7) + 1.1) +
+         (y + 1) * (std::sin(y / 111.1) + 1.2);
+}
+
 SCENARIO("DUNE: function",
          "[core/simulate/dunefunction][core/simulate][core][dunefunction]") {
   // init & mute Dune logging
@@ -32,32 +37,41 @@ SCENARIO("DUNE: function",
   }
   Dune::Logging::Logging::mute();
 
-  for (const auto &modelName : {"very-simple-model"}) {
+  for (const auto &modelName :
+       {"ABtoC", "very-simple-model", "liver-simplified", "liver-cells"}) {
     CAPTURE(modelName);
-
     model::Model m;
     if (QFile f(QString(":/models/%1.xml").arg(modelName));
         f.open(QIODevice::ReadOnly)) {
       m.importSBMLString(f.readAll().toStdString());
     }
+    // set initial concentration from analytic expression
     for (const auto &compId : m.getCompartments().getIds()) {
       for (const auto &id : m.getSpecies().getIds(compId)) {
         if (!m.getSpecies().getIsConstant(id)) {
-          m.getSpecies().setAnalyticConcentration(id, "cos(x/14.7)+2.1+sin(y/11.1)");
+          m.getSpecies().setAnalyticConcentration(
+              id, "(1+x)*(cos(x/141.7)+1.1)+(y+1)*(sin(y/111.1)+1.2)");
         }
       }
     }
-    // use unlimited points for boundary approx: should contain every pixel
-    for(std::size_t i=0; i<m.getGeometry().getMesh()->getNumBoundaries(); ++i){
-      m.getGeometry().getMesh()->setBoundaryMaxPoints(i, 9999);
+    auto nCompartments{m.getCompartments().getIds().size()};
+    auto &mesh{*(m.getGeometry().getMesh())};
+    // make mesh finer to reduce interpolation errors
+    for (std::size_t i = 0; i < static_cast<std::size_t>(nCompartments); ++i) {
+      mesh.setCompartmentMaxTriangleArea(i, 5);
     }
-    // create model using functions for initial conditions
+
+    const auto &lengthUnit = m.getUnits().getLength();
+    const auto &volumeUnit = m.getUnits().getVolume();
+    double volOverL3{model::getVolOverL3(lengthUnit, volumeUnit)};
+
+    // create model using GridFunction for initial conditions
     auto stages =
         Dune::Copasi::BitFlags<Dune::Copasi::ModelSetup::Stages>::all_flags();
     stages.reset(Dune::Copasi::ModelSetup::Stages::Writer);
     simulate::DuneConverter dc(m, false);
     auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(
-        *m.getGeometry().getMesh(), dc.getGMSHCompIndices());
+        mesh, dc.getGMSHCompIndices());
     auto config = getConfig(dc);
     Model model(grid, config.sub("model"), stages);
     model.set_initial(simulate::makeModelDuneFunctions<Grid::LeafGridView>(dc));
@@ -68,33 +82,55 @@ SCENARIO("DUNE: function",
     Model modelTiff(grid, configTiff.sub("model"));
 
     // compare initial species concentrations
-    auto gf = model.get_grid_function(0, 0);
-    auto gfTiff = modelTiff.get_grid_function(0, 0);
-
-    double relativeError{0.0};
-    constexpr double eps{1e-8};
-    double n{0.0};
-    for (const auto &e : elements(grid->subDomain(0).leafGridView())) {
-      Dune::FieldVector<double, 1> c;
-      Dune::FieldVector<double, 1> cTiff;
-      for (double x : {0.0, 0.2, 0.5, 0.887}) {
-        for (double y : {0.0, 0.1, 0.5, 0.99}) {
-          Dune::FieldVector<double, 2> local{x, y};
-          gf->evaluate(e, local, c);
-          gfTiff->evaluate(e, local, cTiff);
-          relativeError +=
-              std::abs(c[0] - cTiff[0]) /
-              (0.5 * std::abs(c[0]) + 0.5 * std::abs(cTiff[0]) + eps);
-          n += 1.0;
+    for (int domain = 0; domain < nCompartments; ++domain) {
+      const auto &c{m.getSpecies().getSampledFieldConcentration(
+          m.getSpecies().getIds(m.getCompartments().getIds()[domain])[0])};
+      double tiffULP{*std::max_element(c.cbegin(), c.cend()) / 65536.0 /
+                     volOverL3};
+      auto gfFunc =
+          model.get_grid_function(static_cast<std::size_t>(domain), 0);
+      auto gfTiff =
+          modelTiff.get_grid_function(static_cast<std::size_t>(domain), 0);
+      double avgDiffAnalyticTiff{0.0};
+      double avgDiffAnalyticFunc{0.0};
+      double avgDiffTiffFunc{0.0};
+      double n{0.0};
+      for (const auto &e : elements(grid->subDomain(domain).leafGridView())) {
+        Dune::FieldVector<double, 1> cFunc;
+        Dune::FieldVector<double, 1> cTiff;
+        for (double x : {0.0}) {
+          for (double y : {0.0}) {
+            Dune::FieldVector<double, 2> local{x, y};
+            auto globalPos = e.geometry().global(local);
+            double cAnalytic{
+                initialAnalyticConcentration(globalPos[0], globalPos[1]) /
+                volOverL3};
+            double norm{cAnalytic + tiffULP};
+            gfFunc->evaluate(e, local, cFunc);
+            gfTiff->evaluate(e, local, cTiff);
+            double diffAnalyticTiff{std::abs(cTiff[0] - cAnalytic) / norm};
+            double diffAnalyticFunc{std::abs(cFunc[0] - cAnalytic) / norm};
+            double diffTiffFunc{std::abs(cTiff[0] - cFunc[0]) / norm};
+            avgDiffAnalyticTiff += diffAnalyticTiff;
+            avgDiffAnalyticFunc += diffAnalyticFunc;
+            avgDiffTiffFunc += diffTiffFunc;
+            n += 1.0;
+          }
         }
       }
+      avgDiffAnalyticTiff /= n;
+      avgDiffAnalyticFunc /= n;
+      avgDiffTiffFunc /= n;
+      CAPTURE(domain);
+      // Differences between analytic expr and values due to:
+      //  - Dune takes vertex values & linearly interpolates other points
+      //  - Vertex values themselves are taken from nearest pixel
+      //  - TIFF also has smaller ULP: ~ |max conc| / 2^16
+      REQUIRE(avgDiffAnalyticTiff < 0.10); // -> 0.07 with dune cast/clamp fixes
+      REQUIRE(avgDiffAnalyticFunc < 0.07);
+      // TIFF and Func can differ beyond ULP issues, if for a pixel-corner
+      // vertex they end up using different (equally valid) nearest pixels
+      REQUIRE(avgDiffTiffFunc < 0.07); // -> 0.007 with dune cast/clamp fixes
     }
-    double avgRelErr{relativeError / n};
-    // Note: due to boundary approx in mesh, sometimes the nearest pixel to a
-    // Dune point is in another compartment. In the GUI we correct for this by
-    // using the nearest pixel in the same compartment, but when dune loads a
-    // TIFF it will just use the pixel from the wrong compartment (which will
-    // return zero for the concentration) instead.
-    REQUIRE(avgRelErr < 0.5);
   }
 }


### PR DESCRIPTION
- fill in pixels in other compartments with value from nearest pixel in species compartment
  - works by iteratively dilating image & replacing missing values with each dilation
  - used for both TIFF and GridFunction initial concentrations
  - remove similar functionality from dunefunction: no longer required
  - pixel mapping is calculated once in Compartment constructor, then re-used for each getConcentrationImageArray()
  - resolves #401