### PR TITLE
fix pixel sim stop & simulate bug

### DIFF
--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -2,9 +2,9 @@
 
 #pragma once
 
+#include "model_settings.hpp"
 #include "simulate_data.hpp"
 #include "simulate_options.hpp"
-#include "model_settings.hpp"
 #include <QImage>
 #include <QRgb>
 #include <QSize>
@@ -31,7 +31,7 @@ namespace simulate {
 
 class BaseSim;
 
-struct SimEvent{
+struct SimEvent {
   double time;
   std::vector<std::string> ids;
 };

--- a/src/core/simulate/src/basesim.hpp
+++ b/src/core/simulate/src/basesim.hpp
@@ -2,13 +2,11 @@
 
 #pragma once
 
+#include <QImage>
 #include <string>
 #include <vector>
-#include <QImage>
 
-namespace sme {
-
-namespace simulate {
+namespace sme::simulate {
 
 class BaseSim {
 public:
@@ -19,9 +17,7 @@ public:
   virtual std::size_t getConcentrationPadding() const = 0;
   virtual const std::string &errorMessage() const = 0;
   virtual const QImage &errorImage() const = 0;
-  virtual void requestStop() = 0;
+  virtual void setStopRequested(bool stop) = 0;
 };
 
-} // namespace simulate
-
-} // namespace sme
+} // namespace sme::simulate

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -182,9 +182,9 @@ void DuneSim::updatePixels() {
   }
 }
 
-DuneSim::DuneSim(const model::Model &sbmlDoc,
-                 const std::vector<std::string> &compartmentIds,
-                 const std::map<std::string, double, std::less<>> &substitutions)
+DuneSim::DuneSim(
+    const model::Model &sbmlDoc, const std::vector<std::string> &compartmentIds,
+    const std::map<std::string, double, std::less<>> &substitutions)
     : geometryImageSize{sbmlDoc.getGeometry().getImage().size()},
       pixelSize{sbmlDoc.getGeometry().getPixelWidth()},
       pixelOrigin{sbmlDoc.getGeometry().getPhysicalOrigin()} {
@@ -265,7 +265,7 @@ const std::string &DuneSim::errorMessage() const { return currentErrorMessage; }
 
 const QImage &DuneSim::errorImage() const { return currentErrorImage; }
 
-void DuneSim::requestStop() {
+void DuneSim::setStopRequested([[maybe_unused]] bool stop) {
   SPDLOG_DEBUG("Not implemented - ignoring request");
 }
 

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -10,10 +10,10 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
-#include <map>
 #include <vector>
 
 namespace dune {
@@ -61,14 +61,15 @@ private:
       const std::vector<const geometry::Compartment *> &comps);
   void updatePixels();
   void updateSpeciesConcentrations();
-  std::string currentErrorMessage;
-  QImage currentErrorImage;
+  std::string currentErrorMessage{};
+  QImage currentErrorImage{};
   double volOverL3;
 
 public:
-  explicit DuneSim(const model::Model &sbmlDoc,
-                   const std::vector<std::string> &compartmentIds,
-                   const std::map<std::string, double, std::less<>> &substitutions = {});
+  explicit DuneSim(
+      const model::Model &sbmlDoc,
+      const std::vector<std::string> &compartmentIds,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
   ~DuneSim() override;
   std::size_t run(double time, double timeout_ms) override;
   [[nodiscard]] const std::vector<double> &
@@ -76,7 +77,7 @@ public:
   [[nodiscard]] std::size_t getConcentrationPadding() const override;
   [[nodiscard]] const std::string &errorMessage() const override;
   [[nodiscard]] const QImage &errorImage() const override;
-  void requestStop() override;
+  void setStopRequested(bool stop) override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim.cpp
+++ b/src/core/simulate/src/pixelsim.cpp
@@ -336,6 +336,7 @@ std::size_t PixelSim::run(double time, double timeout_ms) {
   SPDLOG_TRACE("  - max rel local err {}", errMax.rel);
   SPDLOG_TRACE("  - max abs local err {}", errMax.abs);
   SPDLOG_TRACE("  - max stepsize {}", maxTimestep);
+  currentErrorMessage.clear();
 #ifdef SPATIAL_MODEL_EDITOR_WITH_TBB
   tbb::global_control control(tbb::global_control::max_allowed_parallelism,
                               numMaxThreads);
@@ -363,7 +364,7 @@ std::size_t PixelSim::run(double time, double timeout_ms) {
     if (timeout_ms >= 0.0 &&
         static_cast<double>(timer.elapsed()) >= timeout_ms) {
       SPDLOG_DEBUG("Simulation timeout: requesting stop");
-      requestStop();
+      setStopRequested(true);
     }
     if (stopRequested.load()) {
       currentErrorMessage = "Simulation stopped early";
@@ -403,6 +404,6 @@ const std::string &PixelSim::errorMessage() const {
 
 const QImage &PixelSim::errorImage() const { return currentErrorImage; }
 
-void PixelSim::requestStop() { stopRequested.store(true); }
+void PixelSim::setStopRequested(bool stop) { stopRequested.store(stop); }
 
 } // namespace sme::simulate

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -47,8 +47,8 @@ private:
   double epsilon{1e-14};
   bool useTBB{false};
   std::size_t numMaxThreads{1};
-  std::string currentErrorMessage;
-  QImage currentErrorImage;
+  std::string currentErrorMessage{};
+  QImage currentErrorImage{};
   std::atomic<bool> stopRequested{false};
   std::size_t nExtraVars{0};
 
@@ -69,7 +69,7 @@ public:
                                     std::size_t pixelIndex) const;
   const std::string &errorMessage() const override;
   const QImage &errorImage() const override;
-  void requestStop() override;
+  void setStopRequested(bool stop) override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim_impl.cpp
+++ b/src/core/simulate/src/pixelsim_impl.cpp
@@ -21,12 +21,11 @@
 
 namespace sme::simulate {
 
-ReacEval::ReacEval(const model::Model &doc,
-                   const std::vector<std::string> &speciesIDs,
-                   const std::vector<std::string> &reactionIDs,
-                   double reactionScaleFactor, bool doCSE, unsigned optLevel,
-                   bool timeDependent, bool spaceDependent,
-                   const std::map<std::string, double, std::less<>> &substitutions) {
+ReacEval::ReacEval(
+    const model::Model &doc, const std::vector<std::string> &speciesIDs,
+    const std::vector<std::string> &reactionIDs, double reactionScaleFactor,
+    bool doCSE, unsigned optLevel, bool timeDependent, bool spaceDependent,
+    const std::map<std::string, double, std::less<>> &substitutions) {
   // construct reaction expressions and stoich matrix
   PdeScaleFactors pdeScaleFactors;
   pdeScaleFactors.reaction = reactionScaleFactor;
@@ -439,12 +438,11 @@ double SimCompartment::getMaxStableTimestep() const {
   return maxStableTimestep;
 }
 
-SimMembrane::SimMembrane(const model::Model &doc,
-                         const geometry::Membrane *membrane_ptr,
-                         SimCompartment *simCompA, SimCompartment *simCompB,
-                         bool doCSE, unsigned optLevel, bool timeDependent,
-                         bool spaceDependent,
-                         const std::map<std::string, double, std::less<>> &substitutions)
+SimMembrane::SimMembrane(
+    const model::Model &doc, const geometry::Membrane *membrane_ptr,
+    SimCompartment *simCompA, SimCompartment *simCompB, bool doCSE,
+    unsigned optLevel, bool timeDependent, bool spaceDependent,
+    const std::map<std::string, double, std::less<>> &substitutions)
     : membrane(membrane_ptr), compA(simCompA), compB(simCompB) {
   if (timeDependent) {
     ++nExtraVars;


### PR DESCRIPTION
- Simulation::doMultipleTimesteps() sets `stopRequested=false` in simulator before returning
- prevents PixelSim from being left with `stopRequested=true` after a simulation is complete
- resolves #544
