### PR TITLE
avoid intermediate sbml doc in simulations

### DIFF
--- a/src/core/common/inc/utils.hpp
+++ b/src/core/common/inc/utils.hpp
@@ -94,6 +94,19 @@ std::size_t min_element_index(const Container &c) {
 }
 
 /**
+ * @brief The index in the container of the matching element
+ */
+template <typename Container, typename Element>
+std::size_t element_index(const Container &c, const Element &e,
+                          std::size_t index_if_not_found = 0) {
+  auto iter{std::find(cbegin(c), cend(c), e)};
+  if (iter == cend(c)) {
+    return index_if_not_found;
+  }
+  return static_cast<std::size_t>(std::distance(cbegin(c), iter));
+}
+
+/**
  * @brief The type of an object as a string
  *
  * @note Copied from https://stackoverflow.com/a/56766138

--- a/src/core/common/src/utils_t.cpp
+++ b/src/core/common/src/utils_t.cpp
@@ -32,6 +32,17 @@ SCENARIO("Utils", "[core/common/utils][core/common][core][utils]") {
     REQUIRE(min == dbl_approx(-1.0));
     REQUIRE(max == dbl_approx(6.0));
   }
+  GIVEN("index of element in vector of doubles") {
+    std::vector<double> v{1, 2, 3, 4, 5, 6, -1};
+    REQUIRE(utils::element_index(v, 1) == 0);
+    REQUIRE(utils::element_index(v, 2) == 1);
+    REQUIRE(utils::element_index(v, 3) == 2);
+    REQUIRE(utils::element_index(v, -1) == 6);
+    // element not found: return 0 by default
+    REQUIRE(utils::element_index(v, -3) == 0);
+    // element not found: specify return value for this
+    REQUIRE(utils::element_index(v, -3, 999) == 999);
+  }
   GIVEN("QStringList <-> std::vector<std::string>") {
     std::vector<std::string> s{"ab", "qwef", "Qvsdss!"};
     QStringList q;

--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -102,6 +102,7 @@ public:
   void setConcentration(std::size_t index, double concentration);
   void setUniformConcentration(double concentration);
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);
+  void setConcentration(const std::vector<double> &concentration);
   QImage getConcentrationImage() const;
   std::vector<double> getConcentrationImageArray() const;
   void setCompartment(const Compartment *comp);

--- a/src/core/model/inc/model_events.hpp
+++ b/src/core/model/inc/model_events.hpp
@@ -42,6 +42,8 @@ public:
   void setExpression(const QString &id, const QString &expr);
   QString getExpression(const QString &id) const;
   QString add(const QString &name, const QString &variable);
+  bool isParameter(const QString &id) const;
+  [[nodiscard]] double getValue(const QString &id) const;
   void remove(const QString &id);
   void removeAnyUsingVariable(const QString &variable);
   void applyEvent(const QString &id);

--- a/src/core/model/inc/model_species.hpp
+++ b/src/core/model/inc/model_species.hpp
@@ -40,7 +40,6 @@ private:
   ModelReactions *modelReactions = nullptr;
   simulate::SimulationData *simulationData = nullptr;
   Settings *sbmlAnnotation = nullptr;
-  void setFieldConcAnalytic(geometry::Field &field, const std::string &expr);
   void removeInitialAssignment(const QString &id);
   std::vector<double>
   getSampledFieldConcentrationFromSBML(const QString &id) const;
@@ -69,6 +68,9 @@ public:
   double getInitialConcentration(const QString &id) const;
   void setAnalyticConcentration(const QString &id,
                                 const QString &analyticExpression);
+  void
+  setFieldConcAnalytic(geometry::Field &field, const std::string &expr,
+                       const std::map<std::string, double, std::less<>> &substitutions = {});
   QString getAnalyticConcentration(const QString &id) const;
   void
   setSampledFieldConcentration(const QString &id,
@@ -88,4 +90,4 @@ public:
   void setHasUnsavedChanges(bool unsavedChanges);
 };
 
-} // namespace sme
+} // namespace sme::model

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -263,6 +263,10 @@ void Field::importConcentration(
   isUniformConcentration = false;
 }
 
+void Field::setConcentration(const std::vector<double> &concentration){
+  conc = concentration;
+}
+
 void Field::setUniformConcentration(double concentration) {
   SPDLOG_INFO("species {}, compartment {}", id, comp->getId());
   SPDLOG_INFO("  - concentration = {}", concentration);

--- a/src/core/model/src/model_events_t.cpp
+++ b/src/core/model/src/model_events_t.cpp
@@ -42,6 +42,8 @@ SCENARIO("SBML events",
     REQUIRE(events.getVariable("n") == "param1");
     REQUIRE(events.getTime("n") == dbl_approx(0));
     REQUIRE(events.getExpression("n") == "0");
+    REQUIRE(events.isParameter("n") == true);
+    REQUIRE(events.getValue("n") == dbl_approx(0.0));
     // apply event to model
     REQUIRE(params.getExpression("param1") == "55");
     events.applyEvent("n");
@@ -57,6 +59,8 @@ SCENARIO("SBML events",
     // change expression
     events.setExpression("n", "1");
     REQUIRE(events.getExpression("n") == "1");
+    REQUIRE(events.isParameter("n") == true);
+    REQUIRE(events.getValue("n") == dbl_approx(1.0));
     // apply event to model
     REQUIRE(params.getExpression("param1") == "0");
     events.applyEvent("n");
@@ -64,9 +68,12 @@ SCENARIO("SBML events",
     // change expression to invalid math: no-op
     events.setExpression("n", "invalidmath???");
     REQUIRE(events.getExpression("n") == "1");
+    REQUIRE(events.isParameter("n") == true);
+    REQUIRE(events.getValue("n") == dbl_approx(1.0));
     // change variable
     events.setVariable("n", "param2");
     REQUIRE(events.getVariable("n") == "param2");
+    REQUIRE(events.isParameter("n") == true);
     // apply event to model
     REQUIRE(params.getExpression("param1") == "1");
     REQUIRE(params.getExpression("param2") == "-1.2");
@@ -88,8 +95,10 @@ SCENARIO("SBML events",
     REQUIRE(sme::model::mathASTtoString(
                 event->getEventAssignment(0)->getMath()) == "1");
     // change variable to species
+    REQUIRE(events.isParameter("n") == true);
     REQUIRE(species.getInitialConcentration("ATP") == dbl_approx(2.52512746499271));
     events.setVariable("n", "ATP");
+    REQUIRE(events.isParameter("n") == false);
     events.setExpression("n", "x + y");
     events.applyEvent("n");
     REQUIRE(species.getAnalyticConcentration("ATP") == "x + y");
@@ -153,8 +162,14 @@ SCENARIO("SBML events",
     REQUIRE(events.getVariable("e__") == "v2");
     REQUIRE(events.getVariable("e_") == "v3");
     REQUIRE(events.getExpression("e") == "1");
+    REQUIRE(events.isParameter("e") == true);
+    REQUIRE(events.getValue("e") == dbl_approx(1.0));
     REQUIRE(events.getExpression("e__") == "2");
+    REQUIRE(events.isParameter("e__") == true);
+    REQUIRE(events.getValue("e__") == dbl_approx(2.0));
     REQUIRE(events.getExpression("e_") == "3");
+    REQUIRE(events.isParameter("e_") == true);
+    REQUIRE(events.getValue("e_") == dbl_approx(3.0));
     // trigger was unsupported, so replaced with default t >= 0 trigger
     REQUIRE(events.getTime("e") == dbl_approx(0));
     REQUIRE(events.getTime("e__") == dbl_approx(0));
@@ -162,6 +177,8 @@ SCENARIO("SBML events",
     // make some changes
     events.setTime("e_", 9.2);
     events.setExpression("e_", "99");
+    REQUIRE(events.isParameter("e_") == true);
+    REQUIRE(events.getValue("e_") == dbl_approx(99.0));
     s.getParameters().add("param1");
     events.setVariable("e__", "param1");
     REQUIRE(s.getHasUnsavedChanges() == true);

--- a/src/core/model/src/sbml_math.hpp
+++ b/src/core/model/src/sbml_math.hpp
@@ -13,9 +13,7 @@ class Model;
 class ASTNode;
 } // namespace libsbml
 
-namespace sme {
-
-namespace model {
+namespace sme::model {
 
 // return supplied math expression as string with any Function calls and/or
 // Assignment rules inlined e.g. given mathExpression = "z*f(x,y)" where the
@@ -51,7 +49,5 @@ double evaluateMathString(
     const std::string &mathExpression,
     const std::map<const std::string, std::pair<double, bool>> &vars = {},
     const libsbml::Model *model = nullptr);
-
-} // namespace model
 
 } // namespace sme

--- a/src/core/resources/models/very-simple-model.xml
+++ b/src/core/resources/models/very-simple-model.xml
@@ -84,7 +84,7 @@
       <parameter id="y" name="y" value="0" units="unit_of_length" constant="false">
         <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
       </parameter>
-      <parameter id="param" name="param" value="1" units="substance" constant="true"/>
+      <parameter id="param" name="param" value="1" units="substance" constant="false"/>
     </listOfParameters>
     <listOfReactions>
       <reaction id="A_uptake" name="A uptake from outside" reversible="false" compartment="c1_c2_membrane" spatial:isLocal="true">

--- a/src/core/simulate/inc/duneconverter.hpp
+++ b/src/core/simulate/inc/duneconverter.hpp
@@ -6,6 +6,7 @@
 #include "simulate_options.hpp"
 #include <QString>
 #include <vector>
+#include <map>
 
 namespace sme {
 
@@ -21,9 +22,11 @@ namespace simulate {
 
 class DuneConverter {
 public:
-  explicit DuneConverter(const model::Model &model, bool forExternalUse = false,
-                         const QString &outputIniFile = {},
-                         int doublePrecision = 18);
+  explicit DuneConverter(
+      const model::Model &model,
+      const std::map<std::string, double, std::less<>> &substitutions = {},
+      bool forExternalUse = false, const QString &outputIniFile = {},
+      int doublePrecision = 18);
   QString getIniFile(std::size_t compartmentIndex = 0) const;
   const std::vector<QString> &getIniFiles() const;
   bool hasIndependentCompartments() const;

--- a/src/core/simulate/inc/pde.hpp
+++ b/src/core/simulate/inc/pde.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -37,7 +38,6 @@ struct PdeScaleFactors {
 
 class Pde {
 private:
-  std::vector<std::string> species;
   std::vector<std::string> rhs;
   std::vector<std::vector<std::string>> jacobian;
 
@@ -48,7 +48,8 @@ public:
                const std::vector<std::string> &relabelledSpeciesIDs = {},
                const PdeScaleFactors &pdeScaleFactors = {},
                const std::vector<std::string> &extraVariables = {},
-               const std::vector<std::string> &relabelledExtraVariables = {});
+               const std::vector<std::string> &relabelledExtraVariables = {},
+               const std::map<std::string, double, std::less<>> &substitutions = {});
   const std::vector<std::string> &getRHS() const;
   const std::vector<std::vector<std::string>> &getJacobian() const;
 };

--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -41,26 +41,27 @@ private:
   std::unique_ptr<BaseSim> simulator;
   std::vector<const geometry::Compartment *> compartments;
   std::vector<std::string> compartmentIds;
+  std::map<std::string, double, std::less<>> eventSubstitutions{};
   // compartment->species
   std::vector<std::vector<std::string>> compartmentSpeciesIds;
   std::vector<std::vector<std::string>> compartmentSpeciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesIndices;
   std::vector<std::vector<QRgb>> compartmentSpeciesColors;
+  model::Model &model;
   model::SimulationSettings *settings;
   SimulationData *data;
   QSize imageSize;
   std::atomic<bool> isRunning{false};
   std::atomic<bool> stopRequested{false};
   std::atomic<std::size_t> nCompletedTimesteps{0};
-  std::unique_ptr<sme::model::Model> simModel;
   std::queue<SimEvent> simEvents;
-  void initModel(const model::Model &model);
-  void initEvents(model::Model &model);
+  void initModel();
+  void initEvents();
   void applyNextEvent();
   void updateConcentrations(double t);
 
 public:
-  explicit Simulation(model::Model &sbmlDoc);
+  explicit Simulation(model::Model &model);
   ~Simulation();
 
   std::size_t doTimesteps(double time, std::size_t nSteps = 1,
@@ -84,7 +85,7 @@ public:
   std::vector<double> getConcArray(std::size_t timeIndex,
                                    std::size_t compartmentIndex,
                                    std::size_t speciesIndex) const;
-  void applyConcsToModel(model::Model &model, std::size_t timeIndex) const;
+  void applyConcsToModel(model::Model &m, std::size_t timeIndex) const;
   std::vector<double> getDcdt(std::size_t compartmentIndex,
                               std::size_t speciesIndex) const;
   double getLowerOrderConc(std::size_t compartmentIndex,

--- a/src/core/simulate/src/dunefunction_t.cpp
+++ b/src/core/simulate/src/dunefunction_t.cpp
@@ -71,14 +71,14 @@ SCENARIO("DUNE: function",
     auto stages =
         Dune::Copasi::BitFlags<Dune::Copasi::ModelSetup::Stages>::all_flags();
     stages.reset(Dune::Copasi::ModelSetup::Stages::Writer);
-    simulate::DuneConverter dc(m, false);
+    simulate::DuneConverter dc(m, {}, false);
     auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(mesh);
     auto config = getConfig(dc);
     Model model(grid, config.sub("model"), stages);
     model.set_initial(simulate::makeModelDuneFunctions<Grid::LeafGridView>(dc));
 
     // create model using TIFF files for initial conditions
-    simulate::DuneConverter dcTiff(m, true);
+    simulate::DuneConverter dcTiff(m, {}, true);
     auto configTiff = getConfig(dcTiff);
     Model modelTiff(grid, configTiff.sub("model"));
 

--- a/src/core/simulate/src/dunegrid_t.cpp
+++ b/src/core/simulate/src/dunegrid_t.cpp
@@ -37,7 +37,7 @@ SCENARIO("DUNE: grid",
         f.open(QIODevice::ReadOnly)) {
       m.importSBMLString(f.readAll().toStdString());
     }
-    simulate::DuneConverter dc(m, false);
+    simulate::DuneConverter dc(m, {}, false);
     const auto *mesh{m.getGeometry().getMesh()};
 
     // generate dune grid with sim::makeDuneGrid

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -183,7 +183,8 @@ void DuneSim::updatePixels() {
 }
 
 DuneSim::DuneSim(const model::Model &sbmlDoc,
-                 const std::vector<std::string> &compartmentIds)
+                 const std::vector<std::string> &compartmentIds,
+                 const std::map<std::string, double, std::less<>> &substitutions)
     : geometryImageSize{sbmlDoc.getGeometry().getImage().size()},
       pixelSize{sbmlDoc.getGeometry().getPixelWidth()},
       pixelOrigin{sbmlDoc.getGeometry().getPhysicalOrigin()} {
@@ -192,7 +193,7 @@ DuneSim::DuneSim(const model::Model &sbmlDoc,
     const auto &volumeUnit{sbmlDoc.getUnits().getVolume()};
     volOverL3 = model::getVolOverL3(lengthUnit, volumeUnit);
 
-    simulate::DuneConverter dc(sbmlDoc, false);
+    simulate::DuneConverter dc(sbmlDoc, substitutions, false);
     const auto &options{sbmlDoc.getSimulationSettings().options.dune};
     if (options.discretization != DuneDiscretizationType::FEM1) {
       // for now we only support 1st order FEM

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <map>
 #include <vector>
 
 namespace dune {
@@ -56,7 +57,8 @@ private:
   QSize geometryImageSize;
   double pixelSize;
   QPointF pixelOrigin;
-  void initDuneSimCompartments(const std::vector<const geometry::Compartment*>& comps);
+  void initDuneSimCompartments(
+      const std::vector<const geometry::Compartment *> &comps);
   void updatePixels();
   void updateSpeciesConcentrations();
   std::string currentErrorMessage;
@@ -64,9 +66,9 @@ private:
   double volOverL3;
 
 public:
-  explicit DuneSim(
-      const model::Model &sbmlDoc,
-      const std::vector<std::string> &compartmentIds);
+  explicit DuneSim(const model::Model &sbmlDoc,
+                   const std::vector<std::string> &compartmentIds,
+                   const std::map<std::string, double, std::less<>> &substitutions = {});
   ~DuneSim() override;
   std::size_t run(double time, double timeout_ms) override;
   [[nodiscard]] const std::vector<double> &

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -4,13 +4,14 @@
 
 #include "basesim.hpp"
 #include "simulate_options.hpp"
+#include <QImage>
 #include <atomic>
 #include <cstddef>
 #include <limits>
 #include <memory>
 #include <string>
+#include <map>
 #include <vector>
-#include <QImage>
 
 namespace sme {
 
@@ -55,7 +56,8 @@ public:
   explicit PixelSim(
       const model::Model &sbmlDoc,
       const std::vector<std::string> &compartmentIds,
-      const std::vector<std::vector<std::string>> &compartmentSpeciesIds);
+      const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
   ~PixelSim() override;
   std::size_t run(double time, double timeout_ms) override;
   const std::vector<double> &
@@ -66,7 +68,7 @@ public:
                                     std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;
   const std::string &errorMessage() const override;
-  const QImage& errorImage() const override;
+  const QImage &errorImage() const override;
   void requestStop() override;
 };
 

--- a/src/core/simulate/src/pixelsim_impl.hpp
+++ b/src/core/simulate/src/pixelsim_impl.hpp
@@ -8,12 +8,12 @@
 #include "pde.hpp"
 #include "simulate_options.hpp"
 #include "symbolic.hpp"
+#include <QImage>
+#include <QPoint>
 #include <cstddef>
 #include <limits>
 #include <string>
 #include <vector>
-#include <QImage>
-#include <QPoint>
 
 namespace sme {
 
@@ -39,7 +39,8 @@ public:
            const std::vector<std::string> &reactionID,
            double reactionScaleFactor = 1.0, bool doCSE = true,
            unsigned optLevel = 3, bool timeDependent = false,
-           bool spaceDependent = false);
+           bool spaceDependent = false,
+           const std::map<std::string, double, std::less<>> &substitutions = {});
   ReacEval(ReacEval &&) noexcept = default;
   ReacEval(const ReacEval &) = delete;
   ReacEval &operator=(ReacEval &&) noexcept = default;
@@ -69,11 +70,11 @@ private:
   double maxStableTimestep = std::numeric_limits<double>::max();
 
 public:
-  explicit SimCompartment(const model::Model &doc,
-                          const geometry::Compartment *compartment,
-                          std::vector<std::string> sIds, bool doCSE = true,
-                          unsigned optLevel = 3, bool timeDependent = false,
-                          bool spaceDependent = false);
+  explicit SimCompartment(
+      const model::Model &doc, const geometry::Compartment *compartment,
+      std::vector<std::string> sIds, bool doCSE = true, unsigned optLevel = 3,
+      bool timeDependent = false, bool spaceDependent = false,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
   SimCompartment(SimCompartment &&) noexcept = default;
   SimCompartment(const SimCompartment &) = delete;
   SimCompartment &operator=(SimCompartment &&) noexcept = default;
@@ -129,10 +130,11 @@ public:
   void undoRKStep_tbb();
 #endif
   PixelIntegratorError calculateRKError(double epsilon) const;
-  std::string plotRKError(QImage& image, double epsilon, double max) const;
+  std::string plotRKError(QImage &image, double epsilon, double max) const;
   const std::string &getCompartmentId() const;
   const std::vector<std::string> &getSpeciesIds() const;
   const std::vector<double> &getConcentrations() const;
+  void setConcentrations(const std::vector<double> &);
   double getLowerOrderConcentration(std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;
   const std::vector<QPoint> &getPixels() const;
@@ -152,7 +154,8 @@ public:
   SimMembrane(const model::Model &doc, const geometry::Membrane *membrane_ptr,
               SimCompartment *simCompA, SimCompartment *simCompB,
               bool doCSE = true, unsigned optLevel = 3,
-              bool timeDependent = false, bool spaceDependent = false);
+              bool timeDependent = false, bool spaceDependent = false,
+              const std::map<std::string, double, std::less<>> &substitutions = {});
   SimMembrane(SimMembrane &&) noexcept = default;
   SimMembrane(const SimMembrane &) = delete;
   SimMembrane &operator=(SimMembrane &&) noexcept = default;

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -17,12 +17,20 @@
 
 using namespace sme;
 
-static model::Model getVerySimpleModel() {
+static model::Model getModel(const QString &filename) {
   model::Model m;
-  QFile f(":/models/very-simple-model.xml");
+  QFile f(filename);
   f.open(QIODevice::ReadOnly);
   m.importSBMLString(f.readAll().toStdString());
   return m;
+}
+
+static model::Model getVerySimpleModel() {
+  return getModel(":/models/very-simple-model.xml");
+}
+
+static model::Model getBrusselatorModel() {
+  return getModel(":/models/brusselator-model.xml");
 }
 
 SCENARIO("Simulate: very_simple_model, single pixel geometry",
@@ -238,12 +246,7 @@ SCENARIO("Simulate: very_simple_model, single pixel geometry",
 
 SCENARIO("Simulate: very_simple_model, 2d geometry",
          "[core/simulate/simulate][core/simulate][core][simulate][pixel]") {
-  // import model
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
-
+  auto s{getVerySimpleModel()};
   // check fields have correct compartments & sizes
   const auto *fa1 = s.getSpecies().getField("A_c1");
   REQUIRE(fa1->getCompartment()->getId() == "c1");
@@ -318,10 +321,7 @@ SCENARIO("Simulate: very_simple_model, 2d geometry",
 
 SCENARIO("Simulate: very_simple_model, failing Pixel sim",
          "[core/simulate/simulate][core/simulate][core][simulate][pixel]") {
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
+  auto s{getVerySimpleModel()};
   // set A uptake rate very high
   s.getReactions().setParameterValue("A_uptake", "k1", 1e40);
   // Pixel sim stops simulation as timestep required becomes too small
@@ -338,10 +338,7 @@ SCENARIO("Simulate: very_simple_model, empty compartment, DUNE sim",
          "[core/simulate/simulate][core/simulate][core][simulate][dune]") {
   // check that DUNE simulates a model with an empty compartment without
   // crashing
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
+  auto s{getVerySimpleModel()};
   s.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
   WHEN("Outer species removed") {
     s.getSpecies().remove("A_c1");
@@ -391,11 +388,7 @@ SCENARIO("Simulate: very_simple_model, change pixel size, Pixel sim",
   double epsilon{1e-8};
   double margin{1e-13};
   // import model
-  model::Model s1;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  std::string str{f.readAll().toStdString()};
-  s1.importSBMLString(str);
+  auto s1{getVerySimpleModel()};
   // 1st order RK, fixed timestep simulation
   // pixel width: 1
   // length unit: m
@@ -418,8 +411,7 @@ SCENARIO("Simulate: very_simple_model, change pixel size, Pixel sim",
 
   // 3x pixel width
   {
-    model::Model s;
-    s.importSBMLString(str);
+    auto s{getVerySimpleModel()};
     s.getSimulationSettings().options = options;
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
     s.getGeometry().setPixelWidth(3.0);
@@ -490,8 +482,7 @@ SCENARIO("Simulate: very_simple_model, change pixel size, Pixel sim",
   }
   // 0.27* pixel width
   {
-    model::Model s;
-    s.importSBMLString(str);
+    auto s{getVerySimpleModel()};
     s.getSimulationSettings().options = options;
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
     s.getGeometry().setPixelWidth(0.27);
@@ -563,11 +554,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
       epsilon = 1e-6;
     }
     // import model
-    model::Model s1;
-    QFile f(":/models/very-simple-model.xml");
-    f.open(QIODevice::ReadOnly);
-    std::string str{f.readAll().toStdString()};
-    s1.importSBMLString(str);
+    auto s1{getVerySimpleModel()};
     // 1st order RK, fixed timestep simulation
     // pixel width: 1
     // length unit: m
@@ -594,8 +581,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
 
     // Length unit -> 10x smaller
     {
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       s.getUnits().setLengthIndex(1);
@@ -626,8 +612,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
     // Length unit -> 100x smaller
     {
       // as above
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       rescaleMembraneReacRates(s, 1e-6);
@@ -653,8 +638,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
       // concentration values unchanged, but [volume] 10x smaller
       // i.e. concentrations are 10x higher in [amount]/[length]^3 units
       // so membrane rates need to be 10x higher to compensate
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       rescaleMembraneReacRates(s, 10);
@@ -678,8 +662,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
     // Volume unit -> 1000x smaller
     {
       // as above
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       rescaleMembraneReacRates(s, 1000);
@@ -702,8 +685,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
     }
     // Volume unit -> 1000x larger (L -> m^3)
     {
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       rescaleMembraneReacRates(s, 1e-3);
@@ -726,8 +708,7 @@ SCENARIO("Simulate: very_simple_model, membrane reaction units consistency",
     }
     // Volume unit equivalent (L -> dm^3)
     {
-      model::Model s;
-      s.importSBMLString(str);
+      auto s{getVerySimpleModel()};
       s.getSimulationSettings().options = options;
       s.getSimulationSettings().simulatorType = simulatorType;
       s.getUnits().setVolumeIndex(5);
@@ -829,6 +810,7 @@ SCENARIO(
       evolvedAvgRelativeError = 0.10;
     }
     s.getSimulationSettings().simulatorType = simType;
+    s.getSimulationData().clear();
 
     // integrate & compare
     simulate::Simulation sim(s);
@@ -1035,11 +1017,7 @@ SCENARIO("DUNE: simulation",
     REQUIRE(imgConc.size() == QSize(100, 100));
   }
   GIVEN("very-simple-model") {
-    model::Model s;
-    if (QFile f(":/models/very-simple-model.xml");
-        f.open(QIODevice::ReadOnly)) {
-      s.importSBMLString(f.readAll().toStdString());
-    }
+    auto s{getVerySimpleModel()};
     auto &options{s.getSimulationSettings().options};
     options.dune.dt = 0.01;
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
@@ -1052,11 +1030,7 @@ SCENARIO("DUNE: simulation",
 SCENARIO("getConcImage",
          "[core/simulate/simulate][core/simulate][core][simulate]") {
   GIVEN("very-simple-model") {
-    model::Model s;
-    if (QFile f(":/models/very-simple-model.xml");
-        f.open(QIODevice::ReadOnly)) {
-      s.importSBMLString(f.readAll().toStdString());
-    }
+    auto s{getVerySimpleModel()};
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
     simulate::Simulation sim(s);
     sim.doTimesteps(0.5);
@@ -1125,7 +1099,8 @@ SCENARIO("PyConc",
     if (QFile f(":/models/ABtoC.xml"); f.open(QIODevice::ReadOnly)) {
       s.importSBMLString(f.readAll().toStdString());
     }
-    for(auto simType : {simulate::SimulatorType::Pixel, simulate::SimulatorType::DUNE}) {
+    for (auto simType :
+         {simulate::SimulatorType::Pixel, simulate::SimulatorType::DUNE}) {
       s.getSimulationSettings().simulatorType = simType;
       s.getSimulationData().clear();
       simulate::Simulation sim(s);
@@ -1146,7 +1121,7 @@ SCENARIO("PyConc",
       REQUIRE(cA1.size() == 100);
       REQUIRE(cA1[0].size() == 100);
       REQUIRE(cA1[0][0] == dbl_approx(0.0));
-      if(simType == simulate::SimulatorType::Pixel) {
+      if (simType == simulate::SimulatorType::Pixel) {
         REQUIRE(pyDcdts1.size() == 3);
         const auto &dA1 = pyDcdts1["A"];
         REQUIRE(dA1.size() == 100);
@@ -1204,10 +1179,7 @@ static double rel_diff(const std::vector<double> &a,
 
 SCENARIO("applyConcsToModel initial concentrations",
          "[core/simulate/simulate][core/simulate][core][simulate]") {
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
+  auto s{getVerySimpleModel()};
   // set various types of initial concentrations
   s.getSpecies().setInitialConcentration("B_c1", 0.66);
   s.getSpecies().setInitialConcentration("A_c3", 0.123);
@@ -1225,10 +1197,7 @@ SCENARIO("applyConcsToModel initial concentrations",
   sim.doTimesteps(0.01);
 
   // apply simulation initial concs to a copy of the original model
-  model::Model s2;
-  QFile f2(":/models/very-simple-model.xml");
-  f2.open(QIODevice::ReadOnly);
-  s2.importSBMLString(f2.readAll().toStdString());
+  auto s2{getVerySimpleModel()};
   sim.applyConcsToModel(s2, 0);
   // check concentrations match
   for (const auto &cId : s.getCompartments().getIds()) {
@@ -1243,10 +1212,7 @@ SCENARIO("applyConcsToModel initial concentrations",
 
 SCENARIO("applyConcsToModel after simulation",
          "[core/simulate/simulate][core/simulate][core][simulate]") {
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
+  auto s{getVerySimpleModel()};
   s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
   // added this to try to work around
   // https://github.com/spatial-model-editor/spatial-model-editor/issues/465
@@ -1256,7 +1222,7 @@ SCENARIO("applyConcsToModel after simulation",
   //  s.getSpecies().setAnalyticConcentration("A_c3", "cos(x/7.2)+1");
   //  s.getSpecies().setAnalyticConcentration("B_c3", "cos(x/5.2)+1");
   s.exportSBMLFile("tmp.xml");
-  auto& options{s.getSimulationSettings().options};
+  auto &options{s.getSimulationSettings().options};
   options.dune.dt = 0.01;
   // apply initial concs from sim to model s, check they agree with copy of
   // model s2 (note any analytic initial concs in s are replaced with sampled
@@ -1327,7 +1293,7 @@ SCENARIO("Reactions depend on x, y, t",
   s.importSBMLString(f.readAll().toStdString());
   constexpr double eps{1e-20};
   constexpr double dt{1e-3};
-  auto& options{s.getSimulationSettings().options};
+  auto &options{s.getSimulationSettings().options};
   s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
   options.dune.dt = dt;
   options.pixel.integrator = simulate::PixelIntegratorType::RK101;
@@ -1523,17 +1489,14 @@ SCENARIO(
 
 SCENARIO("SimulationData",
          "[core/simulate/simulate][core/simulate][core][simulate]") {
-  model::Model s;
-  QFile f(":/models/very-simple-model.xml");
-  f.open(QIODevice::ReadOnly);
-  s.importSBMLString(f.readAll().toStdString());
+  auto s{getVerySimpleModel()};
   s.getSpecies().setAnalyticConcentration("B_c1", "cos(x/14.2)+1");
   s.getSpecies().setAnalyticConcentration("A_c2", "cos(x/12.2)+1");
   s.getSpecies().setAnalyticConcentration("B_c2", "cos(x/15.1)+1");
   s.getSpecies().setAnalyticConcentration("A_c3", "cos(x/7.2)+1");
   s.getSpecies().setAnalyticConcentration("B_c3", "cos(x/5.2)+1");
   WHEN("Continue previous simulation from data") {
-    auto& options{s.getSimulationSettings().options};
+    auto &options{s.getSimulationSettings().options};
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
     options.pixel.maxErr.rel = 1e-2;
     simulate::Simulation sim(s);
@@ -1610,7 +1573,7 @@ SCENARIO("SimulationData",
     REQUIRE(rel_diff(dataB, data, 5, 5) < allowedDifference);
   }
   WHEN("Repeat with smaller integration errors: difference reduced") {
-    auto& options{s.getSimulationSettings().options};
+    auto &options{s.getSimulationSettings().options};
     s.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
     options.pixel.maxErr.rel = 1e-5;
     simulate::Simulation sim(s);
@@ -1658,64 +1621,157 @@ SCENARIO("doMultipleTimesteps vs doTimesteps",
   }
 }
 
-SCENARIO("Events",
+SCENARIO("Events: setting species concentrations",
          "[core/simulate/simulate][core/simulate][core][simulate][events]") {
   auto m1{getVerySimpleModel()};
-  // disable all reactions
-  for (const auto &id : {"A_uptake", "A_transport", "A_B_conversion",
-                         "B_transport", "B_excretion"}) {
-    m1.getReactions().remove(id);
+  for (auto simType :
+       {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
+    CAPTURE(simType);
+    // disable all reactions
+    for (const auto &id : {"A_uptake", "A_transport", "A_B_conversion",
+                           "B_transport", "B_excretion"}) {
+      m1.getReactions().remove(id);
+    }
+    // add a bunch of events that set species concentrations so we can easily
+    // check they were done correctly
+    auto &events{m1.getEvents()};
+    events.add("eB_c1a", "B_c1");
+    // param = 1 in model
+    events.setExpression("eB_c1a", "9*param");
+    events.setTime("eB_c1a", 0.07);
+    events.add("eB_c1b", "B_c1");
+    events.setExpression("eB_c1b", "2");
+    events.setTime("eB_c1b", 0.12);
+    // change value of p
+    events.add("change_p", "param");
+    events.setExpression("change_p", "27");
+    events.setTime("change_p", 0.11);
+    events.add("eB_c2", "B_c2");
+    events.setExpression("eB_c2", "param");
+    events.setTime("eB_c2", 0.12);
+    events.add("eA_c3a", "A_c3");
+    events.setExpression("eA_c3a", "666");
+    events.setTime("eA_c3a", 0.199999);
+    events.add("eA_c3b", "A_c3");
+    events.setExpression("eA_c3b", "123");
+    // will be applied *during* 0.1->0.2 timestep: visible in 0.2 timestep
+    events.setTime("eA_c3b", 0.1999999);
+    events.add("eA_c2", "A_c2");
+    events.setExpression("eA_c2", "6");
+    // applied *at start of* 0.1-0.2 timestep: visible in 0.2 timestep
+    events.setTime("eA_c2", 0.1);
+    m1.getSimulationSettings().simulatorType = simType;
+    simulate::Simulation sim(m1);
+    sim.doTimesteps(0.1, 3);
+    const auto &data{m1.getSimulationData()};
+    // t=0.1
+    REQUIRE(data.timePoints[1] == dbl_approx(0.1));
+    // B_c1=9
+    REQUIRE(data.concentration[1][0][3] == dbl_approx(9.0));
+    REQUIRE(data.concentration[1][0][16] == dbl_approx(9.0));
+    REQUIRE(data.concentration[1][0][38] == dbl_approx(9.0));
+    // t=0.2
+    REQUIRE(data.timePoints[2] == dbl_approx(0.2));
+    // B_c1=2
+    REQUIRE(data.concentration[2][0][3] == dbl_approx(2.0));
+    REQUIRE(data.concentration[2][0][16] == dbl_approx(2.0));
+    REQUIRE(data.concentration[2][0][38] == dbl_approx(2.0));
+    // B_c2=27 (odd indices)
+    REQUIRE(data.concentration[2][1][183] == dbl_approx(27));
+    REQUIRE(data.concentration[2][1][197] == dbl_approx(27));
+    REQUIRE(data.concentration[2][1][203] == dbl_approx(27));
+    // A_c2=6 (even indices)
+    REQUIRE(data.concentration[2][1][4] == dbl_approx(6.0));
+    REQUIRE(data.concentration[2][1][16] == dbl_approx(6.0));
+    REQUIRE(data.concentration[2][1][40] == dbl_approx(6.0));
+    // A_c3=123 (even indices)
+    REQUIRE(data.concentration[2][2][4] == dbl_approx(123.0));
+    REQUIRE(data.concentration[2][2][16] == dbl_approx(123.0));
+    REQUIRE(data.concentration[2][2][40] == dbl_approx(123.0));
   }
-  // add a bunch of events that set species concentrations so we can easily
-  // check they were done correctly
-  auto &events{m1.getEvents()};
-  events.add("eB_c1a", "B_c1");
-  events.setExpression("eB_c1a", "9");
-  events.setTime("eB_c1a", 0.07);
-  events.add("eB_c1b", "B_c1");
-  events.setExpression("eB_c1b", "2");
-  events.setTime("eB_c1b", 0.12);
-  events.add("eB_c2", "B_c2");
-  events.setExpression("eB_c2", "27");
-  events.setTime("eB_c2", 0.12);
-  events.add("eA_c3a", "A_c3");
-  events.setExpression("eA_c3a", "666");
-  events.setTime("eA_c3a", 0.199999);
-  events.add("eA_c3b", "A_c3");
-  events.setExpression("eA_c3b", "123");
-  // will be applied *during* 0.1->0.2 timestep: visible in 0.2 timestep
-  events.setTime("eA_c3b", 0.1999999);
-  events.add("eA_c2", "A_c2");
-  events.setExpression("eA_c2", "6");
-  // applied *at start of* 0.1-0.2 timestep: visible in 0.2 timestep
-  events.setTime("eA_c2", 0.1);
-  simulate::Simulation sim(m1);
-  sim.doTimesteps(0.1, 3);
-  const auto &data{m1.getSimulationData()};
-  // t=0.1
-  REQUIRE(data.timePoints[1] == dbl_approx(0.1));
-  // B_c1=9
-  REQUIRE(data.concentration[1][0][3] == dbl_approx(9.0));
-  REQUIRE(data.concentration[1][0][16] == dbl_approx(9.0));
-  REQUIRE(data.concentration[1][0][38] == dbl_approx(9.0));
-  // t=0.2
-  REQUIRE(data.timePoints[2] == dbl_approx(0.2));
-  // B_c1=2
-  REQUIRE(data.concentration[2][0][3] == dbl_approx(2.0));
-  REQUIRE(data.concentration[2][0][16] == dbl_approx(2.0));
-  REQUIRE(data.concentration[2][0][38] == dbl_approx(2.0));
-  // B_c2=27 (odd indices)
-  REQUIRE(data.concentration[2][1][183] == dbl_approx(27));
-  REQUIRE(data.concentration[2][1][197] == dbl_approx(27));
-  REQUIRE(data.concentration[2][1][203] == dbl_approx(27));
-  // A_c2=6 (even indices)
-  REQUIRE(data.concentration[2][1][4] == dbl_approx(6.0));
-  REQUIRE(data.concentration[2][1][16] == dbl_approx(6.0));
-  REQUIRE(data.concentration[2][1][40] == dbl_approx(6.0));
-  // A_c3=123 (even indices)
-  REQUIRE(data.concentration[2][2][4] == dbl_approx(123.0));
-  REQUIRE(data.concentration[2][2][16] == dbl_approx(123.0));
-  REQUIRE(data.concentration[2][2][40] == dbl_approx(123.0));
+}
+
+SCENARIO("Events: continuing existing simulation",
+         "[core/simulate/simulate][core/simulate][core][simulate][events]") {
+  for (auto simType :
+       {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
+    CAPTURE(simType);
+    double allowedRelDiff{1e-5};
+    if (simType == simulate::SimulatorType::DUNE) {
+      allowedRelDiff = 0.01;
+    }
+    auto m1{getBrusselatorModel()};
+    m1.getSimulationSettings().simulatorType = simType;
+    simulate::Simulation s1(m1);
+    s1.doTimesteps(20, 1);
+    // t=20: no events so far
+    m1.exportSMEFile("t20.sme");
+    s1.doTimesteps(20, 1);
+    // t=20: k2 increased
+    m1.exportSMEFile("t40.sme");
+    s1.doTimesteps(20, 1);
+    // t=60: k2 decreased
+    m1.exportSMEFile("t60.sme");
+    s1.doTimesteps(20, 1);
+    // s1 has sim data at t = 0, 20, 40, 60, 80
+    const auto &d1{s1.getSimulationData()};
+    REQUIRE(d1.size() == 5);
+    REQUIRE(d1.timePoints.back() == dbl_approx(80.0));
+
+    // load at t=20, simulate
+    model::Model m20;
+    m20.importFile("t20.sme");
+    const auto &d20{m20.getSimulationData()};
+    REQUIRE(d20.size() == 2);
+    REQUIRE(d20.timePoints.back() == dbl_approx(20.0));
+    simulate::Simulation s20(m20);
+    s20.doTimesteps(20, 3);
+    REQUIRE(d20.timePoints.back() == dbl_approx(80.0));
+    REQUIRE(d20.size() == 5);
+    // first two timepoints agree exactly
+    REQUIRE(rel_diff(d1, d20, 0, 0) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d20, 1, 1) == dbl_approx(0.0));
+    // after that they differ by O(dt^2)
+    REQUIRE(rel_diff(d1, d20, 2, 2) < allowedRelDiff);
+    REQUIRE(rel_diff(d1, d20, 3, 3) < allowedRelDiff);
+    REQUIRE(rel_diff(d1, d20, 4, 4) < allowedRelDiff);
+
+    // load at t=40, simulate
+    model::Model m40;
+    m40.importFile("t40.sme");
+    const auto &d40{m40.getSimulationData()};
+    REQUIRE(d40.size() == 3);
+    REQUIRE(d40.timePoints.back() == dbl_approx(40.0));
+    simulate::Simulation s40(m40);
+    s40.doTimesteps(20, 2);
+    REQUIRE(d40.size() == 5);
+    REQUIRE(d40.timePoints.back() == dbl_approx(80.0));
+    // first three timepoints agree exactly
+    REQUIRE(rel_diff(d1, d40, 0, 0) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d40, 1, 1) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d40, 2, 2) == dbl_approx(0.0));
+    // after that they differ by O(dt^2)
+    REQUIRE(rel_diff(d1, d40, 3, 3) < allowedRelDiff);
+    REQUIRE(rel_diff(d1, d40, 4, 4) < allowedRelDiff);
+
+    // load at t=60, simulate
+    model::Model m60;
+    m60.importFile("t60.sme");
+    const auto &d60{m60.getSimulationData()};
+    REQUIRE(d60.size() == 4);
+    REQUIRE(d60.timePoints.back() == dbl_approx(60.0));
+    simulate::Simulation s60(m60);
+    s60.doTimesteps(20, 1);
+    REQUIRE(d60.size() == 5);
+    REQUIRE(d60.timePoints.back() == dbl_approx(80.0));
+    // first four timepoints agree exactly
+    REQUIRE(rel_diff(d1, d60, 0, 0) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d60, 1, 1) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d60, 2, 2) == dbl_approx(0.0));
+    REQUIRE(rel_diff(d1, d60, 3, 3) == dbl_approx(0.0));
+    // after that they differ by O(dt^2)
+    REQUIRE(rel_diff(d1, d60, 4, 4) < allowedRelDiff);
+  }
 }
 
 SCENARIO("simulate w/options & save, load, re-simulate",

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -374,7 +374,7 @@ void MainWindow::actionExport_Dune_ini_file_triggered() {
   if (iniFilename.right(4) != ".ini") {
     iniFilename.append(".ini");
   }
-  sme::simulate::DuneConverter dc(model, true, iniFilename);
+  sme::simulate::DuneConverter dc(model, {}, true, iniFilename);
 }
 
 void MainWindow::actionGeometry_from_model_triggered() {

--- a/src/gui/tabs/tabevents.cpp
+++ b/src/gui/tabs/tabevents.cpp
@@ -37,7 +37,7 @@ void TabEvents::loadModelData(const QString &selection) {
   ui->lblSpeciesExpression->clear();
   ui->stkValue->setCurrentIndex(0);
   ui->txtExpression->clearVariables();
-  ui->txtExpression->resetToDefaultFunctions();
+  ui->txtExpression->clearFunctions();
   ui->cmbEventVariable->clear();
   variableIds.clear();
   for (const auto &cId : model.getCompartments().getIds()) {
@@ -52,12 +52,6 @@ void TabEvents::loadModelData(const QString &selection) {
   for (const auto &id : model.getParameters().getIds()) {
     variableIds.push_back(id);
     ui->cmbEventVariable->addItem(model.getParameters().getName(id));
-  }
-  for (const auto &[id, name] : model.getParameters().getSymbols()) {
-    ui->txtExpression->addVariable(id, name);
-  }
-  for (const auto &function : model.getFunctions().getSymbolicFunctions()) {
-    ui->txtExpression->addFunction(function);
   }
   for (const auto &id : model.getEvents().getIds()) {
     auto name = model.getEvents().getName(id);

--- a/src/gui/tabs/tabevents.hpp
+++ b/src/gui/tabs/tabevents.hpp
@@ -9,10 +9,8 @@ namespace Ui {
 class TabEvents;
 }
 
-namespace sme {
-namespace model {
+namespace sme::model {
 class Model;
-}
 } // namespace sme
 
 class TabEvents : public QWidget {
@@ -20,7 +18,7 @@ class TabEvents : public QWidget {
 
 public:
   explicit TabEvents(sme::model::Model &m, QWidget *parent = nullptr);
-  ~TabEvents();
+  ~TabEvents() override;
   void loadModelData(const QString &selection = {});
 
 private:


### PR DESCRIPTION
- Simulate
  - events no longer applied to model, instead:
  - for parameter events
    - map of substitutions is updated
  - for concentration events
    - applied to simulation data & then imported into simulation
  - on load of existing simulation, apply all t<t0 events to substitutions map
- Pde
  - add optional substitutions parameter
  - map from id of parameter to double value
  - overwrites values of parameter in model
- in PixelSim and DuneConverter
  - if model has simulation data, use last concentration values as initial concentrations
  - add optional substitutions parameter
    - allows events to change value of parameters
- resolves #504