### PR TITLE
refactor benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,6 +28,7 @@ qt5_import_plugins(
 
 find_package(benchmark REQUIRED)
 add_executable(bench bench.cpp)
+target_include_directories(bench PUBLIC .)
 target_link_libraries(
   bench
   PUBLIC ${SME_EXTRA_EXE_LIBS}

--- a/benchmark/bench.hpp
+++ b/benchmark/bench.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "mesh.hpp"
+#include <QImage>
+#include <QPointF>
+#include <QRgb>
+#include <benchmark/benchmark.h>
+
+// Each dataset for constructing benchmarks is stored as a custom type
+struct ConcaveCellNucleus_100x100 {
+  QImage img{":/geometry/concave-cell-nucleus-100x100.png"};
+  std::vector<QRgb> colours{img.pixel(0, 0), img.pixel(35, 20),
+                            img.pixel(40, 50)};
+  std::vector<std::size_t> maxTriangleArea{10, 10, 10};
+  QPointF origin{0.0, 0.0};
+  double pixelWidth{1.0};
+  mesh::Mesh mesh{img, {}, maxTriangleArea, pixelWidth, origin, colours};
+  QSize imageSize{100, 100};
+};
+
+struct LiverCells_200x100 {
+  QImage img{":/geometry/liver-cells-200x100.png"};
+  std::vector<QRgb> colours{img.pixel(50, 50), img.pixel(40, 20),
+                            img.pixel(21, 14)};
+  std::vector<std::size_t> maxTriangleArea{2, 2, 2};
+  QPointF origin{0.0, 0.0};
+  double pixelWidth{1.0};
+  mesh::Mesh mesh{img, {}, maxTriangleArea, pixelWidth, origin, colours};
+  QSize imageSize{1000, 1000};
+};
+
+// Use millisecond as the default time unit
+#define SME_BENCHMARK_TEMPLATE(X, data)                                        \
+  BENCHMARK_TEMPLATE(X, data)->Unit(benchmark::kMillisecond);
+
+// Given a benchmark function, for each dataset defined above, this macro
+// creates a benchmark with the dataset supplied as a template parameter
+#define SME_BENCHMARK(func)                                                        \
+  SME_BENCHMARK_TEMPLATE(func, ConcaveCellNucleus_100x100);                    \
+  SME_BENCHMARK_TEMPLATE(func, LiverCells_200x100);

--- a/src/core/mesh/src/boundary_bench.cpp
+++ b/src/core/mesh/src/boundary_bench.cpp
@@ -1,30 +1,12 @@
 #include "boundary.hpp"
-#include <QImage>
-#include <QPointF>
-#include <QRgb>
-#include <benchmark/benchmark.h>
+#include "bench.hpp"
 
-static void boundary_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0 = img.pixel(0, 0);
-  QRgb col1 = img.pixel(35, 20);
-  QRgb col2 = img.pixel(40, 50);
+template <typename T> static void mesh_constructBoundaries(benchmark::State &state) {
+  T data;
   std::vector<mesh::Boundary> boundaries;
   for (auto _ : state) {
-    boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
+    boundaries = mesh::constructBoundaries(data.img, data.colours);
   }
 }
 
-static void boundary_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 = img.pixel(50, 50);
-  QRgb col1 = img.pixel(40, 20);
-  QRgb col2 = img.pixel(21, 14);
-  std::vector<mesh::Boundary> boundaries;
-  for (auto _ : state) {
-    boundaries = mesh::constructBoundaries(img, {col0, col1, col2});
-  }
-}
-
-BENCHMARK(boundary_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+SME_BENCHMARK(mesh_constructBoundaries);

--- a/src/core/mesh/src/interior_point_bench.cpp
+++ b/src/core/mesh/src/interior_point_bench.cpp
@@ -1,32 +1,12 @@
 #include "interior_point.hpp"
-#include <QImage>
-#include <QPointF>
-#include <QRgb>
-#include <benchmark/benchmark.h>
+#include "bench.hpp"
 
-static void
-interior_points_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0 = img.pixel(0, 0);
-  QRgb col1 = img.pixel(35, 20);
-  QRgb col2 = img.pixel(40, 50);
+template <typename T> static void mesh_getInteriorPoints(benchmark::State &state) {
+  T data;
   std::vector<std::vector<QPointF>> interiorPoints;
   for (auto _ : state) {
-    interiorPoints = mesh::getInteriorPoints(img, {col0, col1, col2});
+    interiorPoints = mesh::getInteriorPoints(data.img, data.colours);
   }
 }
 
-static void
-interior_points_boundary_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 = img.pixel(50, 50);
-  QRgb col1 = img.pixel(40, 20);
-  QRgb col2 = img.pixel(21, 14);
-  std::vector<std::vector<QPointF>> interiorPoints;
-  for (auto _ : state) {
-    interiorPoints = mesh::getInteriorPoints(img, {col0, col1, col2});
-  }
-}
-
-BENCHMARK(interior_points_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(interior_points_boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+SME_BENCHMARK(mesh_getInteriorPoints);

--- a/src/core/mesh/src/line_simplifier_bench.cpp
+++ b/src/core/mesh/src/line_simplifier_bench.cpp
@@ -1,17 +1,11 @@
-#include <benchmark/benchmark.h>
 #include "boundary.hpp"
 #include "line_simplifier.hpp"
-#include <QPointF>
-#include <QRgb>
-#include <QImage>
+#include "bench.hpp"
 
-static void line_simplifier_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0 = img.pixel(0, 0);
-  QRgb col1 = img.pixel(35, 20);
-  QRgb col2 = img.pixel(40, 50);
+template <typename T> static void mesh_LineSimplifier(benchmark::State &state) {
+  T data;
   auto boundaries{
-      mesh::constructBoundaries(img, {col0, col1, col2})};
+      mesh::constructBoundaries(data.img, data.colours)};
   for (auto _ : state) {
     for(const auto& boundary : boundaries) {
       auto l{mesh::LineSimplifier(boundary.getAllPoints(), boundary.isLoop())};
@@ -19,19 +13,4 @@ static void line_simplifier_concave_cell_nucleus_100x100(benchmark::State &state
   }
 }
 
-static void line_simplifier_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 = img.pixel(50, 50);
-  QRgb col1 = img.pixel(40, 20);
-  QRgb col2 = img.pixel(21, 14);
-  auto boundaries{
-      mesh::constructBoundaries(img, {col0, col1, col2})};
-  for (auto _ : state) {
-    for(const auto& boundary : boundaries) {
-      auto l{mesh::LineSimplifier(boundary.getAllPoints(), boundary.isLoop())};
-    }
-  }
-}
-
-BENCHMARK(line_simplifier_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(line_simplifier_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+SME_BENCHMARK(mesh_LineSimplifier);

--- a/src/core/mesh/src/mesh_bench.cpp
+++ b/src/core/mesh/src/mesh_bench.cpp
@@ -1,30 +1,32 @@
 #include "mesh.hpp"
-#include <QImage>
-#include <QPointF>
-#include <QRgb>
-#include <benchmark/benchmark.h>
+#include "bench.hpp"
 
-static void mesh_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0 = img.pixel(0, 0);
-  QRgb col1 = img.pixel(35, 20);
-  QRgb col2 = img.pixel(40, 50);
+template <typename T> static void mesh_Mesh(benchmark::State &state) {
+  T data;
   for (auto _ : state) {
-    auto m{
-        mesh::Mesh(img, {}, {10, 10, 10}, 1.0, {0.0, 0.0}, {col0, col1, col2})};
+    auto m{mesh::Mesh(data.img, {}, data.maxTriangleArea, data.pixelWidth, data.origin,
+                      data.colours)};
   }
 }
 
-static void mesh_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 = img.pixel(50, 50);
-  QRgb col1 = img.pixel(40, 20);
-  QRgb col2 = img.pixel(21, 14);
+template <typename T> static void mesh_Mesh_getMeshImages(benchmark::State &state) {
+  T data;
+  QImage img1;
+  QImage img2;
   for (auto _ : state) {
-    auto m{
-        mesh::Mesh(img, {}, {10, 10, 10}, 1.0, {0.0, 0.0}, {col0, col1, col2})};
+    std::tie(img1, img2) = data.mesh.getMeshImages(data.imageSize, 0);
   }
 }
 
-BENCHMARK(mesh_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(mesh_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+template <typename T> static void mesh_Mesh_getBoundariesImages(benchmark::State &state) {
+  T data;
+  QImage img1;
+  QImage img2;
+  for (auto _ : state) {
+    std::tie(img1, img2) = data.mesh.getBoundariesImages(data.imageSize, 0);
+  }
+}
+
+SME_BENCHMARK(mesh_Mesh);
+SME_BENCHMARK(mesh_Mesh_getMeshImages);
+SME_BENCHMARK(mesh_Mesh_getBoundariesImages);

--- a/src/core/mesh/src/triangulate_bench.cpp
+++ b/src/core/mesh/src/triangulate_bench.cpp
@@ -1,38 +1,18 @@
 #include "boundary.hpp"
 #include "interior_point.hpp"
 #include "triangulate.hpp"
-#include <QImage>
-#include <QPointF>
-#include <QRgb>
-#include <benchmark/benchmark.h>
+#include "bench.hpp"
 
-static void triangulate_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0 = img.pixel(0, 0);
-  QRgb col1 = img.pixel(35, 20);
-  QRgb col2 = img.pixel(40, 50);
-  auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
-  auto boundaries{mesh::constructBoundaries(img, {col0, col1, col2})};
+template <typename T> static void
+mesh_TriangulateBoundaries(benchmark::State &state) {
+  T data;
+  auto interiorPoints{mesh::getInteriorPoints(data.img, data.colours)};
+  auto boundaries{mesh::constructBoundaries(data.img, data.colours)};
   auto tb{
-      mesh::TriangulateBoundaries(boundaries, interiorPoints, {10, 10, 10})};
+      mesh::TriangulateBoundaries(boundaries, interiorPoints, data.maxTriangleArea)};
   for (auto _ : state) {
     auto t{mesh::Triangulate(tb)};
   }
 }
 
-static void triangulate_boundary_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 = img.pixel(50, 50);
-  QRgb col1 = img.pixel(40, 20);
-  QRgb col2 = img.pixel(21, 14);
-  auto interiorPoints{mesh::getInteriorPoints(img, {col0, col1, col2})};
-  auto boundaries{mesh::constructBoundaries(img, {col0, col1, col2})};
-  for (auto _ : state) {
-    auto tb{
-        mesh::TriangulateBoundaries(boundaries, interiorPoints, {10, 10, 10})};
-    auto t{mesh::Triangulate(tb)};
-  }
-}
-
-BENCHMARK(triangulate_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(triangulate_boundary_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+SME_BENCHMARK(mesh_TriangulateBoundaries);

--- a/src/core/model/src/geometry_bench.cpp
+++ b/src/core/model/src/geometry_bench.cpp
@@ -1,29 +1,20 @@
+#include "bench.hpp"
 #include "geometry.hpp"
-#include <benchmark/benchmark.h>
 
-static void compartment_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0{img.pixel(0, 0)};
+template <typename T>
+static void geometry_Compartment(benchmark::State &state) {
+  T data;
   geometry::Compartment compartment;
   for (auto _ : state) {
-      compartment = geometry::Compartment("id", img, col0);
-    }
-  }
-
-static void compartment_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 {img.pixel(50, 50)};
-  geometry::Compartment compartment;
-  for (auto _ : state) {
-      compartment = geometry::Compartment("id", img, col0);
+    compartment = geometry::Compartment("id", data.img, data.colours[0]);
   }
 }
 
-static void concentration_image_array_concave_cell_nucleus_100x100(benchmark::State &state) {
-  QImage img(":/geometry/concave-cell-nucleus-100x100.png");
-  QRgb col0{img.pixel(0, 0)};
-  geometry::Compartment compartment("id", img, col0);
-  geometry::Field field(&compartment, "id", 1.0, col0);
+template <typename T>
+static void geometry_Field_getConcentrationImageArray(benchmark::State &state) {
+  T data;
+  geometry::Compartment compartment("id", data.img, data.colours[0]);
+  geometry::Field field(&compartment, "id", 1.0, data.colours[0]);
   field.setUniformConcentration(1.2);
   std::vector<double> concentration;
   for (auto _ : state) {
@@ -31,19 +22,5 @@ static void concentration_image_array_concave_cell_nucleus_100x100(benchmark::St
   }
 }
 
-static void concentration_image_array_liver_cells_200x100(benchmark::State &state) {
-  QImage img(":/geometry/liver-cells-200x100.png");
-  QRgb col0 {img.pixel(50, 50)};
-  geometry::Compartment compartment("id", img, col0);
-  geometry::Field field(&compartment, "id", 1.0, col0);
-  field.setUniformConcentration(1.2);
-  std::vector<double> concentration;
-  for (auto _ : state) {
-    concentration = field.getConcentrationImageArray();
-  }
-}
-
-BENCHMARK(compartment_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(compartment_liver_cells_200x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(concentration_image_array_concave_cell_nucleus_100x100)->Unit(benchmark::kMillisecond);
-BENCHMARK(concentration_image_array_liver_cells_200x100)->Unit(benchmark::kMillisecond);
+SME_BENCHMARK(geometry_Compartment);
+SME_BENCHMARK(geometry_Field_getConcentrationImageArray);


### PR DESCRIPTION
- add bench.hpp with common datasets used for benchmarks
- each dataset is a custom type (which contains a geometry image, colours, etc)
- `SME_BENCHMARK(f)` macro constructs a templated benchmark of `f` for each dataset
