### PR TITLE
version 1.0.7

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,7 @@ name: Python Wheel Builds
 on: push
 
 env:
-  CIBUILDWHEEL_VERSION: 1.8.0
+  CIBUILDWHEEL_VERSION: 1.9.0
 
 jobs:
   linux-wheel:
@@ -13,8 +13,8 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.01.22
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010-pypy_x86_64:2021.01.22
+      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.02.07
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010-pypy_x86_64:2021.02.07
       CIBW_SKIP: '*-manylinux_i686'
       CIBW_TEST_COMMAND: 'python -m unittest discover -s {project}/sme/test -v'
       CIBW_BUILD_VERBOSITY: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Removed
 
+## [1.0.7] - 2021-02-07
+### Fixed
+- illegal instruction crash on old CPUs [#422](https://github.com/spatial-model-editor/spatial-model-editor/issues/422)
+
 ## [1.0.6] - 2021-01-29
 ### Added
 - python library `sme.Model.simulate`:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.0.6
+  VERSION 1.0.7
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="1.0.6",
+    version="1.0.7",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",


### PR DESCRIPTION
- update static libs & docker images
- these no longer include avx2 intrinsics, so binaries now run on all 64-bit CPUs
- resolves #422
