### PR TITLE
build system improvements

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
     - name: Cache ccache
       uses: actions/cache@v2
       with:
@@ -58,3 +59,66 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ci/sonar.sh
+
+  asan:
+    name: ASAN
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Get static libs
+        run: sudo ./ci/getlibs.sh linux
+      - name: Build script
+        run: ./ci/asan.sh
+
+  ubsan:
+    name: UBSAN
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Get static libs
+        run: sudo ./ci/getlibs.sh linux
+      - name: Build script
+        run: ./ci/ubsan.sh
+
+  tsan:
+    name: TSAN
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Get static libs
+        run: sudo ./ci/getlibs.sh linux
+      - name: Build script
+        run: ./ci/tsan.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,14 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
+set(SME_LOG_LEVEL
+    "INFO"
+    CACHE
+      STRING
+      "Logging level. Available levels in ascending order of verbosity: OFF, CRITICAL, ERROR, WARN, INFO, DEBUG, TRACE"
+)
+message(STATUS "SME_LOG_LEVEL: ${SME_LOG_LEVEL}")
+
 set(SME_EXTRA_EXE_LIBS
     ""
     CACHE STRING "Optional additional exe libs")

--- a/ci/asan.sh
+++ b/ci/asan.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Ubuntu ASAN build script
+
+set -e -x
+
+sudo apt-get update -yy
+# build dependencies
+sudo apt-get install -yy ccache xvfb jwm
+
+# qt dependencies
+sudo apt-get install -yy libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-xinerama0-dev libkrb5-dev
+
+# use clang 9
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100
+
+# check versions
+cmake --version
+clang++ --version
+python --version
+ccache --version
+
+ccache --zero-stats
+
+# start a virtual display for the Qt GUI tests
+Xvfb -screen 0 1280x800x24 :99 &
+export DISPLAY=:99
+
+# start a window manager so the Qt GUI tests can have their focus set
+jwm &
+
+# various external libs "leak" memory, don't fail the build because of this
+
+# known LSAN "leaks" from external libraries to suppress
+export LSAN_OPTIONS=suppressions=$(pwd)/lsan_suppr.txt
+echo "leak:libfontconfig.so" > lsan_suppr.txt
+echo "leak:libX11.so" >> lsan_suppr.txt
+echo "leak:libdbus-1.so" >> lsan_suppr.txt
+
+# hack to prevent external libs from dlclosing libraries,
+# which otherwise results in <module not found> LSAN leaks that cannot be suppressed
+# https://github.com/google/sanitizers/issues/89#issuecomment-406316683
+echo "#include <stdio.h>" > dlclose.c
+echo "int dlclose(void *handle) { return 0; }" >> dlclose.c
+clang -shared dlclose.c -o libdlclose.so
+export LD_PRELOAD=$(pwd)/libdlclose.so
+
+# add some optional ASAN checks
+export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+
+# do build
+mkdir build
+cd build
+CC=clang CXX=clang++ cmake ..  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wshadow -Wunused -Wconversion -Wsign-conversion -Wcast-align -fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer" -DSME_WITH_TBB=ON  -DBoost_NO_BOOST_CMAKE=on -DSTDTHREAD_WORKS=ON
+time make tests -j2
+ccache --show-stats
+
+# run c++ tests
+time ./test/tests -as > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
+tail -n 100 tests.txt
+
+# todo: also run with python lib
+# LD_PRELOAD is a hack required to use with python (since python is not itself compiled with ASAN)
+# this also requires -shared-asan in link/compile cmake flags
+# but also seems to have lots of false positives, so just disabling this for now
+
+# export LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so)
+
+# run python tests
+
+#cd sme
+#PYTHONMALLOC=malloc python -m unittest discover -s ../../sme/test > sme.txt 2>&1
+#tail -n 100 sme.txt

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -36,7 +36,7 @@ jwm &
 # do build
 mkdir build
 cd build
-CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DSME_WITH_TBB=ON -DBoost_NO_BOOST_CMAKE=on
+CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld --coverage" -DCMAKE_CXX_FLAGS="--coverage" -DSME_WITH_TBB=ON -DBoost_NO_BOOST_CMAKE=on
 make -j2 VERBOSE=1
 ccache --show-stats
 
@@ -45,7 +45,7 @@ mkdir gcov
 
 # core unit core_tests
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[core]" > core.txt 2>&1 || (tail -n 1000 core.txt && exit 1)
+./test/tests -as "[core]" > core.txt 2>&1 || (tail -n 1000 core.txt && exit 1)
 tail -n 100 core.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -58,7 +58,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # gui unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "~[mainwindow][gui]" > gui.txt 2>&1 || (tail -n 1000 gui.txt && exit 1)
