### PR TITLE
add git commit hash as suffix to version number for "latest" releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - name: Set "latest" version number
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/latest')
+      run: ./ci/set-latest-version.sh ${GITHUB_SHA}
     - name: Cache ccache
       uses: actions/cache@v2
       with:
@@ -42,6 +45,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
+      - name: Set "latest" version number
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/latest')
+        run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
         uses: actions/cache@v2
         with:
@@ -74,6 +80,9 @@ jobs:
           msystem: MINGW64
           update: true
           install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache make
+      - name: Set "latest" version number
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/latest')
+        run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
         uses: actions/cache@v2
         with:

--- a/ci/linux-gui.sh
+++ b/ci/linux-gui.sh
@@ -42,6 +42,9 @@ time ./benchmark/benchmark 1
 ldd src/spatial-model-editor
 ldd cli/spatial-cli
 
+# display version
+./src/spatial-model-editor -v
+
 # move binaries to artefacts/
 cd ..
 mkdir artefacts

--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -48,6 +48,9 @@ mkdir spatial-cli
 cp cli/spatial-cli spatial-cli/.
 hdiutil create spatial-cli -fs HFS+ -srcfolder spatial-cli
 
+# display version
+./src/spatial-model-editor.app/Contents/MacOS/spatial-model-editor -v
+
 # move binaries to artefacts/
 cd ..
 mkdir artefacts

--- a/ci/set-latest-version.sh
+++ b/ci/set-latest-version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# bash script to set the version number for "latest" release builds
+# usage: ./ci/set-latest-version.sh "asdfasdgfawerce"
+# appends the first 7 chars of supplied string to SPATIAL_MODEL_EDITOR_VERSION
+
+set -e -x
+
+VERSION_SUFFIX=$(echo "$1" | head -c 7)
+VERSION_FILE=src/core/common/src/version.cpp.in
+
+echo "Appending ${VERSION_SUFFIX} to SPATIAL_MODEL_EDITOR_VERSION in ${VERSION_FILE}"
+
+cat ${VERSION_FILE}
+
+sed -i.bak "s/@PROJECT_VERSION@/@PROJECT_VERSION@+${VERSION_SUFFIX}/g" ${VERSION_FILE}
+
+cat ${VERSION_FILE}

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -35,7 +35,6 @@ objdump.exe -x sme/sme.cp38-win_amd64.pyd > sme_obj.txt
 head -n 20 sme_obj.txt
 head -n 1000 sme_obj.txt | grep "DLL Name"
 
-# temporarily exclude simulate tests due to mystery segfault on windows
 ./test/tests.exe -as ~[gui] > tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt
 
@@ -45,6 +44,9 @@ tail -n 100 tests.txt
 cd ..
 mv build/sme/sme.cp38-win_amd64.pyd .
 python -m unittest discover -s sme/test -v
+
+# display version
+./build/src/spatial-model-editor.exe -v
 
 # move binaries to artefacts/
 mkdir artefacts


### PR DESCRIPTION
- e.g. version number "x.y.z" -> "x.y.z+a8c6x27" in the "latest" GUI binary
- resolves #491
