### PR TITLE
allow DUNE simulation from sme python lib

### DIFF
--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -26,7 +26,7 @@ public:
   explicit Model(const std::string &filename);
   std::string getName() const;
   void setName(const std::string &name);
-  void importGeometryFromImage(const std::string& filename);
+  void importGeometryFromImage(const std::string &filename);
   void exportSbmlFile(const std::string &filename);
   std::vector<Compartment> compartments;
   std::vector<Membrane> membranes;
@@ -35,7 +35,8 @@ public:
   std::vector<SimulationResult> simulate(double simulationTime,
                                          double imageInterval,
                                          int timeoutSeconds = 86400,
-                                         bool throwOnTimeout = true);
+                                         bool throwOnTimeout = true,
+                                         simulate::SimulatorType simulatorType = simulate::SimulatorType::Pixel);
   std::string getStr() const;
 };
 

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -57,44 +57,51 @@ class TestModel(unittest.TestCase):
         self.assertRaises(sme.InvalidArgument, lambda: m2.compartments["Cell"])
 
     def test_simulate(self):
-        m = sme.open_example_model()
-        sim_results = m.simulate(0.002, 0.001)
-        self.assertEqual(len(sim_results), 3)
-        res = sim_results[1]
-        self.assertEqual(repr(res), "<sme.SimulationResult from timepoint 0.001>")
-        self.assertEqual(
-            str(res),
-            "<sme.SimulationResult>\n  - timepoint: 0.001\n  - number of species: 5\n",
-        )
-        self.assertEqual(res.time_point, 0.001)
-        img = res.concentration_image
-        self.assertEqual(len(img), 100)
-        self.assertEqual(len(img[0]), 100)
-        self.assertEqual(len(img[0][0]), 3)
-        self.assertEqual(len(res.species_concentration), 5)
-        conc = res.species_concentration["B_cell"]
-        self.assertEqual(len(conc), 100)
-        self.assertEqual(len(conc[0]), 100)
-        self.assertEqual(conc[0][0], 0.0)
-        dcdt = res.species_dcdt["B_cell"]
-        self.assertEqual(len(dcdt), 100)
-        self.assertEqual(len(dcdt[0]), 100)
-        self.assertEqual(dcdt[0][0], 0.0)
+        for sim in [sme.SimulatorType.DUNE, sme.SimulatorType.Pixel]:
+            m = sme.open_example_model()
+            sim_results = m.simulate(0.002, 0.001)
+            self.assertEqual(len(sim_results), 3)
 
-        # approximate dcdt
-        dcdt_approx = sim_results[1].species_concentration["A_cell"]
-        _sub_div(dcdt_approx, sim_results[0].species_concentration["A_cell"], 0.001)
-        dcdt = sim_results[1].species_dcdt["A_cell"]
-        rms_norm = _rms(dcdt)
-        _sub_div(dcdt, dcdt_approx)
-        rms_diff = _rms(dcdt)
-        self.assertLess(rms_diff / rms_norm, 0.01)
+            # repeat, previous sim results are cleared by default
+            sim_results = m.simulate(0.002, 0.001)
+            self.assertEqual(len(sim_results), 3)
 
-        # set timeout to 1 second: by default simulation throws on timeout
-        # multiple timesteps before timeout:
-        with self.assertRaises(sme.RuntimeError):
-            m.simulate(10000, 0.1, 1)
-        # single long timestep that times out
+            res = sim_results[1]
+            self.assertEqual(repr(res), "<sme.SimulationResult from timepoint 0.001>")
+            self.assertEqual(
+                str(res),
+                "<sme.SimulationResult>\n  - timepoint: 0.001\n  - number of species: 5\n",
+            )
+            self.assertEqual(res.time_point, 0.001)
+            img = res.concentration_image
+            self.assertEqual(len(img), 100)
+            self.assertEqual(len(img[0]), 100)
+            self.assertEqual(len(img[0][0]), 3)
+            self.assertEqual(len(res.species_concentration), 5)
+            conc = res.species_concentration["B_cell"]
+            self.assertEqual(len(conc), 100)
+            self.assertEqual(len(conc[0]), 100)
+            self.assertEqual(conc[0][0], 0.0)
+            dcdt = res.species_dcdt["B_cell"]
+            self.assertEqual(len(dcdt), 100)
+            self.assertEqual(len(dcdt[0]), 100)
+            self.assertEqual(dcdt[0][0], 0.0)
+
+            # approximate dcdt
+            dcdt_approx = sim_results[1].species_concentration["A_cell"]
+            _sub_div(dcdt_approx, sim_results[0].species_concentration["A_cell"], 0.001)
+            dcdt = sim_results[1].species_dcdt["A_cell"]
+            rms_norm = _rms(dcdt)
+            _sub_div(dcdt, dcdt_approx)
+            rms_diff = _rms(dcdt)
+            self.assertLess(rms_diff / rms_norm, 0.01)
+
+            # set timeout to 1 second: by default simulation throws on timeout
+            # multiple timesteps before timeout:
+            with self.assertRaises(sme.RuntimeError):
+                m.simulate(10000, 0.1, 1)
+
+        # single long timestep that times out (only check pixel)
         with self.assertRaises(sme.RuntimeError):
             m.simulate(10000, 10000, 1)
         # set timeout to 1 second: don't throw on timeout, return partial results


### PR DESCRIPTION
- add `simulator_type` arg to `Model.Simulate()`
- type is sme.SimulatorType enum: `sme.SimulatorType.DUNE` or `sme.SimulatorType.Pixel`
- default value Pixel to avoid breaking existing python code using `simulate()`
- resolves #276