### PR TITLE
remove any unused vertices from dune grid

### DIFF
--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -339,10 +339,13 @@ DuneConverter::DuneConverter(const model::Model &model, bool forExternalUse,
   std::size_t modelIndex{0};
   // for each compartment
   for (const auto &compId : model.getCompartments().getIds()) {
-    addCompartment(inis[modelIndex], model, doublePrecision, forExternalUse,
-                   iniFileDir, concentrations, compId);
-    if (independentCompartments) {
-      ++modelIndex;
+    // skip compartments which contain no non-constant species
+    if (compartmentContainsNonConstantSpecies(model, compId)) {
+      addCompartment(inis[modelIndex], model, doublePrecision, forExternalUse,
+                     iniFileDir, concentrations, compId);
+      if (independentCompartments) {
+        ++modelIndex;
+      }
     }
   }
 

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -320,6 +320,36 @@ SCENARIO("Simulate: very_simple_model, failing Pixel sim",
   REQUIRE(sim.errorImage().size() == QSize(100,100));
 }
 
+SCENARIO("Simulate: very_simple_model, empty compartment, DUNE sim",
+         "[core/simulate/simulate][core/simulate][core][simulate][dune]") {
+  // check that DUNE simulates a model with an empty compartment without crashing
+  model::Model s;
+  QFile f(":/models/very-simple-model.xml");
+  f.open(QIODevice::ReadOnly);
+  s.importSBMLString(f.readAll().toStdString());
+  WHEN("Outer species removed"){
+    s.getSpecies().remove("A_c1");
+    s.getSpecies().remove("B_c1");
+    REQUIRE(s.getSpecies().getIds("c1").empty());
+    simulate::Simulation sim(s, simulate::SimulatorType::DUNE);
+    REQUIRE(sim.errorMessage().empty());
+    sim.doTimesteps(0.1, 1);
+    REQUIRE(sim.errorMessage().empty());
+  }
+  WHEN("Inner and Outer species removed"){
+    s.getSpecies().remove("A_c1");
+    s.getSpecies().remove("B_c1");
+    REQUIRE(s.getSpecies().getIds("c1").empty());
+    s.getSpecies().remove("A_c3");
+    s.getSpecies().remove("B_c3");
+    REQUIRE(s.getSpecies().getIds("c3").empty());
+    simulate::Simulation sim(s, simulate::SimulatorType::DUNE);
+    REQUIRE(sim.errorMessage().empty());
+    sim.doTimesteps(0.1, 1);
+    REQUIRE(sim.errorMessage().empty());
+  }
+}
+
 static void rescaleMembraneReacRates(model::Model &s, double factor) {
   for (const auto &memId : s.getMembranes().getIds()) {
     for (const auto &reacId : s.getReactions().getIds(memId)) {


### PR DESCRIPTION
- if a compartment doesn't contain any non-constant species it should be excluded from the dune simulation
- previously the corresponding triangular elements were removed from the grid, but not the vertices
- now the unused vertices are also removed
- resolves #434

also fix a related bug in duneconverter where a compartment with no non-constant species was added to the ini file
