### PR TITLE
fix events import/export

### DIFF
--- a/src/core/model/src/model_events_t.cpp
+++ b/src/core/model/src/model_events_t.cpp
@@ -1,6 +1,7 @@
 #include "catch_wrapper.hpp"
 #include "model.hpp"
 #include "model_events.hpp"
+#include "sbml_math.hpp"
 #include "sbml_test_data/yeast_glycolysis.hpp"
 #include <QFile>
 #include <QImage>
@@ -46,14 +47,29 @@ SCENARIO("SBML events",
     events.setTime("n", 1.4);
     REQUIRE(events.getTime("n") == dbl_approx(1.4));
     // change expression
-    events.setExpression("n", "1    + cos(0)");
-    REQUIRE(events.getExpression("n") == "1 + cos(0)");
+    events.setExpression("n", "1");
+    REQUIRE(events.getExpression("n") == "1");
     // change expression to invalid math: no-op
     events.setExpression("n", "invalidmath???");
-    REQUIRE(events.getExpression("n") == "1 + cos(0)");
+    REQUIRE(events.getExpression("n") == "1");
     // change variable
     events.setVariable("n", "param2");
     REQUIRE(events.getVariable("n") == "param2");
+    // check sbml output
+    s.updateSBMLDoc();
+    std::unique_ptr<libsbml::SBMLDocument> doc2(
+        libsbml::readSBMLFromString(s.getXml().toStdString().c_str()));
+    const auto *model{doc2->getModel()};
+    REQUIRE(model->getNumEvents() == 1);
+    const auto *event{model->getEvent(0)};
+    REQUIRE(event->getId() == "n");
+    REQUIRE(event->getName() == "new name");
+    REQUIRE(sme::model::mathASTtoString(event->getTrigger()->getMath()) ==
+            "time >= 1.4");
+    REQUIRE(event->getNumEventAssignments() == 1);
+    REQUIRE(event->getEventAssignment(0)->getVariable() == "param2");
+    REQUIRE(sme::model::mathASTtoString(
+                event->getEventAssignment(0)->getMath()) == "1");
     // change to non-existent variable: no-op
     events.setHasUnsavedChanges(false);
     events.setVariable("n", "idontexist");
@@ -67,10 +83,92 @@ SCENARIO("SBML events",
     REQUIRE(events.getHasUnsavedChanges() == true);
     REQUIRE(events.getIds().size() == 0);
     REQUIRE(events.getNames().size() == 0);
-//    int k = 0x7fffffff;
-//    int kk = k + 1;
-//    CAPTURE(k);
-//    CAPTURE(kk);
-//    REQUIRE(k == kk);
+  }
+  GIVEN("event with multiple assignments") {
+    std::unique_ptr<libsbml::SBMLDocument> doc(
+        libsbml::readSBMLFromString(sbml_test_data::yeast_glycolysis().xml));
+    // add event with 3 assignments
+    auto *m{doc->getModel()};
+    auto *p1{m->createParameter()};
+    p1->setConstant(false);
+    p1->setId("v1");
+    auto *p2{m->createParameter()};
+    p2->setConstant(false);
+    p2->setId("v2");
+    auto *p3{m->createParameter()};
+    p3->setConstant(false);
+    p3->setId("v3");
+    auto *e{m->createEvent()};
+    e->setId("e");
+    e->setUseValuesFromTriggerTime(true);
+    auto *t{e->createTrigger()};
+    t->setInitialValue(false);
+    t->setPersistent(false);
+    // unsupported trigger
+    t->setMath(sme::model::mathStringToAST("v1 >= v2").get());
+    auto *a1{e->createEventAssignment()};
+    a1->setId("a1");
+    a1->setVariable("v1");
+    a1->setMath(sme::model::mathStringToAST("1").get());
+    auto *a2{e->createEventAssignment()};
+    a2->setId("a2");
+    a2->setVariable("v2");
+    a2->setMath(sme::model::mathStringToAST("2").get());
+    auto *a3{e->createEventAssignment()};
+    a3->setId("a3");
+    a3->setVariable("v3");
+    a3->setMath(sme::model::mathStringToAST("3").get());
+    libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
+    model::Model s;
+    s.importSBMLFile("tmp.xml");
+    auto &events = s.getEvents();
+    REQUIRE(s.getHasUnsavedChanges() == false);
+    REQUIRE(events.getHasUnsavedChanges() == false);
+    REQUIRE(events.getIds().size() == 3);
+    REQUIRE(events.getNames().size() == 3);
+    REQUIRE(events.getVariable("e") == "v1");
+    REQUIRE(events.getVariable("e__") == "v2");
+    REQUIRE(events.getVariable("e_") == "v3");
+    REQUIRE(events.getExpression("e") == "1");
+    REQUIRE(events.getExpression("e__") == "2");
+    REQUIRE(events.getExpression("e_") == "3");
+    // trigger was unsupported, so replaced with default t >= 0 trigger
+    REQUIRE(events.getTime("e") == dbl_approx(0));
+    REQUIRE(events.getTime("e__") == dbl_approx(0));
+    REQUIRE(events.getTime("e_") == dbl_approx(0));
+    // make some changes
+    events.setTime("e_", 9.2);
+    events.setExpression("e_", "99");
+    s.getParameters().add("param1");
+    events.setVariable("e__", "param1");
+    REQUIRE(s.getHasUnsavedChanges() == true);
+    REQUIRE(events.getHasUnsavedChanges() == true);
+    // check sbml output
+    s.updateSBMLDoc();
+    std::unique_ptr<libsbml::SBMLDocument> doc2(
+        libsbml::readSBMLFromString(s.getXml().toStdString().c_str()));
+    const auto *model{doc2->getModel()};
+    REQUIRE(model->getNumEvents() == 3);
+    const auto *e1{model->getEvent("e")};
+    const auto *e2{model->getEvent("e__")};
+    const auto *e3{model->getEvent("e_")};
+    REQUIRE(e1->getNumEventAssignments() == 1);
+    REQUIRE(e1->getEventAssignment(0)->getVariable() == "v1");
+    REQUIRE(sme::model::mathASTtoString(
+        e1->getEventAssignment(0)->getMath()) == "1");
+    REQUIRE(sme::model::mathASTtoString(e2->getTrigger()->getMath()) ==
+            "time >= 0");
+    REQUIRE(e2->getNumEventAssignments() == 1);
+    REQUIRE(e2->getEventAssignment(0)->getVariable() == "param1");
+    REQUIRE(sme::model::mathASTtoString(
+        e2->getEventAssignment(0)->getMath()) == "2");
+    REQUIRE(sme::model::mathASTtoString(e2->getTrigger()->getMath()) ==
+            "time >= 0");
+    REQUIRE(e3->getNumEventAssignments() == 1);
+    REQUIRE(e3->getEventAssignment(0)->getVariable() == "v3");
+    REQUIRE(sme::model::mathASTtoString(
+        e3->getEventAssignment(0)->getMath()) == "99");
+    REQUIRE(sme::model::mathASTtoString(e3->getTrigger()->getMath()) ==
+            "time >= 9.2");
   }
 }


### PR DESCRIPTION
- change trigger from from "t == 1" to form "t >= 1"
- on import, events with multiple assignments are split into multiple events each with one assignment
- on import, unsupported triggers are replaced with a default t >= 0 trigger
- resolves #448
