### PR TITLE
add optional grid & scale to geometry image

### DIFF
--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -222,7 +222,8 @@ void ModelGeometry::importGeometryFromImage(const QImage &img) {
 
 void ModelGeometry::updateMesh() {
   // geometry only valid if all compartments have a colour
-  isValid = hasImage && !modelCompartments->getColours().empty() && !modelCompartments->getColours().contains(0);
+  isValid = hasImage && !modelCompartments->getColours().empty() &&
+            !modelCompartments->getColours().contains(0);
   if (!isValid) {
     mesh.reset();
     return;
@@ -330,21 +331,21 @@ void ModelGeometry::setPixelWidth(double width) {
     mesh->setPhysicalGeometry(width, physicalOrigin);
   }
   // update xy coordinates
+  physicalSize = {pixelWidth * static_cast<double>(image.width()),
+                  pixelWidth * static_cast<double>(image.height())};
   auto *coord = geom->getCoordinateComponentByKind(
       libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_X);
   auto *min = coord->getBoundaryMin();
   auto *max = coord->getBoundaryMax();
   min->setValue(physicalOrigin.x());
-  max->setValue(physicalOrigin.x() +
-                pixelWidth * static_cast<double>(image.width()));
+  max->setValue(physicalOrigin.x() + physicalSize.width());
   SPDLOG_INFO("  - x now in range [{},{}]", min->getValue(), max->getValue());
   coord = geom->getCoordinateComponentByKind(
       libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_Y);
   min = coord->getBoundaryMin();
   max = coord->getBoundaryMax();
   min->setValue(physicalOrigin.y());
-  max->setValue(physicalOrigin.y() +
-                pixelWidth * static_cast<double>(image.height()));
+  max->setValue(physicalOrigin.y() + physicalSize.height());
   SPDLOG_INFO("  - y now in range [{},{}]", min->getValue(), max->getValue());
 }
 

--- a/src/gui/dialogs/dialoganalytic.ui
+++ b/src/gui/dialogs/dialoganalytic.ui
@@ -19,24 +19,14 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0" colspan="3">
-      <widget class="QLabelMouseTracker" name="lblImage" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>1</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
-&lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
-       </property>
-       <property name="text" stdset="0">
-        <string/>
+     <item row="5" column="0" colspan="2">
+      <widget class="QPushButton" name="btnExportImage">
+       <property name="text">
+        <string>export as image...</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="3" column="0" colspan="2">
       <widget class="QPlainTextMathEdit" name="txtExpression">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -61,6 +51,42 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="QLabel" name="lblExpressionStatus">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">font-weight: bold; color: red</string>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLabelMouseTracker" name="lblImage" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+&lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+       </property>
+       <property name="text" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0" colspan="2">
       <widget class="QLabel" name="lblConcentration">
        <property name="sizePolicy">
@@ -80,29 +106,23 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="lblExpressionStatus">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">font-weight: bold; color: red</string>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="chkGrid">
        <property name="text">
-        <string/>
+        <string>Show &amp;grid</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QPushButton" name="btnExportImage">
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="chkScale">
        <property name="text">
-        <string>export as image...</string>
+        <string>Show &amp;scale</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -132,6 +152,12 @@
    <header>qplaintextmathedit.hpp</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>chkGrid</tabstop>
+  <tabstop>chkScale</tabstop>
+  <tabstop>txtExpression</tabstop>
+  <tabstop>btnExportImage</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/dialogs/dialoganalytic_t.cpp
+++ b/src/gui/dialogs/dialoganalytic_t.cpp
@@ -96,8 +96,8 @@ SCENARIO("DialogAnalytic",
                        doc.getParameters().getSpatialCoordinates());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
-    WHEN("valid expr: 10") {
-      mwt.addUserAction({"Delete", "1", "0"});
+    WHEN("valid expr: 10 & unclick grid/scale checkboxes") {
+      mwt.addUserAction({"Delete", "1", "0", "Shift+Tab", "Space", "Shift+Tab", "Space"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.isExpressionValid() == true);

--- a/src/gui/dialogs/dialogconcentrationimage.cpp
+++ b/src/gui/dialogs/dialogconcentrationimage.cpp
@@ -36,6 +36,17 @@ DialogConcentrationImage::DialogConcentrationImage(
                QImage::Format_ARGB32_Premultiplied);
   img.fill(0);
 
+  ui->lblImage->displayGrid(ui->chkGrid->isChecked());
+  ui->lblImage->displayScale(ui->chkScale->isChecked());
+  QSizeF physicalSize;
+  physicalSize.rwidth() =
+      static_cast<double>(speciesGeometry.compartmentImageSize.width()) *
+      speciesGeometry.pixelWidth;
+  physicalSize.rheight() =
+      static_cast<double>(speciesGeometry.compartmentImageSize.height()) *
+      speciesGeometry.pixelWidth;
+  ui->lblImage->setPhysicalSize(physicalSize, lengthUnit);
+
   if (concentrationArray.empty()) {
     SPDLOG_DEBUG("empty initial concentrationArray - "
                  "setting concentration to zero everywhere");
@@ -51,6 +62,10 @@ DialogConcentrationImage::DialogConcentrationImage(
           &DialogConcentrationImage::reject);
   connect(ui->lblImage, &QLabelMouseTracker::mouseOver, this,
           &DialogConcentrationImage::lblImage_mouseOver);
+  connect(ui->chkGrid, &QCheckBox::stateChanged, this,
+          &DialogConcentrationImage::chkGrid_stateChanged);
+  connect(ui->chkScale, &QCheckBox::stateChanged, this,
+          &DialogConcentrationImage::chkScale_stateChanged);
   connect(ui->btnImportImage, &QPushButton::clicked, this,
           &DialogConcentrationImage::btnImportImage_clicked);
   connect(ui->btnExportImage, &QPushButton::clicked, this,
@@ -260,6 +275,13 @@ void DialogConcentrationImage::lblImage_mouseOver(QPoint point) {
           .arg(physical.y())
           .arg(concentration[*index])
           .arg(concentrationUnit));
+}
+
+void DialogConcentrationImage::chkGrid_stateChanged(int state) {
+  ui->lblImage->displayGrid(state == Qt::Checked);
+}
+void DialogConcentrationImage::chkScale_stateChanged(int state) {
+  ui->lblImage->displayScale(state == Qt::Checked);
 }
 
 void DialogConcentrationImage::btnImportImage_clicked() {

--- a/src/gui/dialogs/dialogconcentrationimage.hpp
+++ b/src/gui/dialogs/dialogconcentrationimage.hpp
@@ -53,6 +53,8 @@ private:
   void gaussianFilter(const QPoint &direction, double sigma);
   void smoothConcentration();
   void lblImage_mouseOver(QPoint point);
+  void chkGrid_stateChanged(int state);
+  void chkScale_stateChanged(int state);
   void btnImportImage_clicked();
   void btnExportImage_clicked();
   void cmbExampleImages_currentTextChanged(const QString &text);

--- a/src/gui/dialogs/dialogconcentrationimage.ui
+++ b/src/gui/dialogs/dialogconcentrationimage.ui
@@ -276,6 +276,26 @@
          </property>
         </widget>
        </item>
+       <item row="10" column="0">
+        <widget class="QCheckBox" name="chkGrid">
+         <property name="text">
+          <string>Show &amp;grid</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="chkScale">
+         <property name="text">
+          <string>Show &amp;scale</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -302,6 +322,8 @@
  <tabstops>
   <tabstop>txtMinConc</tabstop>
   <tabstop>txtMaxConc</tabstop>
+  <tabstop>chkGrid</tabstop>
+  <tabstop>chkScale</tabstop>
   <tabstop>btnImportImage</tabstop>
   <tabstop>btnExportImage</tabstop>
   <tabstop>cmbExampleImages</tabstop>

--- a/src/gui/dialogs/dialogconcentrationimage_t.cpp
+++ b/src/gui/dialogs/dialogconcentrationimage_t.cpp
@@ -1,9 +1,9 @@
-#include <QFile>
-#include <numeric>
 #include "catch_wrapper.hpp"
 #include "dialogconcentrationimage.hpp"
 #include "model.hpp"
 #include "qt_test_utils.hpp"
+#include <QFile>
+#include <numeric>
 
 SCENARIO(
     "DialogConcentrationImage",
@@ -21,7 +21,7 @@ SCENARIO(
     auto compArrayIndices = std::vector<std::size_t>{6, 3, 0, 7};
     auto outsideArrayIndices = std::vector<std::size_t>{1, 2, 4, 5, 8};
     sme::model::SpeciesGeometry specGeom{sz, compartmentPoints, origin, width,
-                                    doc.getUnits()};
+                                         doc.getUnits()};
     ModalWidgetTimer mwt;
 
     WHEN("empty concentration array: set concentration to 0") {
@@ -172,7 +172,7 @@ SCENARIO(
       DialogConcentrationImage dia({}, specGeom);
       // import image
       ModalWidgetTimer mwtImage;
-      mwt.addUserAction({"Tab", "Tab", "Space"}, true, &mwtImage);
+      mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Space"}, true, &mwtImage);
       mwtImage.addUserAction({"t", "m", "p", ".", "p", "n", "g"}, true);
       mwt.start();
       dia.exec();
@@ -191,7 +191,7 @@ SCENARIO(
       DialogConcentrationImage dia({}, specGeom);
       // import image
       ModalWidgetTimer mwtImage;
-      mwt.addUserAction({"Tab", "Tab", "Space"}, true, &mwtImage);
+      mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Space"}, true, &mwtImage);
       mwtImage.addUserAction({"t", "m", "p", ".", "p", "n", "g"});
       mwt.start();
       dia.exec();
@@ -215,7 +215,8 @@ SCENARIO(
       std::vector<double> values = {0, 1, 0.5, 0.25};
       // import image
       ModalWidgetTimer mwtImage;
-      mwt.addUserAction({"Tab", "Tab", "Space"}, false, &mwtImage);
+      mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Space"}, false,
+                        &mwtImage);
       mwtImage.addUserAction({"t", "m", "p", ".", "p", "n", "g"});
       THEN("get concentration array") {
         mwt.addUserAction();
@@ -265,9 +266,10 @@ SCENARIO(
     WHEN("built-in image loaded") {
       DialogConcentrationImage dia({}, specGeom);
       // load built-in two-blobs image
+      // uncheck grid & scale checkboxes on the way
       ModalWidgetTimer mwtImage;
-      mwt.addUserAction(
-          {"Tab", "Tab", "Tab", "Tab", "Space", "Down", "Down", "Enter"});
+      mwt.addUserAction({"Tab", "Tab", "Space", "Tab", "Space", "Tab", "Tab", "Tab", "Space",
+                         "Down", "Down", "Enter"});
       mwt.start();
       dia.exec();
       auto a = dia.getConcentrationArray();

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -23,13 +23,12 @@ class MainWindow : public QMainWindow {
 
 public:
   explicit MainWindow(const QString &filename = {}, QWidget *parent = nullptr);
-  ~MainWindow();
+  ~MainWindow() override;
 
 private:
   std::unique_ptr<Ui::MainWindow> ui;
   QLabel *statusBarPermanentMessage;
-  sme::model::Model sbmlDoc;
-  QString currentFilename;
+  sme::model::Model model;
 
   void setupTabs();
   void setupConnections();
@@ -73,6 +72,7 @@ private:
   // Advanced menu actions
   void actionSimulation_options_triggered();
 
+  void lblGeometry_mouseOver(QPoint point);
   void dragEnterEvent(QDragEnterEvent *event) override;
   void dropEvent(QDropEvent *event) override;
   void closeEvent(QCloseEvent *event) override;

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -239,9 +239,17 @@
     </property>
     <addaction name="actionSimulation_options"/>
    </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionGeometry_grid"/>
+    <addaction name="actionGeometry_scale"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuImport"/>
    <addaction name="menu_Tools"/>
+   <addaction name="menu_View"/>
    <addaction name="menu_Advanced"/>
    <addaction name="menu_Help"/>
   </widget>
@@ -456,6 +464,28 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionGeometry_grid">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Geometry &amp;grid</string>
+   </property>
+  </action>
+  <action name="actionGeometry_scale">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Geometry &amp;scale</string>
    </property>
   </action>
   <actiongroup name="actionGroupSimType">

--- a/src/gui/widgets/qlabelmousetracker.hpp
+++ b/src/gui/widgets/qlabelmousetracker.hpp
@@ -28,6 +28,9 @@ public:
   int getMaskIndex() const;
   void setAspectRatioMode(Qt::AspectRatioMode aspectRatioMode);
   void setTransformationMode(Qt::TransformationMode transformationMode);
+  void setPhysicalSize(const QSizeF& size, const QString& units);
+  void displayGrid(bool enable);
+  void displayScale(bool enable);
 
 signals:
   void mouseClicked(QRgb col, QPoint point);
@@ -45,14 +48,22 @@ protected:
 private:
   Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio;
   Qt::TransformationMode transformationMode = Qt::FastTransformation;
-  // (x,y) location of current pixel
   bool setCurrentPixel(const QMouseEvent *ev);
   void resizeImage(const QSize &size);
   QImage image;
   // Pixmap used to display scaled version of image
   QPixmap pixmap;
+  // size of actual image in pixmap (may be smaller than pixmap)
+  QSize pixmapImageSize;
   QImage maskImage;
   QPoint currentPixel;
+  const int tickLength{10};
+  // x & y offsets for ruler, if present
+  QPoint offset{0,0};
+  bool drawGrid{false};
+  bool drawScale{false};
+  QSizeF physicalSize{1.0, 1.0};
+  QString lengthUnits{};
   QRgb colour{};
   int maskIndex{};
 };


### PR DESCRIPTION
- enable via "View"->"Geometry Grid" and "View"->"Geometry Scale" menu items
- also add this option to Analytic and Image initial concentration dialogs
- display spatial location of mouse in GUI status bar
- resolves #497