### PR TITLE
Pixel interface improvements

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,6 +20,9 @@ jobs:
         path: ~/.ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Get static libs
       run: sudo ./ci/getlibs.sh linux
     - name: Build script
@@ -45,6 +48,9 @@ jobs:
           path: ~/.sonarcache
           key: sonar-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: sonar-${{ github.job }}-${{ runner.os }}-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Get static libs
         run: sudo ./ci/getlibs.sh linux
       - name: Build script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         path: ~/.ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Get static libs
       run: sudo ./ci/getlibs.sh linux
     - name: Build script
@@ -43,6 +46,9 @@ jobs:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Get static libs
         run: sudo ./ci/getlibs.sh osx
       - name: Build script

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -21,7 +21,7 @@ sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-
 cmake --version
 clang++ --version
 llvm-cov --version
-python3 --version
+python --version
 ccache --version
 
 ccache --zero-stats
@@ -36,7 +36,7 @@ jwm &
 # do build
 mkdir build
 cd build
-CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DPYTHON_EXECUTABLE=/usr/bin/python3 -DSME_WITH_TBB=ON
+CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DSME_WITH_TBB=ON
 make -j2 VERBOSE=1
 ccache --show-stats
 
@@ -101,7 +101,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 rm -f gcov/*
 lcov -q -z -d .
 cd sme
-LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) PYTHONMALLOC=malloc python3 -m unittest discover -v -s ../../sme/test > sme.txt 2>&1
+LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) PYTHONMALLOC=malloc python -m unittest discover -v -s ../../sme/test > sme.txt 2>&1
 tail -n 100 sme.txt
 cd ..
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null

--- a/ci/linux-gui.sh
+++ b/ci/linux-gui.sh
@@ -22,7 +22,7 @@ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100
 # check versions
 cmake --version
 g++ --version
-python3 --version
+python --version
 ccache --zero-stats
 
 # start a virtual display for the Qt GUI tests
@@ -35,7 +35,7 @@ jwm &
 # do build
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS -DSME_WITH_TBB=ON
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS -DSME_WITH_TBB=ON
 make -j2 VERBOSE=1
 ccache --show-stats
 
@@ -46,8 +46,8 @@ tail -n 100 tests.txt
 
 # run python tests
 cd sme
-python3 -m unittest discover -s ../../sme/test -v
-PYTHONPATH=`pwd` python3 ../../sme/test/sme_doctest.py -v
+python -m unittest discover -s ../../sme/test -v
+PYTHONPATH=`pwd` python ../../sme/test/sme_doctest.py -v
 cd ..
 
 # run benchmarks (~1 sec per benchmark, ~20secs total)

--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -9,13 +9,13 @@ brew install ccache
 # check versions
 cmake --version
 g++ --version
-python3 --version
+python --version
 ccache --zero-stats
 
 # do build
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_WITH_TBB=ON -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DSME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM=ON
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_WITH_TBB=ON -DSME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM=ON
 make -j2 VERBOSE=1
 ccache --show-stats
 
@@ -26,7 +26,7 @@ tail -n 100 tests.txt
 # run python tests
 cd sme
 python3 -m unittest discover -s ../../sme/test -v
-PYTHONPATH=`pwd` python3 ../../sme/test/sme_doctest.py -v
+PYTHONPATH=`pwd` python ../../sme/test/sme_doctest.py -v
 cd ..
 
 # run benchmarks (~1 sec per benchmark, ~20secs total)

--- a/ci/sonar.sh
+++ b/ci/sonar.sh
@@ -21,7 +21,7 @@ sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-
 cmake --version
 clang++ --version
 llvm-cov --version
-python3 --version
+python --version
 ccache --version
 
 ccache --zero-stats
@@ -47,7 +47,7 @@ jwm &
 # do build
 mkdir build
 cd build
-CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DPYTHON_EXECUTABLE=/usr/bin/python3 -DSME_WITH_TBB=ON
+CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake;/opt/smelibs/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DSME_WITH_TBB=ON
 build-wrapper-linux-x86-64 --out-dir bw-output make -j2
 ccache --show-stats
 
@@ -67,7 +67,7 @@ rm -f *.gcov
 # also run python tests, but only copy gcov data for sme files: don't want to overwrite coverage info on core from c++ tests
 lcov -q -z -d .
 cd sme
-LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) PYTHONMALLOC=malloc python3 -m unittest discover -s ../../sme/test > sme.txt 2>&1
+LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) PYTHONMALLOC=malloc python -m unittest discover -s ../../sme/test > sme.txt 2>&1
 tail -n 100 sme.txt
 cd ..
 llvm-cov gcov -p sme/CMakeFiles/sme.dir/*.gcno > /dev/null

--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -33,7 +33,8 @@ public:
   PyImageRgb compartmentImage;
   std::vector<SimulationResult> simulate(double simulationTime,
                                          double imageInterval,
-                                         int timeoutSeconds = 86400);
+                                         int timeoutSeconds = 86400,
+                                         bool throwOnTimeout = true);
   std::string getStr() const;
 };
 

--- a/sme/src/sme_simulationresult.cpp
+++ b/sme/src/sme_simulationresult.cpp
@@ -27,10 +27,19 @@ void pybindSimulationResult(pybind11::module &m) {
       .def_readonly("species_concentration",
                     &SimulationResult::speciesConcentration,
                     R"(
-                    dict: the species concentrations of each species at this timepoint
+                    dict: the species concentrations at this timepoint
 
                     for each species, the concentrations are provided as a
-                    list of list of float, where concentration[y][x] is the concentration at the point (x,y)
+                    list of list of float, where species_concentration['A'][y][x]
+                    is the concentration of species 'A" at the point (x,y)
+                    )")
+      .def_readonly("species_dcdt", &SimulationResult::speciesDcdt,
+                    R"(
+                    dict: the rate of change of the species concentrations at this timepoint
+
+                    for each species, the rate of change of the concentrations are provided as a
+                    list of list of float, where species_dcdt['A'][y][x] is the rate of change
+                    of concentration of species 'A' at the point (x,y)
                     )")
       .def("__repr__",
            [](const SimulationResult &a) {

--- a/sme/src/sme_simulationresult.hpp
+++ b/sme/src/sme_simulationresult.hpp
@@ -15,6 +15,7 @@ struct SimulationResult {
   double timePoint{0.0};
   PyImageRgb concentrationImage;
   std::map<std::string, PyConc> speciesConcentration;
+  std::map<std::string, PyConc> speciesDcdt;
   std::string getStr() const;
   std::string getName() const;
 };

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -2,6 +2,24 @@ import unittest
 import sme
 
 
+# root-mean-square of all elements
+def rms(a_ij):
+    d = 0.0
+    n = 0.0
+    for a_i in a_ij:
+        for a in a_i:
+            d += a ** 2
+            n += 1.0
+    return (d / n) ** 0.5
+
+
+# a_ij <- (a_ij - b_ij) / dt
+def sub_div(a_ij, b_ij, dt=1.0):
+    for i, (a_i, b_i) in enumerate(zip(a_ij, b_ij)):
+        for j, (a, b) in enumerate(zip(a_i, b_i)):
+            a_ij[i][j] = (a - b) / dt
+
+
 class TestModel(unittest.TestCase):
     def test_load_open_sbml_file(self):
         with self.assertRaises(sme.InvalidArgument):
@@ -35,15 +53,15 @@ class TestModel(unittest.TestCase):
 
     def test_simulate(self):
         m = sme.open_example_model()
-        sim_results = m.simulate(0.02, 0.01)
+        sim_results = m.simulate(0.002, 0.001)
         self.assertEqual(len(sim_results), 3)
         res = sim_results[1]
-        self.assertEqual(repr(res), "<sme.SimulationResult from timepoint 0.01>")
+        self.assertEqual(repr(res), "<sme.SimulationResult from timepoint 0.001>")
         self.assertEqual(
             str(res),
-            "<sme.SimulationResult>\n  - timepoint: 0.01\n  - number of species: 5\n",
+            "<sme.SimulationResult>\n  - timepoint: 0.001\n  - number of species: 5\n",
         )
-        self.assertEqual(res.time_point, 0.01)
+        self.assertEqual(res.time_point, 0.001)
         img = res.concentration_image
         self.assertEqual(len(img), 100)
         self.assertEqual(len(img[0]), 100)
@@ -53,6 +71,29 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(conc), 100)
         self.assertEqual(len(conc[0]), 100)
         self.assertEqual(conc[0][0], 0.0)
-        # set timeout to 1 second: simulation throws on timeout
+        dcdt = res.species_dcdt["B_cell"]
+        self.assertEqual(len(dcdt), 100)
+        self.assertEqual(len(dcdt[0]), 100)
+        self.assertEqual(dcdt[0][0], 0.0)
+
+        # approximate dcdt
+        dcdt_approx = sim_results[1].species_concentration["A_cell"]
+        sub_div(dcdt_approx, sim_results[0].species_concentration["A_cell"], 0.001)
+        dcdt = sim_results[1].species_dcdt["A_cell"]
+        rms_norm = rms(dcdt)
+        sub_div(dcdt, dcdt_approx)
+        rms_diff = rms(dcdt)
+        self.assertLess(rms_diff / rms_norm, 0.01)
+
+        # set timeout to 1 second: by default simulation throws on timeout
+        # multiple timesteps before timeout:
         with self.assertRaises(sme.RuntimeError):
-            m.simulate(10000, 0.01, 1)
+            m.simulate(10000, 0.1, 1)
+        # single long timestep that times out
+        with self.assertRaises(sme.RuntimeError):
+            m.simulate(10000, 10000, 1)
+        # set timeout to 1 second: don't throw on timeout, return partial results
+        res1 = m.simulate(10000, 0.1, 1, False)
+        self.assertGreaterEqual(len(res1), 1)
+        res2 = m.simulate(10000, 10000, 1, False)
+        self.assertEqual(len(res2), 1)

--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -63,7 +63,8 @@ public:
                       const Options &options = {});
   ~Simulation();
 
-  std::size_t doTimesteps(double time, std::size_t nSteps = 1);
+  std::size_t doTimesteps(double time, std::size_t nSteps = 1,
+                          double timeout_ms = -1.0);
   const std::string &errorMessage() const;
   const std::vector<std::string> &getCompartmentIds() const;
   const std::vector<std::string> &
@@ -76,6 +77,8 @@ public:
   std::vector<double> getConc(std::size_t timeIndex,
                               std::size_t compartmentIndex,
                               std::size_t speciesIndex) const;
+  std::vector<double> getDcdt(std::size_t compartmentIndex,
+                              std::size_t speciesIndex) const;
   double getLowerOrderConc(std::size_t compartmentIndex,
                            std::size_t speciesIndex,
                            std::size_t pixelIndex) const;
@@ -84,8 +87,8 @@ public:
                const std::vector<std::vector<std::size_t>> &speciesToDraw = {},
                bool normaliseOverAllTimepoints = false,
                bool normaliseOverAllSpecies = false) const;
-  // map from name to vec<vec<double>> species concentration for python bindings
-  std::map<std::string, std::vector<std::vector<double>>>
+  // map from name to vec<vec<double>> species conc/dcdt for python bindings
+  std::pair<std::map<std::string, std::vector<std::vector<double>>>,std::map<std::string, std::vector<std::vector<double>>>>
   getPyConcs(std::size_t timeIndex) const;
   std::size_t getNCompletedTimesteps() const;
   bool getIsRunning() const;

--- a/src/core/simulate/src/basesim.hpp
+++ b/src/core/simulate/src/basesim.hpp
@@ -12,7 +12,7 @@ namespace simulate {
 class BaseSim {
 public:
   virtual ~BaseSim() = default;
-  virtual std::size_t run(double time) = 0;
+  virtual std::size_t run(double time, double timeout_ms = -1.0) = 0;
   virtual const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const = 0;
   virtual std::size_t getConcentrationPadding() const = 0;

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -246,7 +246,7 @@ DuneSim::DuneSim(
 
 DuneSim::~DuneSim() = default;
 
-std::size_t DuneSim::run(double time) {
+std::size_t DuneSim::run(double time, double timeout_ms) {
   if (pDuneImpl == nullptr) {
     return 0;
   }

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -70,7 +70,7 @@ public:
       const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
       const DuneOptions &duneOptions = {});
   ~DuneSim() override;
-  std::size_t run(double time) override;
+  std::size_t run(double time, double timeout_ms) override;
   const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
   std::size_t getConcentrationPadding() const override;

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -56,10 +56,11 @@ public:
       const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
       const PixelOptions &pixelOptions = {});
   ~PixelSim() override;
-  std::size_t run(double time) override;
+  std::size_t run(double time, double timeout_ms) override;
   const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
   std::size_t getConcentrationPadding() const override;
+  const std::vector<double> &getDcdt(std::size_t compartmentIndex) const;
   double getLowerOrderConcentration(std::size_t compartmentIndex,
                                     std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -202,8 +202,9 @@ void TabSimulate::btnSimulate_clicked() {
 
   this->setCursor(Qt::WaitCursor);
   // start simulation in a new thread
-  simSteps = std::async(std::launch::async, &sme::simulate::Simulation::doTimesteps,
-                        sim.get(), dtImage, n_images);
+  simSteps =
+      std::async(std::launch::async, &sme::simulate::Simulation::doTimesteps,
+                 sim.get(), dtImage, n_images, -1.0);
   // start timer to periodically update simulation results
   plotRefreshTimer.start();
 }
@@ -274,7 +275,8 @@ void TabSimulate::updatePlotAndImages() {
     ui->btnSimulate->setEnabled(true);
     ui->btnResetSimulation->setEnabled(true);
     // ..but failed
-    if (!sim->errorMessage().empty()) {
+    if (const auto &err{sim->errorMessage()};
+        !err.empty() && err != "Simulation stopped early") {
       QMessageBox::warning(
           this, "Simulation Failed",
           QString("Simulation failed - changing the Simulation options in the "


### PR DESCRIPTION
- add getDcdt() function to Pixel
- add species_dcdt member to sme.SimulationResult
  - useful to determine steady-state in sme
- add timeout option to Pixel
  - if simulation (real) time exceeds timeout, simulation is stopped early
  - default is no timeout (timeout_ms = -1.0)
  - sme simulate now uses this for its timeout
- add throw_on_timeout option to sme.simulate
  - if true: throws a runtime error on timeout or other simulation error
  - if false: returns partial simulation results on timeout or other simulation error
