### PR TITLE
add support for continuing existing simulations in python lib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.4b2
     hooks:
     - id: black
 
@@ -18,6 +18,6 @@ repos:
     - id: cmake-format
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.3.9
+    rev: 0.4.0
     hooks:
     - id: nbstripout

--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -20,23 +20,31 @@ class Model {
 private:
   std::unique_ptr<model::Model> s;
   std::unique_ptr<simulate::Simulation> sim;
-  void importSbmlFile(const std::string &filename);
+  void init();
 
 public:
-  explicit Model(const std::string &filename);
+  explicit Model(const std::string &filename = {});
+  void importFile(const std::string &filename);
+  void importSbmlString(const std::string &xml);
   std::string getName() const;
   void setName(const std::string &name);
   void importGeometryFromImage(const std::string &filename);
   void exportSbmlFile(const std::string &filename);
+  void exportSmeFile(const std::string &filename);
   std::vector<Compartment> compartments;
   std::vector<Membrane> membranes;
   std::vector<Parameter> parameters;
   PyImageRgb compartmentImage;
-  std::vector<SimulationResult> simulate(double simulationTime,
-                                         double imageInterval,
-                                         int timeoutSeconds = 86400,
-                                         bool throwOnTimeout = true,
-                                         simulate::SimulatorType simulatorType = simulate::SimulatorType::Pixel);
+  std::vector<SimulationResult> simulateString(
+      const std::string& lengths, const std::string& intervals, int timeoutSeconds,
+      bool throwOnTimeout,
+      simulate::SimulatorType simulatorType,
+      bool continueExistingSimulation);
+  std::vector<SimulationResult> simulateFloat(
+      double simulationTime, double imageInterval, int timeoutSeconds,
+      bool throwOnTimeout,
+      simulate::SimulatorType simulatorType,
+      bool continueExistingSimulation);
   std::string getStr() const;
 };
 

--- a/sme/src/sme_module.cpp
+++ b/sme/src/sme_module.cpp
@@ -4,6 +4,7 @@
 
 #include "sme_module.hpp"
 #include "version.hpp"
+#include <QFile>
 
 namespace sme {
 
@@ -16,6 +17,16 @@ void pybindModule(pybind11::module &m) {
 
             https://spatial-model-editor.readthedocs.io/
             )";
+  m.def("open_file", openFile, pybind11::arg("filename"),
+        R"(
+        opens a sme or SBML file containing a spatial model
+
+        Args:
+            filename (str): the sme or SBML file to open
+
+        Returns:
+            Model: the spatial model
+        )");
   m.def("open_sbml_file", openSbmlFile, pybind11::arg("filename"),
         R"(
         opens an SBML file containing a spatial model
@@ -36,9 +47,22 @@ void pybindModule(pybind11::module &m) {
   m.attr("__version__") = utils::SPATIAL_MODEL_EDITOR_VERSION;
 }
 
+Model openFile(const std::string &filename) { return Model(filename);}
+
 Model openSbmlFile(const std::string &filename) { return Model(filename); }
 
-Model openExampleModel() { return Model(":/models/very-simple-model.xml"); }
+Model openExampleModel() {
+  Model m;
+  std::string xml;
+  if (QFile f(":/models/very-simple-model.xml");
+      f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    xml = f.readAll().toStdString();
+  } else {
+    throw SmeInvalidArgument("Failed to open example model");
+  }
+  m.importSbmlString(xml);
+  return m;
+}
 
 } // namespace sme
 

--- a/sme/src/sme_module.hpp
+++ b/sme/src/sme_module.hpp
@@ -7,6 +7,7 @@ namespace sme {
 
 void pybindModule(pybind11::module &m);
 
+Model openFile(const std::string &filename);
 Model openSbmlFile(const std::string &filename);
 Model openExampleModel();
 

--- a/src/core/simulate/src/dunesim_t.cpp
+++ b/src/core/simulate/src/dunesim_t.cpp
@@ -36,9 +36,10 @@ SCENARIO("DuneSim: empty compartments",
     m.getCompartments().setColour("c1", col1);
     std::vector<std::string> comps{"c1", "c2", "c3"};
     simulate::DuneSim duneSim(m, comps);
-    for(std::size_t i=0; i<10; ++i){
-      duneSim.run(0.1, 100);
+    for(std::size_t i=0; i<2; ++i){
+      duneSim.run(0.05, 100e3);
     }
+    simulate::SimulationData data0{m.getSimulationData()};
     REQUIRE(duneSim.getConcentrations(0).size() == 5441);
     REQUIRE(duneSim.getConcentrations(1).size() == 8068);
     REQUIRE(duneSim.errorMessage().empty());
@@ -49,8 +50,8 @@ SCENARIO("DuneSim: empty compartments",
     m.getCompartments().setColour("c2", col2);
     comps.pop_back();
     simulate::DuneSim newDuneSim(m, comps);
-    for(std::size_t i=0; i<10; ++i){
-      newDuneSim.run(0.1, 100);
+    for(std::size_t i=0; i<2; ++i){
+      newDuneSim.run(0.05, 100e3);
     }
     REQUIRE(newDuneSim.getConcentrations(0).size() == 5441);
     REQUIRE(newDuneSim.getConcentrations(1).size() == 8068);


### PR DESCRIPTION
- add `continue_existing_simulation` arg to `Model.simulate()`
  - default value `False` to avoid changing existing default behaviour of `simulate()`
- `simulate()` now returns all simulation results (not just the ones it generated)
  - `species_dcdt` is now only provided for pixel simulations and for the last timepoint
  - this is not part of `SimulationData`, but is currently used for steady-state python fitting
- add `Model.export_sme_file()` and `sme.import_file()` to allow import/export of sme files
- add `simulate()` overload that takes strings instead of floats for lengths/intervals
  - allows comma-delimited lists of lengths&intervals as in GUI & CLI
- resolves #514
