### PR TITLE
look-up compartment name by id instead of by index in TabSimulate

### DIFF
--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -122,7 +122,7 @@ void TabSimulate::loadModelData() {
   std::size_t nSpecies{0};
   for (std::size_t ic = 0; ic < sim->getCompartmentIds().size(); ++ic) {
     compartmentNames.push_back(
-        model.getCompartments().getNames()[static_cast<int>(ic)]);
+        model.getCompartments().getName(sim->getCompartmentIds()[ic].c_str()));
     auto &names = speciesNames.emplace_back();
     for (const auto &sId : sim->getSpeciesIds(ic)) {
       names.push_back(model.getSpecies().getName(sId.c_str()));


### PR DESCRIPTION
- using the index could give the wrong compartment name for simulation with empty compartments
- resolves #487
