### PR TITLE
display more info when Pixel simulation fails

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -66,6 +66,7 @@ public:
   std::size_t doTimesteps(double time, std::size_t nSteps = 1,
                           double timeout_ms = -1.0);
   const std::string &errorMessage() const;
+  const QImage& errorImage() const;
   const std::vector<std::string> &getCompartmentIds() const;
   const std::vector<std::string> &
   getSpeciesIds(std::size_t compartmentIndex) const;

--- a/src/core/simulate/src/basesim.hpp
+++ b/src/core/simulate/src/basesim.hpp
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <QImage>
 
 namespace sme {
 
@@ -17,6 +18,7 @@ public:
   getConcentrations(std::size_t compartmentIndex) const = 0;
   virtual std::size_t getConcentrationPadding() const = 0;
   virtual const std::string &errorMessage() const = 0;
+  virtual const QImage &errorImage() const = 0;
   virtual void requestStop() = 0;
 };
 

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -270,6 +270,8 @@ std::size_t DuneSim::getConcentrationPadding() const { return 0; }
 
 const std::string &DuneSim::errorMessage() const { return currentErrorMessage; }
 
+const QImage &DuneSim::errorImage() const { return currentErrorImage; }
+
 void DuneSim::requestStop() {
   SPDLOG_DEBUG("Not implemented - ignoring request");
 }

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -60,6 +60,7 @@ private:
   void updatePixels();
   void updateSpeciesConcentrations();
   std::string currentErrorMessage;
+  QImage currentErrorImage;
   DuneOptions options;
   double volOverL3;
 
@@ -75,6 +76,7 @@ public:
   getConcentrations(std::size_t compartmentIndex) const override;
   std::size_t getConcentrationPadding() const override;
   const std::string &errorMessage() const override;
