### PR TITLE
fix data race in Simulation::getConcImage

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -47,8 +47,8 @@ private:
   std::vector<std::vector<std::vector<double>>> concentration;
   // time->compartment->species
   std::vector<std::vector<std::vector<AvgMinMax>>> avgMinMax;
-  // compartment->species
-  std::vector<std::vector<double>> maxConcWholeSimulation;
+  // time->compartment->species
+  std::vector<std::vector<std::vector<double>>> concentrationMax;
   QSize imageSize;
   std::atomic<bool> isRunning{false};
   std::atomic<bool> stopRequested{false};


### PR DESCRIPTION
- store running max concentration for each timepoint in simulation, instead of only the last timepoint
- fixes the race condition between updateConcentrations writing this and getConcImage reading it
- resolves #445