+./test/tests -as "~[mainwindow][gui]" > gui.txt 2>&1 || (tail -n 1000 gui.txt && exit 1)
 tail -n 100 gui.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -72,7 +72,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # mainwindow unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[mainwindow][gui]" > gui-mainwindow.txt 2>&1 || (tail -n 1000 gui-mainwindow.txt && exit 1)
+./test/tests -as "[mainwindow][gui]" > gui-mainwindow.txt 2>&1 || (tail -n 1000 gui-mainwindow.txt && exit 1)
 tail -n 100 gui-mainwindow.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
@@ -86,7 +86,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 # cli unit tests
 rm -f gcov/*
 lcov -q -z -d .
-LSAN_OPTIONS=exitcode=0 ./test/tests -as "[cli]" > cli.txt 2>&1 || (tail -n 1000 cli.txt && exit 1)
+./test/tests -as "[cli]" > cli.txt 2>&1 || (tail -n 1000 cli.txt && exit 1)
 tail -n 100 cli.txt
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
 llvm-cov gcov -p cli/CMakeFiles/cli.dir/src/*.gcno > /dev/null
@@ -101,7 +101,7 @@ bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -
 rm -f gcov/*
 lcov -q -z -d .
 cd sme
-LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) PYTHONMALLOC=malloc python -m unittest discover -v -s ../../sme/test > sme.txt 2>&1
+python -m unittest discover -v -s ../../sme/test > sme.txt 2>&1
 tail -n 100 sme.txt
 cd ..
 llvm-cov gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null

--- a/ci/tsan.sh
+++ b/ci/tsan.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Ubuntu TSAN build script
+
+set -e -x
+
+sudo apt-get update -yy
+# build dependencies
+sudo apt-get install -yy ccache xvfb jwm
+
+# qt dependencies
+sudo apt-get install -yy libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-xinerama0-dev libkrb5-dev
+
+# use clang 9
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100
+
+# check versions
+cmake --version
+clang++ --version
+python --version
+ccache --version
+
+ccache --zero-stats
+
+# start a virtual display for the Qt GUI tests
+Xvfb -screen 0 1280x800x24 :99 &
+export DISPLAY=:99
+
+# start a window manager so the Qt GUI tests can have their focus set
+jwm &
+
+# suppress intel TBB false positives
+export TSAN_OPTIONS=suppressions=$(pwd)/tsan_suppr.txt
+echo "race:^tbb::blocked_range*" > tsan_suppr.txt
+echo "race:^tbb::interface9::internal::start_for*" >> tsan_suppr.txt
+
+# do build
+mkdir build
+cd build
+CC=clang CXX=clang++ cmake ..  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wshadow -Wunused -Wconversion -Wsign-conversion -Wcast-align -fsanitize=thread -fno-omit-frame-pointer" -DSME_WITH_TBB=ON  -DBoost_NO_BOOST_CMAKE=on -DSTDTHREAD_WORKS=ON
+time make tests -j2
+ccache --show-stats
+
+# run c++ tests
+time ./test/tests -as > tests.txt || echo "ignoring return code for now"

--- a/ci/ubsan.sh
+++ b/ci/ubsan.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Ubuntu UBSAN build script
+
+set -e -x
+
+sudo apt-get update -yy
+# build dependencies
+sudo apt-get install -yy ccache xvfb jwm
+
+# qt dependencies
+sudo apt-get install -yy libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-xinerama0-dev libkrb5-dev
+
+# use clang 9
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100
+
+# check versions
+cmake --version
+clang++ --version
+python --version
+ccache --version
+
+ccache --zero-stats
+
+# start a virtual display for the Qt GUI tests
+Xvfb -screen 0 1280x800x24 :99 &
+export DISPLAY=:99
+
+# start a window manager so the Qt GUI tests can have their focus set
+jwm &
+
+# note: currently we just output the UB logs to file, print them and return success:
+export UBSAN_OPTIONS="print_stacktrace=1:log_path=$(pwd)/ub"
+# todo: once dune has no UB, we can remove the log_path above, and instead add `-fno-sanitize-recover=undefined`
+# to the cmake copmile/link flags so that UB results in a failed build
+
+# do build
+mkdir build
+cd build
+CC=clang CXX=clang++ cmake ..  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wshadow -Wunused -Wconversion -Wsign-conversion -Wcast-align -fsanitize=undefined -fno-omit-frame-pointer" -DSME_WITH_TBB=ON  -DBoost_NO_BOOST_CMAKE=on -DSTDTHREAD_WORKS=ON
+time make tests -j2
+ccache --show-stats
+
+# run c++ tests
+time ./test/tests -as > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
+tail -n 100 tests.txt
+
+# print UBSAN logfile
+cat ../ub* || echo "no UBSAN logfile found"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -120,10 +120,7 @@ endif()
 target_include_directories(core SYSTEM PRIVATE ${SYMENGINE_INCLUDE_DIRS})
 # set Logger level
 target_compile_definitions(
-  core
-  PUBLIC
-    SPDLOG_ACTIVE_LEVEL=$<$<CONFIG:Debug>:SPDLOG_LEVEL_TRACE>$<$<CONFIG:Release>:SPDLOG_LEVEL_INFO>
-)
+  core PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${SME_LOG_LEVEL})
 
 target_link_libraries(
   core
@@ -159,29 +156,3 @@ add_subdirectory(simulate)
 # set Compile options and warnings
 set_target_properties(core PROPERTIES CXX_STANDARD 17)
 set_target_properties(core PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-# todo: do these in CI, not here:
-target_link_options(
-  core
-  PUBLIC
-  $<$<CONFIG:Debug>:
-  --coverage
-  -fsanitize=address
-  -fno-omit-frame-pointer>
-  $<$<CXX_COMPILER_ID:Clang>:-fuse-ld=lld>)
-target_compile_options(
-  core
-  PUBLIC $<$<CONFIG:Debug>:--coverage
-         -fsanitize=address
-         -fno-omit-frame-pointer
-         -Wall
-         -Wextra
-         -Wpedantic
-         -Wshadow
-         -Wunused
-         -Wconversion
-         -Wsign-conversion
-         -Wcast-align>)
-target_compile_options(
-  core
-  PUBLIC $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:Clang>>:-shared-libasan>)

--- a/src/core/model/src/geometry_analytic.cpp
+++ b/src/core/model/src/geometry_analytic.cpp
@@ -86,7 +86,7 @@ importGeometryFromAnalyticGeometry(const libsbml::Model *model,
   if (size.width() > size.height()) {
     imageSize.setHeight(static_cast<int>(
         static_cast<double>(imageSize.width()) * size.height() / size.width()));
-  } else {
+  } else if (size.width() < size.height()) {
     imageSize.setWidth(
         static_cast<int>(static_cast<double>(imageSize.height()) *
                          size.width() / size.height()));

--- a/src/core/model/src/model_events_t.cpp
+++ b/src/core/model/src/model_events_t.cpp
@@ -67,5 +67,10 @@ SCENARIO("SBML events",
     REQUIRE(events.getHasUnsavedChanges() == true);
     REQUIRE(events.getIds().size() == 0);
     REQUIRE(events.getNames().size() == 0);
+//    int k = 0x7fffffff;
+//    int kk = k + 1;
+//    CAPTURE(k);
+//    CAPTURE(kk);
+//    REQUIRE(k == kk);
   }
 }

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -445,7 +445,7 @@ SCENARIO("Simulate: very_simple_model, change pixel size, Pixel sim",
 }
 
 SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
-         "[core/simulate/simulate][core/simulate][core][simulate]") {
+         "[core/simulate/simulate][core/simulate][core][simulate][Q]") {
   for (auto simulatorType :
        {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
     double epsilon{1e-8};

--- a/src/gui/tabs/tabgeometry_t.cpp
+++ b/src/gui/tabs/tabgeometry_t.cpp
@@ -84,6 +84,8 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       REQUIRE(txtCompartmentName->text() == "Cell");
       // select first membrane
       listMembranes->setFocus();
+      // CI delay: give time for focus to be set
+      wait(50);
       sendKeyEvents(listMembranes, {" "});
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(listMembranes->currentItem()->text() == "Outside <-> Cell");


### PR DESCRIPTION
- move hard-coded link/compile options from CMakeLists to CI
- add SME_LOG_LEVEL cmake option instead of hard-coding based on Release/Debug build type

CI improvements

- don't use ASAN on coverage/sonar builds
- add ASAN build
- add UBSAN build (currently for info only: build passes regardless of UBSAN output)
- add TSAN build (currently for info only: build passes regardless of TSAN output)
