### PR TITLE
allow semicolon-separated list of values for sim length & image interval in TabSimulate

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "simulate_options.hpp"
 #include "simulate_data.hpp"
+#include "simulate_options.hpp"
 #include <QImage>
 #include <QRgb>
 #include <QSize>
@@ -43,7 +43,7 @@ private:
   std::vector<std::vector<std::string>> compartmentSpeciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesIndices;
   std::vector<std::vector<QRgb>> compartmentSpeciesColors;
-  SimulationData* data;
+  SimulationData *data;
   std::unique_ptr<SimulationData> dataIfNotProvided;
   QSize imageSize;
   std::atomic<bool> isRunning{false};
@@ -64,6 +64,9 @@ public:
 
   std::size_t doTimesteps(double time, std::size_t nSteps = 1,
                           double timeout_ms = -1.0);
+  std::size_t doMultipleTimesteps(
+      const std::vector<std::pair<std::size_t, double>> &timesteps,
+      double timeout_ms = -1.0);
   const std::string &errorMessage() const;
   const QImage &errorImage() const;
   const std::vector<std::string> &getCompartmentIds() const;
@@ -96,7 +99,7 @@ public:
             std::map<std::string, std::vector<std::vector<double>>>>
   getPyConcs(std::size_t timeIndex) const;
   std::size_t getNCompletedTimesteps() const;
-  const SimulationData& getSimulationData() const;
+  const SimulationData &getSimulationData() const;
   bool getIsRunning() const;
   bool getIsStopping() const;
   void requestStop();

--- a/src/core/simulate/inc/simulate_data.hpp
+++ b/src/core/simulate/inc/simulate_data.hpp
@@ -21,6 +21,8 @@ public:
   std::vector<std::size_t> concPadding;
   std::string xmlModel;
   void clear();
+  [[nodiscard]] std::size_t size() const;
+  void reserve(std::size_t n);
   void pop_back();
 };
 

--- a/src/core/simulate/src/simulate_data.cpp
+++ b/src/core/simulate/src/simulate_data.cpp
@@ -11,7 +11,17 @@ void SimulationData::clear() {
   xmlModel.clear();
 }
 
-void SimulationData::pop_back(){
+std::size_t SimulationData::size() const { return timePoints.size(); }
+
+void SimulationData::reserve(std::size_t n) {
+  timePoints.reserve(n);
+  concentration.reserve(n);
+  avgMinMax.reserve(n);
+  concentrationMax.reserve(n);
+  concPadding.reserve(n);
+}
+
+void SimulationData::pop_back() {
   timePoints.pop_back();
   concentration.pop_back();
   avgMinMax.pop_back();

--- a/src/gui/tabs/tabsimulate_t.cpp
+++ b/src/gui/tabs/tabsimulate_t.cpp
@@ -83,6 +83,46 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
     wait(100);
   }
 
+  // set an invalid simulation lengths / image intervals
+  sendMouseClick(btnResetSimulation);
+  QString invalidMessage{"Invalid simulation length or image interval"};
+  // invalid double
+  sendKeyEvents(txtSimLength, {";", "c"});
+  mwt.start();
+  sendMouseClick(btnSimulate);
+  REQUIRE(mwt.getResult() == invalidMessage);
+
+  sendKeyEvents(txtSimLength, {"Backspace", "1"});
+  // sim interval larger than sim length
+  sendKeyEvents(txtSimInterval, {";", "9", "9", "9"});
+  mwt.start();
+  sendMouseClick(btnSimulate);
+  REQUIRE(mwt.getResult() == invalidMessage);
+
+  sendKeyEvents(txtSimLength, {";", "2", "0"});
+  // mismatch in number of elements in each vector
+  mwt.start();
+  sendMouseClick(btnSimulate);
+  REQUIRE(mwt.getResult() == invalidMessage);
+
+  // do valid multiple timestep simulation: 2x0.5, 2x0.25
+  sendKeyEvents(txtSimLength,
+                {"Backspace", "Backspace", "Backspace", "Backspace",
+                 "Backspace", "Backspace", "Backspace", "Backspace",
+                 "Backspace", "1", ";", "0", ".", "5"});
+  sendKeyEvents(txtSimInterval,
+                {"Backspace", "Backspace", "Backspace", "Backspace",
+                 "Backspace", "Backspace", "Backspace", "0", ".", "5", ";", "0",
+                 ".", "2", "5"});
+  sendMouseClick(btnSimulate);
+  REQUIRE(btnSimulate->isEnabled() == false);
+  while (!btnSimulate->isEnabled()) {
+    wait(100);
+  }
+  REQUIRE(hslideTime->isEnabled() == true);
+  REQUIRE(hslideTime->maximum() == 4);
+  REQUIRE(hslideTime->minimum() == 0);
+
   // hide all species
   mwt.addUserAction({"Space"});
   mwt.start();


### PR DESCRIPTION
- add Simulate::doMultipleTimesteps() that takes a vector of {n_steps, time_per_step} pairs
- resolves #464