+  const QImage& errorImage() const override;
   void requestStop() override;
 };
 

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <QImage>
 
 namespace sme {
 
@@ -46,6 +47,7 @@ private:
   bool useTBB{false};
   std::size_t numMaxThreads{1};
   std::string currentErrorMessage;
+  QImage currentErrorImage;
   std::atomic<bool> stopRequested{false};
   std::size_t nExtraVars{0};
 
@@ -64,8 +66,9 @@ public:
   double getLowerOrderConcentration(std::size_t compartmentIndex,
                                     std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;
-  virtual const std::string &errorMessage() const override;
-  virtual void requestStop() override;
+  const std::string &errorMessage() const override;
+  const QImage& errorImage() const override;
+  void requestStop() override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim_impl.hpp
+++ b/src/core/simulate/src/pixelsim_impl.hpp
@@ -12,8 +12,8 @@
 #include <limits>
 #include <string>
 #include <vector>
-
-class QPoint;
+#include <QImage>
+#include <QPoint>
 
 namespace sme {
 
@@ -64,6 +64,7 @@ private:
   std::size_t nSpecies;
   std::string compartmentId;
   std::vector<std::string> speciesIds;
+  std::vector<std::string> speciesNames;
   std::vector<std::size_t> nonSpatialSpeciesIndices;
   double maxStableTimestep = std::numeric_limits<double>::max();
 
@@ -128,6 +129,7 @@ public:
   void undoRKStep_tbb();
 #endif
   PixelIntegratorError calculateRKError(double epsilon) const;
+  std::string plotRKError(QImage& image, double epsilon, double max) const;
   const std::string &getCompartmentId() const;
   const std::vector<std::string> &getSpeciesIds() const;
   const std::vector<double> &getConcentrations() const;

--- a/src/core/simulate/src/simulate.cpp
+++ b/src/core/simulate/src/simulate.cpp
@@ -148,6 +148,10 @@ const std::string &Simulation::errorMessage() const {
   return simulator->errorMessage();
 }
 
+const QImage& Simulation::errorImage() const{
+  return simulator->errorImage();
+}
+
 const std::vector<std::string> &Simulation::getCompartmentIds() const {
   return compartmentIds;
 }

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -303,6 +303,23 @@ SCENARIO("Simulate: very_simple_model, 2d geometry",
   }
 }
 
+SCENARIO("Simulate: very_simple_model, failing Pixel sim",
+         "[core/simulate/simulate][core/simulate][core][simulate][pixel]") {
+  model::Model s;
+  QFile f(":/models/very-simple-model.xml");
+  f.open(QIODevice::ReadOnly);
+  s.importSBMLString(f.readAll().toStdString());
+  // set A uptake rate very high
+  s.getReactions().setParameterValue("A_uptake", "k1", 1e40);
+  // Pixel sim stops simulation as timestep required becomes too small
+  simulate::Simulation sim(s, simulate::SimulatorType::Pixel);
+  REQUIRE(sim.errorMessage().empty());
+  REQUIRE(sim.errorImage().isNull());
+  sim.doTimesteps(1.0);
+  REQUIRE(!sim.errorMessage().empty());
+  REQUIRE(sim.errorImage().size() == QSize(100,100));
+}
+
 static void rescaleMembraneReacRates(model::Model &s, double factor) {
   for (const auto &memId : s.getMembranes().getIds()) {
     for (const auto &reacId : s.getReactions().getIds(memId)) {

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           dialogdisplayoptions.cpp
           dialogeditunit.cpp
           dialogexport.cpp
+          dialogimage.cpp
           dialogimagesize.cpp
           dialogimageslice.cpp
           dialogsimulationoptions.cpp
@@ -23,6 +24,7 @@ if(BUILD_TESTING)
            dialogdisplayoptions_t.cpp
            dialogeditunit_t.cpp
            dialogexport_t.cpp
+           dialogimage_t.cpp
            dialogimagesize_t.cpp
            dialogimageslice_t.cpp
            dialogsimulationoptions_t.cpp

--- a/src/gui/dialogs/dialogimage.cpp
+++ b/src/gui/dialogs/dialogimage.cpp
@@ -1,0 +1,20 @@
+#include "dialogimage.hpp"
+#include "ui_dialogimage.h"
+#include <QLabel>
+#include <QPixmap>
+
+DialogImage::DialogImage(QWidget *parent, const QString &title,
+                         const QString &message, const QImage &image)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogImage>()} {
+  ui->setupUi(this);
+
+  setWindowTitle(title);
+  ui->lblMessage->setText(message);
+  ui->lblImage->setPixmap(QPixmap::fromImage(image));
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+          &DialogImage::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &DialogImage::reject);
+}
+
+DialogImage::~DialogImage() = default;

--- a/src/gui/dialogs/dialogimage.hpp
+++ b/src/gui/dialogs/dialogimage.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QDialog>
+#include <QImage>
+#include <memory>
+
+namespace Ui {
+class DialogImage;
+}
+
+class DialogImage : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit DialogImage(QWidget *parent = nullptr, const QString &title = {},
+                       const QString &message = {}, const QImage &image = {});
+  ~DialogImage() override;
+
+private:
+  std::unique_ptr<Ui::DialogImage> ui;
+};

--- a/src/gui/dialogs/dialogimage.ui
+++ b/src/gui/dialogs/dialogimage.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogImage</class>
+ <widget class="QDialog" name="DialogImage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>708</width>
+    <height>632</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="lblMessage">
+     <property name="text">
+      <string>message</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblImage">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>image</string>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/dialogs/dialogimage_t.cpp
+++ b/src/gui/dialogs/dialogimage_t.cpp
@@ -1,0 +1,16 @@
+#include "catch_wrapper.hpp"
+#include "dialogimage.hpp"
+#include <QLabel>
+
+TEST_CASE("DialogImage", "[gui/dialogs/image][gui/dialogs][gui][image]") {
+  QImage image(":/icon/icon128.png");
+  QString title("my title");
+  QString message("see image below:");
+  auto dia = DialogImage(nullptr, title, message, image);
+  auto *lblMessage = dia.findChild<QLabel *>("lblMessage");
+  auto *lblImage = dia.findChild<QLabel *>("lblImage");
+  REQUIRE(lblMessage != nullptr);
+  REQUIRE(lblImage != nullptr);
+  REQUIRE(dia.windowTitle() == title);
+  REQUIRE(lblMessage->text() == message);
+}

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -1,5 +1,6 @@
 #include "tabsimulate.hpp"
 #include "dialogexport.hpp"
+#include "dialogimage.hpp"
 #include "dialogimageslice.hpp"
 #include "guiutils.hpp"
 #include "logger.hpp"
@@ -267,7 +268,6 @@ void TabSimulate::updatePlotAndImages() {
 
   if (!sim->getIsRunning()) {
     SPDLOG_DEBUG("simulation finished");
-
     // simulation finished..
     progressDialog->reset();
     plotRefreshTimer.stop();
@@ -277,11 +277,13 @@ void TabSimulate::updatePlotAndImages() {
     // ..but failed
     if (const auto &err{sim->errorMessage()};
         !err.empty() && err != "Simulation stopped early") {
-      QMessageBox::warning(
+      DialogImage(
           this, "Simulation Failed",
           QString("Simulation failed - changing the Simulation options in the "
                   "\"Advanced\" menu might help.\n\nError message: %1")
-              .arg(sim->errorMessage().c_str()));
+              .arg(err.c_str()),
+          sim->errorImage())
+          .exec();
       return;
     }
     // .. and succeeded


### PR DESCRIPTION
- display the species with the largest relative integration error (i.e. which species is the problem)
- draw a heatmap of these errors (i.e. spatial location of the problem)
- this can help the user to understand which reaction in their model is causing the simulation difficulties
- resolves #431

also

- add DialogImage to display a message together with an image
- add errorImage() to Simulation interface to complement existing errorMessage()
