### PR TITLE
improve reactions Tab

### DIFF
--- a/src/core/model/inc/model_reactions.hpp
+++ b/src/core/model/inc/model_reactions.hpp
@@ -38,12 +38,13 @@ public:
   void removeAllInvolvingSpecies(const QString &speciesId);
   QString setName(const QString &id, const QString &name);
   QString getName(const QString &id) const;
+  QString getScheme(const QString& id) const;
   void setLocation(const QString &id, const QString &locationId);
   QString getLocation(const QString &id) const;
-  int getSpeciesStoichiometry(const QString &id,
+  double getSpeciesStoichiometry(const QString &id,
                               const QString &speciesId) const;
   void setSpeciesStoichiometry(const QString &id, const QString &speciesId,
-                               int stoichiometry);
+                               double stoichiometry);
   QString getRateExpression(const QString &id) const;
   void setRateExpression(const QString &id, const QString &expression);
   QStringList getParameterIds(const QString &id) const;

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -297,9 +297,10 @@ SCENARIO("SBML: import SBML level 2 document",
       REQUIRE(reacs.getIds("compartment0")[0] == "reac1");
       REQUIRE(reacs.getName("reac1") == "reac1");
       REQUIRE(reacs.getLocation("reac1") == "compartment0");
-      REQUIRE(reacs.getSpeciesStoichiometry("reac1", "spec1c0") == 1);
-      REQUIRE(reacs.getSpeciesStoichiometry("reac1", "spec0c0") == -1);
+      REQUIRE(reacs.getSpeciesStoichiometry("reac1", "spec1c0") == dbl_approx(1));
+      REQUIRE(reacs.getSpeciesStoichiometry("reac1", "spec0c0") == dbl_approx(-1));
       REQUIRE(reacs.getRateExpression("reac1") == "5 * spec0c0 / compartment0");
+      REQUIRE(reacs.getScheme("reac1") == "spec0c0 -> spec1c0");
     }
     WHEN("exportSBMLFile called") {
       THEN("exported file is a SBML level (3,2) document with spatial "
@@ -551,14 +552,15 @@ SCENARIO("SBML: ABtoC.xml", "[core/model/model][core/model][core][model]") {
         REQUIRE(s.getReactions().getIds("comp").size() == 1);
         REQUIRE(s.getReactions().getIds("comp")[0] == "r1");
         REQUIRE(s.getReactions().getName("r1") == "r1");
-        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "C") == 1);
-        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "A") == -1);
-        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "B") == -1);
+        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "C") == dbl_approx(1));
+        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "A") ==  dbl_approx(-1));
+        REQUIRE(s.getReactions().getSpeciesStoichiometry("r1", "B") ==  dbl_approx(-1));
         REQUIRE(s.getReactions().getParameterIds("r1").size() == 1);
         REQUIRE(s.getReactions().getParameterName("r1", "k1") == "k1");
         REQUIRE(s.getReactions().getParameterValue("r1", "k1") ==
                 dbl_approx(0.1));
         REQUIRE(s.getReactions().getRateExpression("r1") == "A * B * k1");
