### PR TITLE
bugfixes for simulations with events

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -31,6 +31,11 @@ namespace simulate {
 class BaseSim;
 enum class SimulatorType { DUNE, Pixel };
 
+struct SimEvent{
+  double time;
+  std::vector<std::string> ids;
+};
+
 class Simulation {
 private:
   std::unique_ptr<BaseSim> simulator;
@@ -50,7 +55,7 @@ private:
   std::atomic<bool> stopRequested{false};
   std::atomic<std::size_t> nCompletedTimesteps{0};
   std::unique_ptr<sme::model::Model> simModel;
-  std::queue<double> eventTimes;
+  std::queue<SimEvent> simEvents;
   void initModel(const model::Model &model);
   void initEvents(model::Model &model);
   void applyNextEvent();

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -133,7 +133,7 @@ void DuneSim::updatePixels() {
     const auto &gridview{
         pDuneImpl->grid->subDomain(static_cast<int>(comp.index))
             .leafGridView()};
-    SPDLOG_TRACE("compartment[{}]: {}", comp.duneIndex, comp.name);
+    SPDLOG_TRACE("compartment[{}]: {}", comp.index, comp.name);
     const auto &qpi{comp.qPointIndexer};
     std::vector<bool> ixAssigned(qpi.getNumPoints(), false);
     // get local coord for each pixel in each triangle


### PR DESCRIPTION
- use externally supplied Model, not internal simulation Model in Simulation::initModel()
  - otherwise we are left with dangling pointers when the simulation Model is changed
  - resolves #484
- use latest concentration (which is not always nCompletedTimesteps - 1) in Simulation::applyEvent()
  - resolves #485
- create queue of event times with list of events to apply at each time before starting simulation
  - replaces unsafe comparison between event time and current simulation time
  - resolves #486
- correctly simulate multiple, closely spaced but not exactly coincident events
  - before each step, if any events would occur in less than some tiny fraction of a timestep, apply them
  - then, if an event would occur during the next timestep
    - do a sub step until this timepoint, apply the event, reduce the current step size accordingly
  - repeat until no further events would occur during the step
- only create a new simulation Model if > 1 existing simulation data timepoints
  - avoids needlessly re-importing the model
