### PR TITLE
add a zoom combobox to geometry image in MainWindow

### DIFF
--- a/src/gui/guiutils.cpp
+++ b/src/gui/guiutils.cpp
@@ -99,3 +99,13 @@ QImage getImageFromUser(QWidget *parent, const QString &title) {
   }
   return img;
 }
+
+QSize zoomedSize(const QSize &originalSize, int zoomFactor) {
+  QSize newSize{originalSize};
+  for (int i = 0; i < zoomFactor; ++i) {
+    // 20% increase in size for each step
+    newSize *= 6;
+    newSize /= 5;
+  }
+  return newSize;
+}

--- a/src/gui/guiutils.hpp
+++ b/src/gui/guiutils.hpp
@@ -19,3 +19,5 @@ void selectMatchingOrFirstChild(QTreeWidget *list, const QString &text = {});
 
 QImage getImageFromUser(QWidget *parent = nullptr,
                         const QString &title = "Import image");
+
+QSize zoomedSize(const QSize& originalSize, int zoomFactor);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -157,6 +157,9 @@ void MainWindow::setupConnections() {
 
   connect(ui->lblGeometry, &QLabelMouseTracker::mouseOver, this,
           &MainWindow::lblGeometry_mouseOver);
+
+  connect(ui->spinGeometryZoom, qOverload<int>(&QSpinBox::valueChanged), this,
+          &MainWindow::spinGeometryZoom_valueChanged);
 }
 
 void MainWindow::tabMain_currentChanged(int index) {
@@ -527,4 +530,15 @@ void MainWindow::lblGeometry_mouseOver(QPoint point) {
                                .arg(physical.x())
                                .arg(lengthUnit)
                                .arg(physical.y()));
+}
+
+void MainWindow::spinGeometryZoom_valueChanged(int value) {
+  if (value == 0) {
+    // rescale to fit entire scroll region
+    ui->scrollGeometry->setWidgetResizable(true);
+  } else {
+    ui->scrollGeometry->setWidgetResizable(false);
+    auto sz{zoomedSize(ui->scrollGeometry->size(), value)};
+    ui->scrollGeometryContents->resize(sz);
+  }
 }

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "model.hpp"
 #include <QMainWindow>
 #include <memory>
-#include "model.hpp"
 
 class QLabel;
 class TabFunctions;
@@ -16,7 +16,6 @@ class TabSpecies;
 namespace Ui {
 class MainWindow;
 }
-
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
@@ -77,6 +76,8 @@ private:
   void actionSimulation_options_triggered();
 
   void lblGeometry_mouseOver(QPoint point);
+  void spinGeometryZoom_valueChanged(int value);
+
   void dragEnterEvent(QDragEnterEvent *event) override;
   void dropEvent(QDropEvent *event) override;
   void closeEvent(QCloseEvent *event) override;

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -31,7 +31,20 @@
       </property>
       <widget class="QWidget" name="gridLayoutWidget">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0" colspan="2">
+        <item row="0" column="2">
+         <widget class="QSpinBox" name="spinGeometryZoom">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
          <widget class="QLabel" name="lblGeometryStatus">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -44,20 +57,55 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0" colspan="2">
-         <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
+        <item row="1" column="0" colspan="3">
+         <widget class="QScrollArea" name="scrollGeometry">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollGeometryContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>129</width>
+             <height>560</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
+&lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
+              </property>
+              <property name="text" stdset="0">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="lblGeometryZoomLabel">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="whatsThis">
-           <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
-&lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
+          <property name="text">
+           <string>Zoom:</string>
           </property>
-          <property name="text" stdset="0">
-           <string/>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>

--- a/src/gui/mainwindow_t.cpp
+++ b/src/gui/mainwindow_t.cpp
@@ -1,8 +1,10 @@
 #include "catch_wrapper.hpp"
 #include "mainwindow.hpp"
+#include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
 #include <QFile>
 #include <QMenu>
+#include <QSpinBox>
 #include <sbml/SBMLTypes.h>
 #include <sbml/extension/SBMLDocumentPlugin.h>
 #include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
@@ -224,6 +226,26 @@ TEST_CASE("Mainwindow", "[gui/mainwindow][gui][mainwindow]") {
       sendKeyEvents(menu_Advanced, {"S"});
       REQUIRE(mwt.getResult() == "Simulation Options");
     }