+        REQUIRE(s.getReactions().getScheme("r1") == "A + B -> C");
       }
       THEN("species have correct colours") {
         REQUIRE(s.getSpecies().getColour("A") == 0xffe60003);
@@ -668,7 +670,7 @@ SCENARIO("SBML: very-simple-model.xml",
       s.getReactions().setName("re_ac1", "new Name");
       s.getReactions().setLocation("re_ac1", "c3");
       s.getReactions().setSpeciesStoichiometry("re_ac1", "A_c3", 1);
-      s.getReactions().setSpeciesStoichiometry("re_ac1", "B_c3", -2);
+      s.getReactions().setSpeciesStoichiometry("re_ac1", "B_c3", -2.0123);
       s.getReactions().addParameter("re_ac1", "const 1", 0.2);
       s.getReactions().setRateExpression("re_ac1",
                                          "0.2 + A_c3 * B_c3 * const_1");
@@ -676,8 +678,9 @@ SCENARIO("SBML: very-simple-model.xml",
       REQUIRE(s.getReactions().getLocation("re_ac1") == "c3");
       REQUIRE(s.getReactions().getRateExpression("re_ac1") ==
               "0.2 + A_c3 * B_c3 * const_1");
-      REQUIRE(s.getReactions().getSpeciesStoichiometry("re_ac1", "A_c3") == 1);
-      REQUIRE(s.getReactions().getSpeciesStoichiometry("re_ac1", "B_c3") == -2);
+      REQUIRE(s.getReactions().getSpeciesStoichiometry("re_ac1", "A_c3") ==  dbl_approx(1));
+      REQUIRE(s.getReactions().getSpeciesStoichiometry("re_ac1", "B_c3") ==  dbl_approx(-2.0123));
+      REQUIRE(s.getReactions().getScheme("re_ac1") == "2.0123 B_nucl -> A_nucl");
     }
     WHEN("change reaction location") {
       REQUIRE(s.getReactions().getIds("c2").size() == 0);

--- a/src/core/simulate/src/pde.cpp
+++ b/src/core/simulate/src/pde.cpp
@@ -121,9 +121,8 @@ Reaction::getStoichMatrixRow(const model::Model *doc,
   bool isReaction = false;
   for (const auto &speciesID : speciesIDs) {
     auto speciesName = doc->getSpecies().getName(speciesID.c_str());
-    double stoichCoeff =
-        static_cast<double>(doc->getReactions().getSpeciesStoichiometry(
-            reacId.c_str(), speciesID.c_str()));
+    double stoichCoeff{doc->getReactions().getSpeciesStoichiometry(
+        reacId.c_str(), speciesID.c_str())};
     SPDLOG_DEBUG("product '{}'", speciesID);
     auto speciesIndex = getSpeciesIndex(doc, speciesID, speciesIDs);
     if (speciesIndex) {

--- a/src/gui/tabs/tabreactions.ui
+++ b/src/gui/tabs/tabreactions.ui
@@ -92,44 +92,11 @@
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <layout class="QGridLayout" name="gridLayout_9" rowstretch="1,0,0,0,0,0,0,0">
+        <layout class="QGridLayout" name="gridLayout_9" rowstretch="1,0,0,0,0,0,0,0,0">
          <property name="horizontalSpacing">
           <number>6</number>
          </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lblReactionLocationLabel">
-           <property name="text">
-            <string>Location:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1" colspan="3">
-          <widget class="QTreeWidget" name="listReactionSpecies">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="rootIsDecorated">
-            <bool>true</bool>
-           </property>
-           <column>
-            <property name="text">
-             <string>Species</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Stoichiometry</string>
-            </property>
-           </column>
-          </widget>
-         </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="lblReactionParamsLabel">
            <property name="text">
             <string>Params:</string>
@@ -139,100 +106,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="QPushButton" name="btnRemoveReactionParam">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Remove parameter</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1" colspan="3">
-          <widget class="QTableWidget" name="listReactionParams">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="cornerButtonEnabled">
-            <bool>true</bool>
-           </property>
-           <attribute name="horizontalHeaderStretchLastSection">
-            <bool>true</bool>
-           </attribute>
-           <attribute name="verticalHeaderVisible">
-            <bool>false</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Value</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Units</string>
-            </property>
-           </column>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lblReactionRateLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Rate:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="3">
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblReactionNameLabel">
-           <property name="text">
-            <string>Name:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QPushButton" name="btnAddReactionParam">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Add parameter</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="lblStoichiometryLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -248,20 +122,27 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1" colspan="3">
-          <widget class="QPlainTextMathEdit" name="txtReactionRate">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblReactionLocationLabel">
+           <property name="text">
+            <string>Location:</string>
            </property>
-           <property name="tabChangesFocus">
-            <bool>true</bool>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="7" column="1" colspan="3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblReactionNameLabel">
+           <property name="text">
+            <string>Name:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1" colspan="3">
           <widget class="QLabel" name="lblReactionRateStatus">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -398,13 +279,67 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1" colspan="3">
-          <widget class="QLineEdit" name="txtReactionName"/>
+         <item row="4" column="1" colspan="3">
+          <widget class="QTableWidget" name="listReactionParams">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="cornerButtonEnabled">
+            <bool>true</bool>
+           </property>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
+           </attribute>
+           <attribute name="verticalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Units</string>
+            </property>
+           </column>
+          </widget>
          </item>
-         <item row="1" column="1" colspan="3">
-          <widget class="QComboBox" name="cmbReactionLocation"/>
+         <item row="5" column="3">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
-         <item row="6" column="0">
+         <item row="6" column="1" colspan="3">
+          <widget class="QPlainTextMathEdit" name="txtReactionRate">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="tabChangesFocus">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
           <widget class="QLabel" name="lblReactionRateUnitsLabel">
            <property name="text">
             <string>Units:</string>
@@ -414,10 +349,85 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1" colspan="3">
+         <item row="3" column="1" colspan="3">
+          <widget class="QTreeWidget" name="listReactionSpecies">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="rootIsDecorated">
+            <bool>true</bool>
+           </property>
+           <column>
+            <property name="text">
+             <string>Species</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Stoichiometry</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QPushButton" name="btnRemoveReactionParam">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Remove parameter</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1" colspan="3">
+          <widget class="QComboBox" name="cmbReactionLocation"/>
+         </item>
+         <item row="0" column="1" colspan="3">
+          <widget class="QLineEdit" name="txtReactionName"/>
+         </item>
+         <item row="7" column="1" colspan="3">
           <widget class="QLabel" name="lblReactionRateUnits">
            <property name="text">
             <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="lblReactionRateLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Rate:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QPushButton" name="btnAddReactionParam">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Add parameter</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="3">
+          <widget class="QLabel" name="lblReactionScheme">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
            </property>
           </widget>
          </item>

--- a/src/gui/tabs/tabreactions_t.cpp
+++ b/src/gui/tabs/tabreactions_t.cpp
@@ -23,6 +23,8 @@ SCENARIO("Reactions Tab", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
   auto *btnAddReaction = tab.findChild<QPushButton *>("btnAddReaction");
   auto *btnRemoveReaction = tab.findChild<QPushButton *>("btnRemoveReaction");
   auto *txtReactionName = tab.findChild<QLineEdit *>("txtReactionName");
+  auto *lblReactionScheme{tab.findChild<QLabel *>("lblReactionScheme")};
+  REQUIRE(lblReactionScheme != nullptr);
   auto *cmbReactionLocation = tab.findChild<QComboBox *>("cmbReactionLocation");
   auto *listReactionSpecies =
       tab.findChild<QTreeWidget *>("listReactionSpecies");
@@ -50,6 +52,7 @@ SCENARIO("Reactions Tab", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
     REQUIRE(listReactions->topLevelItem(4)->childCount() == 2);
     REQUIRE(listReactions->currentItem()->text(0) == "A to B conversion");
     REQUIRE(listReactions->currentItem()->parent()->text(0) == "Nucleus");
+    REQUIRE(lblReactionScheme->text() == "A_nucl -> B_nucl");
     // edit reaction name
     txtReactionName->setFocus();
     sendKeyEvents(txtReactionName, {" ", "!", "Enter"});
@@ -85,6 +88,7 @@ SCENARIO("Reactions Tab", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
     REQUIRE(listReactionParams->rowCount() == 0);
     REQUIRE(sbmlDoc.getReactions().getIds("c3").size() == 2);
     REQUIRE(sbmlDoc.getReactions().getName("reacQ") == "reacQ!");
+    REQUIRE(lblReactionScheme->text() == "");
     // add & edit reaction params
     mwt.addUserAction({"y"});
     mwt.start();

--- a/src/gui/tabs/tabsimulate_t.cpp
+++ b/src/gui/tabs/tabsimulate_t.cpp
@@ -99,8 +99,10 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
                  "Backspace", "1", ";", "0", ".", "5"});
   sendKeyEvents(txtSimInterval,
                 {"Backspace", "Backspace", "Backspace", "Backspace",
-                 "Backspace", "Backspace", "Backspace", "0", ".", "4", "9", "9", "9", ";", "0",
-                 ".", "2", "5", "0", "1"});
+                 "Backspace", "Backspace", "Backspace", "0",
+                 ".",         "4",         "9",         "9",
+                 "9",         ";",         "0",         ".",
+                 "2",         "5",         "0",         "1"});
   sendMouseClick(btnSimulate);
   REQUIRE(btnSimulate->isEnabled() == false);
   while (!btnSimulate->isEnabled()) {


### PR DESCRIPTION
- add reaction scheme
  - add getScheme() method to ModelReactions, returns e.g. "A + B -> C"
  - add label displaying reaction scheme to TabReactions
- add support for non-integer stoichiometries
  - use double instead of int in [get/set]Stoichiometry()
  - use QDoubleSpinBox in tabReactions
- resolves #495
