### PR TITLE
fully support dune simulation of models with empty compartments

### DIFF
--- a/src/core/mesh/inc/mesh.hpp
+++ b/src/core/mesh/inc/mesh.hpp
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -83,7 +82,7 @@ public:
   getBoundariesImages(const QSize &size, std::size_t boldBoundaryIndex) const;
   std::pair<QImage, QImage> getMeshImages(const QSize &size,
                                           std::size_t compartmentIndex) const;
-  QString getGMSH(const std::unordered_set<int> &gmshCompIndices = {}) const;
+  QString getGMSH() const;
 };
 
 } // namespace sme::mesh

--- a/src/core/mesh/src/mesh.cpp
+++ b/src/core/mesh/src/mesh.cpp
@@ -296,7 +296,7 @@ Mesh::getMeshImages(const QSize &size, std::size_t compartmentIndex) const {
   return imgPair;
 }
 
-QString Mesh::getGMSH(const std::unordered_set<int> &gmshCompIndices) const {
+QString Mesh::getGMSH() const {
   // note: gmsh indexing starts with 1, so we need to add 1 to all indices
   // meshing is done in terms of pixels, to convert to physical points:
   //   - rescale each vertex by a factor pixel
@@ -320,37 +320,27 @@ QString Mesh::getGMSH(const std::unordered_set<int> &gmshCompIndices) const {
   std::size_t nElem = 0;
   std::size_t compartmentIndex = 1;
   for (const auto &comp : triangleIndices) {
-    if (gmshCompIndices.empty() ||
-        gmshCompIndices.find(static_cast<int>(compartmentIndex)) !=
-            gmshCompIndices.cend()) {
       SPDLOG_TRACE("Adding compartment of triangles, index: {}",
                    compartmentIndex);
       nElem += comp.size();
-    }
     compartmentIndex++;
   }
   msh.append(QString("%1\n").arg(nElem));
-  std::size_t elementIndex = 1;
+  std::size_t elementIndex{1};
   compartmentIndex = 1;
-  std::size_t outputCompartmentIndex = 1;
   for (const auto &comp : triangleIndices) {
-    if (gmshCompIndices.empty() ||
-        gmshCompIndices.find(static_cast<int>(compartmentIndex)) !=
-            gmshCompIndices.cend()) {
-      SPDLOG_TRACE("Writing triangles for compartment index: {}",
+       SPDLOG_TRACE("Writing triangles for compartment index: {}",
                    compartmentIndex);
       for (const auto &t : comp) {
         msh.append(QString("%1 2 2 %2 %2 %3 %4 %5\n")
                        .arg(elementIndex)
-                       .arg(outputCompartmentIndex)
+                       .arg(compartmentIndex)
                        .arg(t[0] + 1)
                        .arg(t[1] + 1)
                        .arg(t[2] + 1));
         ++elementIndex;
       }
-      ++outputCompartmentIndex;
-    }
-    ++compartmentIndex;
+      ++compartmentIndex;
   }
   msh.append("$EndElements\n");
   return msh;

--- a/src/core/simulate/inc/duneconverter.hpp
+++ b/src/core/simulate/inc/duneconverter.hpp
@@ -5,7 +5,6 @@
 
 #include "simulate_options.hpp"
 #include <QString>
-#include <unordered_set>
 #include <vector>
 
 namespace sme {
@@ -28,8 +27,8 @@ public:
                          int doublePrecision = 18);
   QString getIniFile(std::size_t compartmentIndex = 0) const;
   const std::vector<QString> &getIniFiles() const;
-  const std::unordered_set<int> &getGMSHCompIndices() const;
   bool hasIndependentCompartments() const;
+
   const mesh::Mesh *getMesh() const;
   const std::vector<std::vector<std::vector<double>>> &
   getConcentrations() const;
@@ -40,7 +39,6 @@ public:
 
 private:
   std::vector<QString> iniFiles;
-  std::unordered_set<int> gmshCompIndices;
   bool independentCompartments{true};
   const mesh::Mesh *mesh;
   std::vector<std::vector<std::vector<double>>> concentrations;

--- a/src/core/simulate/src/duneconverter_impl.cpp
+++ b/src/core/simulate/src/duneconverter_impl.cpp
@@ -23,9 +23,7 @@
 #include <string>
 #include <utility>
 
-namespace sme {
-
-namespace simulate {
+namespace sme::simulate {
 
 std::vector<std::string>
 makeValidDuneSpeciesNames(const std::vector<std::string> &names) {
@@ -96,6 +94,4 @@ bool modelHasIndependentCompartments(const model::Model &model) {
   return true;
 }
 
-} // namespace simulate
-
-} // namespace sme
+} // namespace sme::simulate

--- a/src/core/simulate/src/duneconverter_impl.hpp
+++ b/src/core/simulate/src/duneconverter_impl.hpp
@@ -8,9 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace sme {
-
-namespace simulate {
+namespace sme::simulate {
 
 std::vector<std::string>
 makeValidDuneSpeciesNames(const std::vector<std::string> &names);
@@ -23,6 +21,4 @@ std::vector<std::string> getNonConstantSpecies(const model::Model &model,
 
 bool modelHasIndependentCompartments(const model::Model &model);
 
-} // namespace simulate
-
-} // namespace sme
+} // namespace sme::simulate

--- a/src/core/simulate/src/dunefunction.hpp
+++ b/src/core/simulate/src/dunefunction.hpp
@@ -44,6 +44,11 @@ public:
   template <typename Element, typename Domain>
   void evaluate(const Element &elem, const Domain &localPos,
                 typename Traits::RangeType &result) const {
+    if(c.empty()){
+      // dummy species, just return 0 everywhere
+      result = 0;
+      return;
+    }
     SPDLOG_TRACE("localPos ({},{})", localPos[0], localPos[1]);
     auto globalPos = elem.geometry().global(localPos);
     SPDLOG_TRACE("globalPos ({},{})", globalPos[0], globalPos[1]);

--- a/src/core/simulate/src/dunefunction_t.cpp
+++ b/src/core/simulate/src/dunefunction_t.cpp
@@ -72,8 +72,7 @@ SCENARIO("DUNE: function",
         Dune::Copasi::BitFlags<Dune::Copasi::ModelSetup::Stages>::all_flags();
     stages.reset(Dune::Copasi::ModelSetup::Stages::Writer);
     simulate::DuneConverter dc(m, false);
-    auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(
-        mesh, dc.getGMSHCompIndices());
+    auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(mesh);
     auto config = getConfig(dc);
     Model model(grid, config.sub("model"), stages);
     model.set_initial(simulate::makeModelDuneFunctions<Grid::LeafGridView>(dc));

--- a/src/core/simulate/src/dunegrid.hpp
+++ b/src/core/simulate/src/dunegrid.hpp
@@ -55,8 +55,7 @@ void insertTriangle(const std::array<std::size_t, 3> &t,
 
 template <typename HostGrid>
 std::pair<std::vector<std::size_t>, std::shared_ptr<HostGrid>>
-makeHostGrid(const mesh::Mesh &mesh,
-             const std::unordered_set<int> &compartmentIndicies) {
+makeHostGrid(const mesh::Mesh &mesh) {
   Dune::GridFactory<HostGrid> factory;
   // get original vertices
   auto v = mesh.getVerticesAsFlatArray();
@@ -67,11 +66,9 @@ makeHostGrid(const mesh::Mesh &mesh,
   // add triangles from each compartment
   std::size_t compIndex{1};
   for (const auto &triangles : mesh.getTriangleIndices()) {
-    if (useCompartment(compIndex, compartmentIndicies)) {
-      numElements.push_back(triangles.size());
-      for (const auto &triangle : triangles) {
-        insertTriangle(triangle, factory, newVertexIndices, newVertexCount);
-      }
+    numElements.push_back(triangles.size());
+    for (const auto &triangle : triangles) {
+      insertTriangle(triangle, factory, newVertexIndices, newVertexCount);
     }
     ++compIndex;
   }
@@ -125,10 +122,8 @@ void assignElements(Grid &grid, const std::vector<std::size_t> &numElements) {
 } // namespace detail
 
 template <class HostGrid, class MDGTraits>
-auto makeDuneGrid(const mesh::Mesh &mesh,
-                  const std::unordered_set<int> &compartmentIndicies) {
-  auto [numElements, hostGrid] =
-      detail::makeHostGrid<HostGrid>(mesh, compartmentIndicies);
+auto makeDuneGrid(const mesh::Mesh &mesh) {
+  auto [numElements, hostGrid] = detail::makeHostGrid<HostGrid>(mesh);
   auto grid =
       detail::makeGrid<HostGrid, MDGTraits>(*hostGrid, numElements.size());
   detail::assignElements(grid, numElements);

--- a/src/core/simulate/src/dunegrid_t.cpp
+++ b/src/core/simulate/src/dunegrid_t.cpp
@@ -38,16 +38,14 @@ SCENARIO("DUNE: grid",
       m.importSBMLString(f.readAll().toStdString());
     }
     simulate::DuneConverter dc(m, false);
-    const auto *mesh = m.getGeometry().getMesh();
-    const auto &compIndices = dc.getGMSHCompIndices();
+    const auto *mesh{m.getGeometry().getMesh()};
 
     // generate dune grid with sim::makeDuneGrid
-    auto [grid, hostGrid] =
-        simulate::makeDuneGrid<HostGrid, MDGTraits>(*mesh, compIndices);
+    auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(*mesh);
 
     // generate dune grid with Dune::Copasi::MultiDomainGmshReader
     if (QFile f("grid.msh"); f.open(QIODevice::WriteOnly | QIODevice::Text)) {
-      f.write(mesh->getGMSH(compIndices).toUtf8());
+      f.write(mesh->getGMSH().toUtf8());
       f.close();
     }
     // note: requires C locale
@@ -64,7 +62,6 @@ SCENARIO("DUNE: grid",
 
     // compare grids
     int nCompartments{grid->maxSubDomainIndex()};
-    REQUIRE(nCompartments == static_cast<int>(compIndices.size()));
     REQUIRE(gmshGrid->maxSubDomainIndex() == nCompartments);
     for (int compIndex = 0; compIndex < nCompartments; ++compIndex) {
       auto meshCoords = getAllElementCoordinates(grid.get(), compIndex);

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -35,28 +35,28 @@ using PixelLocalPair = std::pair<std::size_t, std::array<double, 2>>;
 
 class DuneImpl;
 
+struct DuneSimCompartment {
+  std::string name;
+  std::size_t index;
+  std::vector<std::size_t> speciesIndices;
+  utils::QPointIndexer qPointIndexer;
+  const geometry::Compartment *geometry;
+  // pixels+dune local coords for each triangle
+  std::vector<std::vector<PixelLocalPair>> pixels;
+  // index of nearest valid pixel for any missing pixels
+  std::vector<std::pair<std::size_t, std::size_t>> missingPixels;
+  std::vector<double> concentration;
+};
+
 class DuneSim : public BaseSim {
 private:
   std::unique_ptr<DuneImpl> pDuneImpl;
-  std::vector<std::string> compartmentDuneNames;
-  // DUNE species index for each species
-  std::vector<std::vector<std::size_t>> compartmentSpeciesIndex;
+  std::vector<DuneSimCompartment> duneCompartments;
   // dimensions of model
   QSize geometryImageSize;
   double pixelSize;
   QPointF pixelOrigin;
-  // map from pixel QPoint to ix index for each compartment
-  std::vector<utils::QPointIndexer> compartmentPointIndex;
-  std::vector<const geometry::Compartment *> compartmentGeometry;
-  // pixels+dune local coords for each triangle
-  // compartment::triangle::pixels+local-coord
-  std::vector<std::vector<std::vector<PixelLocalPair>>> pixels;
-  // missing pixels: use concentration from neighbouring pixel
-  std::vector<std::vector<std::pair<std::size_t, std::size_t>>> missingPixels;
-  // concentrations for each pixel in compartments
-  std::vector<std::vector<double>> concentration;
-  void initCompartmentNames();
-  void initSpeciesIndices();
+  void initDuneSimCompartments(const std::vector<const geometry::Compartment*>& comps);
   void updatePixels();
   void updateSpeciesConcentrations();
   std::string currentErrorMessage;
@@ -68,15 +68,14 @@ public:
   explicit DuneSim(
       const model::Model &sbmlDoc,
       const std::vector<std::string> &compartmentIds,
-      const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
       const DuneOptions &duneOptions = {});
   ~DuneSim() override;
   std::size_t run(double time, double timeout_ms) override;
-  const std::vector<double> &
+  [[nodiscard]] const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
-  std::size_t getConcentrationPadding() const override;
-  const std::string &errorMessage() const override;
-  const QImage& errorImage() const override;
+  [[nodiscard]] std::size_t getConcentrationPadding() const override;
+  [[nodiscard]] const std::string &errorMessage() const override;
+  [[nodiscard]] const QImage &errorImage() const override;
   void requestStop() override;
 };
 

--- a/src/core/simulate/src/dunesim_impl.cpp
+++ b/src/core/simulate/src/dunesim_impl.cpp
@@ -24,8 +24,7 @@ DuneImpl::DuneImpl(const simulate::DuneConverter &dc) {
     }
   }
   // construct grid
-  std::tie(grid, hostGrid) =
-      makeDuneGrid<HostGrid, MDGTraits>(*dc.getMesh(), dc.getGMSHCompIndices());
+  std::tie(grid, hostGrid) = makeDuneGrid<HostGrid, MDGTraits>(*dc.getMesh());
 }
 
 DuneImpl::~DuneImpl() = default;

--- a/src/core/simulate/src/dunesim_t.cpp
+++ b/src/core/simulate/src/dunesim_t.cpp
@@ -6,19 +6,67 @@
 
 using namespace sme;
 
-SCENARIO("DuneSim: model without species",
+SCENARIO("DuneSim: empty compartments",
          "[core/simulate/dunesim][core/simulate][core][simulate][dunesim]") {
-  model::Model m;
-  QFile f(":/models/ABtoC.xml");
-  f.open(QIODevice::ReadOnly);
-  m.importSBMLString(f.readAll().toStdString());
-  for (const auto &speciesId : m.getSpecies().getIds("comp")) {
-    m.getSpecies().remove(speciesId);
+  WHEN("Model has no species") {
+    model::Model m;
+    QFile f(":/models/ABtoC.xml");
+    f.open(QIODevice::ReadOnly);
+    m.importSBMLString(f.readAll().toStdString());
+    for (const auto &speciesId : m.getSpecies().getIds("comp")) {
+      m.getSpecies().remove(speciesId);
+    }
+    std::vector<std::string> comps{"comp"};
+    simulate::DuneSim duneSim(m, comps);
+    REQUIRE(duneSim.errorMessage().empty());
   }
-  std::vector<std::string> comps{"comp"};
-  std::vector<std::vector<std::string>> species;
-  species.emplace_back();
-  simulate::DuneSim duneSim(m, comps, species);
-  REQUIRE(duneSim.errorMessage() ==
-          "Nothing to simulate: no non-constant species in model");
+  WHEN("Compartment in model has no species, but membrane contains reactions") {
+    // see https://github.com/spatial-model-editor/spatial-model-editor/issues/435
+    model::Model m;
+    QFile f(":/models/very-simple-model.xml");
+    f.open(QIODevice::ReadOnly);
+    m.importSBMLString(f.readAll().toStdString());
+    m.getSpecies().setInitialConcentration("B_c2", 0.1);
+    auto col1{m.getCompartments().getColour("c1")};
+    auto col2{m.getCompartments().getColour("c2")};
+    // remove all species from nucleus, but keep compartment in model
+    m.getSpecies().remove("A_c3");
+    m.getSpecies().remove("B_c3");
+    // re-assign compartment colour to generate default boundaries & mesh
+    m.getCompartments().setColour("c1", col1);
+    std::vector<std::string> comps{"c1", "c2", "c3"};
+    simulate::DuneSim duneSim(m, comps);
+    for(std::size_t i=0; i<10; ++i){
+      duneSim.run(0.1, 100);
+    }
+    REQUIRE(duneSim.getConcentrations(0).size() == 5441);
+    REQUIRE(duneSim.getConcentrations(1).size() == 8068);
+    REQUIRE(duneSim.errorMessage().empty());
+    // completely remove nucleus compartment from model and repeat:
+    // shouldn't change simulation results
+    m.getCompartments().remove("c3");
+    m.getCompartments().setColour("c1", col1);
+    m.getCompartments().setColour("c2", col2);
+    comps.pop_back();
+    simulate::DuneSim newDuneSim(m, comps);
+    for(std::size_t i=0; i<10; ++i){
+      newDuneSim.run(0.1, 100);
+    }
+    REQUIRE(newDuneSim.getConcentrations(0).size() == 5441);
+    REQUIRE(newDuneSim.getConcentrations(1).size() == 8068);
+    for(std::size_t iComp=0; iComp<2; ++iComp){
+      double diff{0};
+      double sum{0};
+      const auto n{duneSim.getConcentrations(iComp).size()};
+      const auto& a{duneSim.getConcentrations(iComp)};
+      const auto& b{newDuneSim.getConcentrations(iComp)};
+      for(std::size_t i=0; i<n; ++i){
+        diff += std::abs(a[i] - b[i]);
+        sum += std::abs(a[i]) + std::abs(b[i]);
+      }
+      CAPTURE(sum);
+      CAPTURE(diff);
+      REQUIRE(diff/sum < 1e-8);
+    }
+  }
 }

--- a/src/core/simulate/src/simulate.cpp
+++ b/src/core/simulate/src/simulate.cpp
@@ -94,9 +94,8 @@ void Simulation::applyNextEvent() {
   if (simulatorType == SimulatorType::DUNE &&
       simModel->getGeometry().getMesh() != nullptr &&
       simModel->getGeometry().getMesh()->isValid()) {
-    simulator =
-        std::make_unique<DuneSim>(*simModel.get(), compartmentIds,
-                                  compartmentSpeciesIds, simulatorOptions.dune);
+    simulator = std::make_unique<DuneSim>(*simModel.get(), compartmentIds,
+                                          simulatorOptions.dune);
   } else {
     simulator = std::make_unique<PixelSim>(*simModel.get(), compartmentIds,
                                            compartmentSpeciesIds,
@@ -175,7 +174,7 @@ Simulation::Simulation(model::Model &sbmlDoc, SimulatorType simType,
       sbmlDoc.getGeometry().getMesh() != nullptr &&
       sbmlDoc.getGeometry().getMesh()->isValid()) {
     simulator = std::make_unique<DuneSim>(*modelToSimulate, compartmentIds,
-                                          compartmentSpeciesIds, options.dune);
+                                          options.dune);
   } else {
     simulator = std::make_unique<PixelSim>(
         *modelToSimulate, compartmentIds, compartmentSpeciesIds, options.pixel);


### PR DESCRIPTION
- previously compartments with no species were excluded from grid & ini file
- now they are included with a single dummy species with no reactions
- these compartments are excluded from the generated concentration results
- resolves #435