+  }
+  SECTION("built-in SBML model, change geometry image zoom") {
+    MainWindow w;
+    w.show();
+    waitFor(&w);
+    auto *spinGeometryZoom{w.findChild<QSpinBox *>("spinGeometryZoom")};
+    REQUIRE(spinGeometryZoom != nullptr);
+    auto *lblGeometry{w.findChild<QLabelMouseTracker *>("lblGeometry")};
+    REQUIRE(lblGeometry != nullptr);
+    REQUIRE(spinGeometryZoom->value() == 0);
+    int width0{lblGeometry->width()};
+    sendKeyEvents(spinGeometryZoom, {"Up", "Up", "Up", "Up"});
+    REQUIRE(spinGeometryZoom->value() == 4);
+    int width4{lblGeometry->width()};
+    REQUIRE(width4 > width0);
+    sendKeyEvents(spinGeometryZoom, {"Down", "Down"});
+    REQUIRE(spinGeometryZoom->value() == 2);
+    int width2{lblGeometry->width()};
+    REQUIRE(width2 < width4);
+    REQUIRE(width2 > width0);
   }
   SECTION("built-in SBML model, change units") {
     MainWindow w;

--- a/src/gui/tabs/tabgeometry.cpp
+++ b/src/gui/tabs/tabgeometry.cpp
@@ -38,8 +38,8 @@ TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
           &TabGeometry::spinBoundaryIndex_valueChanged);
   connect(ui->spinMaxBoundaryPoints, qOverload<int>(&QSpinBox::valueChanged),
           this, &TabGeometry::spinMaxBoundaryPoints_valueChanged);
-  connect(ui->spinBoundaryZoom, qOverload<int>(&QSpinBox::valueChanged),
-          this, &TabGeometry::spinBoundaryZoom_valueChanged);
+  connect(ui->spinBoundaryZoom, qOverload<int>(&QSpinBox::valueChanged), this,
+          &TabGeometry::spinBoundaryZoom_valueChanged);
   connect(ui->lblCompMesh, &QLabelMouseTracker::mouseClicked, this,
           &TabGeometry::lblCompMesh_mouseClicked);
   connect(ui->lblCompMesh, &QLabelMouseTracker::mouseWheelEvent, this,
@@ -48,8 +48,8 @@ TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
           });
   connect(ui->spinMaxTriangleArea, qOverload<int>(&QSpinBox::valueChanged),
           this, &TabGeometry::spinMaxTriangleArea_valueChanged);
-  connect(ui->spinMeshZoom, qOverload<int>(&QSpinBox::valueChanged),
-          this, &TabGeometry::spinMeshZoom_valueChanged);
+  connect(ui->spinMeshZoom, qOverload<int>(&QSpinBox::valueChanged), this,
+          &TabGeometry::spinMeshZoom_valueChanged);
   connect(ui->listCompartments, &QListWidget::itemSelectionChanged, this,
           &TabGeometry::listCompartments_itemSelectionChanged);
   connect(ui->listCompartments, &QListWidget::itemDoubleClicked, this,
@@ -241,7 +241,7 @@ void TabGeometry::tabCompartmentGeometry_currentChanged(int index) {
     return;
   }
   if (index == TabIndex::MESH) {
-    if(model.getGeometry().getMesh() == nullptr){
+    if (model.getGeometry().getMesh() == nullptr) {
       ui->spinMaxTriangleArea->setEnabled(false);
       ui->spinMeshZoom->setEnabled(false);
     }
@@ -284,18 +284,8 @@ void TabGeometry::spinMaxBoundaryPoints_valueChanged(int value) {
       model.getGeometry().getMesh()->getBoundariesImages(size, boundaryIndex));
 }
 
-static QSize zoomedSize(const QSize originalSize, int zoomFactor){
-  QSize newSize{originalSize};
-  for (int i = 0; i < zoomFactor; ++i) {
-    // 20% increase in size versus scroll region for each step
-    newSize *= 6;
-    newSize /= 5;
-  }
-  return newSize;
-}
-
 void TabGeometry::spinBoundaryZoom_valueChanged(int value) {
-  if(value == 0){
+  if (value == 0) {
     // rescale to fit entire scroll region
     ui->scrollBoundaryLines->setWidgetResizable(true);
   } else {
@@ -333,8 +323,8 @@ void TabGeometry::spinMaxTriangleArea_valueChanged(int value) {
       model.getGeometry().getMesh()->getMeshImages(size, compIndex));
 }
 
-void TabGeometry::spinMeshZoom_valueChanged(int value){
-  if(value == 0){
+void TabGeometry::spinMeshZoom_valueChanged(int value) {
+  if (value == 0) {
     // rescale to fit entire scroll region
     ui->scrollMesh->setWidgetResizable(true);
   } else {


### PR DESCRIPTION
- same zoom behaviour as for mesh/boundary images in TabGeometry
- resolves #516
