### PR TITLE
add option to save simulation results back to model

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -78,6 +78,10 @@ public:
   std::vector<double> getConc(std::size_t timeIndex,
                               std::size_t compartmentIndex,
                               std::size_t speciesIndex) const;
+  std::vector<double> getConcArray(std::size_t timeIndex,
+                                   std::size_t compartmentIndex,
+                                   std::size_t speciesIndex) const;
+  void applyConcsToModel(model::Model& model, std::size_t timeIndex) const;
   std::vector<double> getDcdt(std::size_t compartmentIndex,
                               std::size_t speciesIndex) const;
   double getLowerOrderConc(std::size_t compartmentIndex,

--- a/src/gui/dialogs/dialogexport.hpp
+++ b/src/gui/dialogs/dialogexport.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "model.hpp"
+#include "simulate.hpp"
 #include <QDialog>
 #include <memory>
 
@@ -14,14 +16,18 @@ class DialogExport : public QDialog {
 
 public:
   explicit DialogExport(const QVector<QImage> &images,
-                        const PlotWrapper *plotWrapper, int timepoint = 0,
-                        QWidget *parent = nullptr);
+                        const PlotWrapper *plotWrapper,
+                        sme::model::Model &model,
+                        const sme::simulate::Simulation &simulation,
+                        int timepoint = 0, QWidget *parent = nullptr);
   ~DialogExport();
 
 private:
   const std::unique_ptr<Ui::DialogExport> ui;
   const QVector<QImage> &imgs;
   const PlotWrapper *plot;
+  sme::model::Model& m;
+  const sme::simulate::Simulation& sim;
 
   void radSingleTimepoint_toggled(bool checked);
   void doExport();

--- a/src/gui/dialogs/dialogexport.ui
+++ b/src/gui/dialogs/dialogexport.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>527</width>
-    <height>282</height>
+    <width>519</width>
+    <height>216</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,30 +19,56 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblTimepoint">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Timepoint:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QComboBox" name="cmbTimepoint"/>
      </item>
-     <item row="1" column="0">
-      <widget class="QRadioButton" name="radSingleTimepoint">
+     <item row="1" column="0" colspan="2">
+      <widget class="QRadioButton" name="radModel">
        <property name="text">
-        <string>Concentration image: &amp;single timepoint</string>
+        <string>Export timepoint to model as initial concentrations</string>
        </property>
        <property name="checked">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QRadioButton" name="radAllTimepoints">
+     <item row="2" column="0" colspan="2">
+      <widget class="QRadioButton" name="radSingleImage">
        <property name="text">
-        <string>Concentration images : &amp;all timepoints</string>
+        <string>Export timepoint as concentration image</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="3" column="0" colspan="2">
+      <widget class="QRadioButton" name="radAllImages">
+       <property name="text">
+        <string>Export entire simulation as images: one for each timepoint</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
       <widget class="QRadioButton" name="radCSV">
        <property name="text">
-        <string>CSV text file</string>
+        <string>Export entire simulation as CSV text file</string>
        </property>
       </widget>
      </item>
@@ -60,11 +86,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>radSingleTimepoint</tabstop>
-  <tabstop>cmbTimepoint</tabstop>
-  <tabstop>radAllTimepoints</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/dialogs/dialogexport_t.cpp
+++ b/src/gui/dialogs/dialogexport_t.cpp
@@ -2,10 +2,18 @@
 #include "dialogexport.hpp"
 #include "plotwrapper.hpp"
 #include "qt_test_utils.hpp"
+#include "model.hpp"
+#include "simulate.hpp"
 #include <QFile>
 
 SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
   GIVEN("5 100x50 images") {
+    sme::model::Model model;
+    QFile f(":/models/very-simple-model.xml");
+    f.open(QIODevice::ReadOnly);
+    model.importSBMLString(f.readAll().toStdString());
+    sme::simulate::Simulation sim(model, sme::simulate::SimulatorType::Pixel);
+
     QImage imgGeometry(100, 50, QImage::Format_ARGB32_Premultiplied);
     QVector<QImage> imgs(5,
                          QImage(100, 50, QImage::Format_ARGB32_Premultiplied));
@@ -27,11 +35,24 @@ SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
     plot.addAvMinMaxPoint(0, 2.0, {1.0, 1.0, 1.0});
     plot.addAvMinMaxPoint(0, 3.0, {1.0, 1.0, 1.0});
     plot.addAvMinMaxPoint(0, 4.0, {1.0, 1.0, 1.0});
-    DialogExport dia(imgs, &plot, 2);
+    DialogExport dia(imgs, &plot, model, sim, 2);
     ModalWidgetTimer mwt;
+    WHEN("user clicks export to model") {
+      std::size_t i{18};
+      double conc0{model.getSpecies().getSampledFieldConcentration("A_c2")[i]};
+      REQUIRE(conc0 == dbl_approx(0.0));
+      // change initial concentration in model
+      model.getSpecies().setInitialConcentration("A_c2", 0.123);
+      REQUIRE(model.getSpecies().getSampledFieldConcentration("A_c2")[i] == dbl_approx(0.123));
+      // export initial simulation concs to model
+      mwt.addUserAction({"Up", "Up", "Up", "Up", "Up", "Enter"} );
+      mwt.start();
+      dia.exec();
+      REQUIRE(model.getSpecies().getSampledFieldConcentration("A_c2")[i] == dbl_approx(conc0));
+    }
     WHEN("user clicks save image, then cancel") {
       ModalWidgetTimer mwt2;
-      mwt.addUserAction({"Enter"}, true, &mwt2);
+      mwt.addUserAction({"Tab", "Down", "Enter"}, true, &mwt2);
       mwt2.addUserAction({"Esc"});
       mwt.start();
       dia.exec();
@@ -39,7 +60,7 @@ SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
     }
     WHEN("user clicks save image, then enters filename") {
       ModalWidgetTimer mwt2;
-      mwt.addUserAction({"Enter"}, true, &mwt2);
+      mwt.addUserAction({"Tab", "Down", "Enter"}, true, &mwt2);
       mwt2.addUserAction({"x", "y", "z"});
       mwt.start();
       dia.exec();
@@ -50,7 +71,7 @@ SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
     }
     WHEN("user changes timepoint, clicks save image, then enters filename") {
       ModalWidgetTimer mwt2;
-      mwt.addUserAction({"Tab", "Down", "Down", "Enter"}, true, &mwt2);
+      mwt.addUserAction({"Down", "Down", "Tab", "Down", "Enter"}, true, &mwt2);
       mwt2.addUserAction({"x", "y", "z"});
       mwt.start();
       dia.exec();
@@ -61,7 +82,7 @@ SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
     }
     WHEN("user clicks on All timepoints, clicks save image, then enter") {
       ModalWidgetTimer mwt2;
-      mwt.addUserAction({"Down", "Enter"}, true, &mwt2);
+      mwt.addUserAction({"Tab", "Down", "Down", "Enter"}, true, &mwt2);
       mwt2.addUserAction({"Enter"});
       mwt.start();
       dia.exec();
@@ -84,7 +105,7 @@ SCENARIO("DialogExport", "[gui/dialogs/export][gui/dialogs][gui][export]") {
     }
     WHEN("user clicks on csv, types xyz, then enter") {
       ModalWidgetTimer mwt2;
-      mwt.addUserAction({"Down", "Down", "Enter"}, true, &mwt2);
+      mwt.addUserAction({"Tab", "Down", "Down", "Down", "Enter"}, true, &mwt2);
       mwt2.addUserAction({"x", "y", "z"});
       mwt.start();
       dia.exec();

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -27,7 +27,6 @@ TabSimulate::TabSimulate(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
   progressDialog->reset();
   connect(progressDialog, &QProgressDialog::canceled, this,
           &TabSimulate::stopSimulation);
-
   connect(ui->btnSimulate, &QPushButton::clicked, this,
           &TabSimulate::btnSimulate_clicked);
   connect(ui->btnResetSimulation, &QPushButton::clicked, this,
@@ -218,7 +217,7 @@ void TabSimulate::btnSliceImage_clicked() {
 }
 
 void TabSimulate::btnExport_clicked() {
-  DialogExport dialog(images, plt.get(), ui->hslideTime->value());
+  DialogExport dialog(images, plt.get(), model, *sim.get(), ui->hslideTime->value());
   if (dialog.exec() == QDialog::Accepted) {
     SPDLOG_DEBUG("todo: save current export settings");
   }


### PR DESCRIPTION
- add getConcArray() method to Simulate
  - returns concentration in form that can be applied to initial species concentration in model
- add applyConcsToModel() method to Simulate
  - sets the initial concentrations of all species in the model to the simulation species concentrations
- add this option to simulation export dialog in GUI
- resolves #285 