### PR TITLE
don't always re-load simulation length/intervals from model in simulate tab

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -267,6 +267,7 @@ void MainWindow::validateSBMLDoc(const QString &filename) {
                            "Failed to load file " + filename);
     }
   }
+  tabSimulate->importTimesAndIntervalsOnNextLoad();
   ui->tabMain->setCurrentIndex(0);
   tabMain_currentChanged(0);
   enableTabs();

--- a/src/gui/tabs/tabsimulate.hpp
+++ b/src/gui/tabs/tabsimulate.hpp
@@ -16,10 +16,8 @@ class QCPAbstractPlottable;
 class QCPItemStraightLine;
 class QCPTextElement;
 class QLabelMouseTracker;
-namespace sme {
-namespace model {
+namespace sme::model {
 class Model;
-}
 } // namespace sme
 class PlotWrapper;
 
@@ -33,6 +31,7 @@ public:
   void loadModelData();
   void stopSimulation();
   void useDune(bool enable);
+  void importTimesAndIntervalsOnNextLoad();
   void reset();
   void setOptions(const sme::simulate::Options &options);
 
@@ -52,8 +51,7 @@ private:
   std::future<std::size_t> simSteps;
   QTimer plotRefreshTimer;
   QProgressDialog *progressDialog;
-  QString cachedSimLength{"100"};
-  QString cachedSimInterval{"1"};
+  bool importTimesAndIntervals{false};
 
   std::optional<std::vector<std::pair<std::size_t, double>>>
   parseSimulationTimes();


### PR DESCRIPTION
- only re-load them if user opens a new model, or clicks 'reset'
- resolves #565
