### PR TITLE
fix Pixel simulation diffusion constant bug

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -31,7 +31,7 @@ struct BenchmarkParams {
                                    "liver-simplified"};
   std::vector<simulate::SimulatorType> simulators{
       simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel};
-  double simulator_timestep{1e-3};
+  double simulator_timestep{1e-4};
 };
 
 static void printHelpMessage() {

--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -24,7 +24,6 @@ private:
   // indices of nearest neighbours
   std::vector<std::size_t> nn;
   std::string compartmentId;
-  double pixelWidth = 1.0;
   // vector of points that make up compartment
   std::vector<QPoint> ix;
   // index of corresponding point for each pixel in array
@@ -38,8 +37,6 @@ public:
   Compartment(std::string compId, const QImage &img, QRgb col);
   const std::string &getId() const;
   QRgb getColour() const;
-  double getPixelWidth() const;
-  void setPixelWidth(double width);
   inline const std::vector<QPoint> &getPixels() const { return ix; }
   inline const QPoint &getPixel(std::size_t i) const { return ix[i]; }
   inline std::size_t nPixels() const { return ix.size(); }

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -101,10 +101,6 @@ const std::string &Compartment::getId() const { return compartmentId; }
 
 QRgb Compartment::getColour() const { return colour; }
 
-double Compartment::getPixelWidth() const { return pixelWidth; }
-
-void Compartment::setPixelWidth(double width) { pixelWidth = width; }
-
 const QImage &Compartment::getCompartmentImage() const { return image; }
 
 const std::vector<std::size_t> &Compartment::getArrayPoints() const {

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -294,13 +294,6 @@ void ModelGeometry::setPixelWidth(double width) {
   hasUnsavedChanges = true;
   double oldWidth = pixelWidth;
   pixelWidth = width;
-  // update pixelWidth for each compartment
-  for (const auto &id : modelCompartments->getIds()) {
-    if (auto *compartment = modelCompartments->getCompartment(id);
-        compartment != nullptr) {
-      compartment->setPixelWidth(width);
-    }
-  }
   SPDLOG_INFO("New pixel width = {}", pixelWidth);
 
   auto *geom = getOrCreateGeometry(sbmlModel);

--- a/src/core/simulate/src/pixelsim_impl.cpp
+++ b/src/core/simulate/src/pixelsim_impl.cpp
@@ -87,9 +87,9 @@ SimCompartment::SimCompartment(const model::Model &doc,
   speciesNames.reserve(nSpecies);
   SPDLOG_DEBUG("compartment: {}", compartmentId);
   std::vector<const geometry::Field *> fields;
+  const double pixelWidth{doc.getGeometry().getPixelWidth()};
   for (const auto &s : speciesIds) {
     const auto *field = doc.getSpecies().getField(s.c_str());
-    double pixelWidth = comp->getPixelWidth();
     diffConstants.push_back(field->getDiffusionConstant() / pixelWidth /
                             pixelWidth);
     // forwards euler stability bound: dt < a^2/4D
@@ -127,7 +127,6 @@ SimCompartment::SimCompartment(const model::Model &doc,
   // setup concentrations vector with initial values
   conc.resize(nSpecies * nPixels);
   dcdt.resize(conc.size(), 0.0);
-  double width{doc.getGeometry().getPixelWidth()};
   auto origin{doc.getGeometry().getPhysicalOrigin()};
   auto concIter = conc.begin();
   for (std::size_t ix = 0; ix < compartment->nPixels(); ++ix) {
@@ -143,9 +142,9 @@ SimCompartment::SimCompartment(const model::Model &doc,
       auto pixel{compartment->getPixel(ix)};
       // pixels have y=0 in top-left, convert to bottom-left:
       pixel.ry() = compartment->getCompartmentImage().height() - 1 - pixel.y();
-      *concIter = origin.x() + static_cast<double>(pixel.x()) * width; // x
+      *concIter = origin.x() + static_cast<double>(pixel.x()) * pixelWidth; // x
       ++concIter;
-      *concIter = origin.y() + static_cast<double>(pixel.y()) * width; // y
+      *concIter = origin.y() + static_cast<double>(pixel.y()) * pixelWidth; // y
       ++concIter;
     }
   }


### PR DESCRIPTION
- remove pixelWidth member from model::geometry::Compartment
- get pixelWidth directly from model in pixel sim implementation
- duplicate existing simulation tests for different pixel sizes but save & reload model before simulating
- resolves #468
