### PR TITLE
use symengine sbml support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.05.31
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010-pypy_x86_64:2021.05.31
+      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.06.11
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010-pypy_x86_64:2021.06.11
       CIBW_SKIP: '*-manylinux_i686 *p27-* *p35-*'
       CIBW_ENVIRONMENT: 'SME_EXTERNAL_SMECORE=on'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2021.05.31"
+SME_DEPS_VERSION="2021.06.11"
 OS=$1
 
 set -e -x

--- a/cmake/checkSymEngineLLVM.cpp
+++ b/cmake/checkSymEngineLLVM.cpp
@@ -1,6 +1,7 @@
-#include <symengine/basic.h>
 #include <symengine/llvm_double.h>
+#include <symengine/parser/sbml/sbml_parser.h>
 
 int main() {
   SymEngine::LLVMDoubleVisitor lambdaLLVM;
+  SymEngine::SbmlParser sbmlParser;
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -63,7 +63,7 @@ find_package(
   CONFIG
   REQUIRED)
 message(STATUS "Found SymEngine library: ")
-message(STATUS "Testing SymEngine LLVM support")
+message(STATUS "Testing SymEngine LLVM & SBML support")
 try_compile(
   SYMENGINE_LLVM "${CMAKE_CURRENT_BINARY_DIR}/cxx"
   "${CMAKE_SOURCE_DIR}/cmake/checkSymEngineLLVM.cpp"
@@ -71,11 +71,11 @@ try_compile(
   LINK_LIBRARIES ${SYMENGINE_LIBRARIES}
   OUTPUT_VARIABLE SYMENGINE_LLVM_ERROR_LOG)
 if(${SYMENGINE_LLVM})
-  message(STATUS "Testing SymEngine LLVM support - found")
+  message(STATUS "Testing SymEngine LLVM & SBML support - found")
 else()
   message(
     WARNING
-      "Supplied SymEngine library does not appear to be compiled with LLVM support"
+      "Supplied SymEngine library appears to be missing LLVM and/or SBML support"
   )
   message(WARNING "${SYMENGINE_LLVM_ERROR_LOG}")
 endif()

--- a/src/core/common/src/symbolic_t.cpp
+++ b/src/core/common/src/symbolic_t.cpp
@@ -154,8 +154,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
       }
     }
   }
-  GIVEN("e^(4*x): print exponential function") {
-    std::string expr = "e^(4*x)";
+  GIVEN("exponentiale^(4*x): print exponential function") {
+    std::string expr = "exponentiale^(4*x)";
     REQUIRE(utils::Symbolic(expr, {}, {}).getErrorMessage() ==
             "Unknown symbol: x");
     utils::Symbolic sym(expr, {"x"}, {});

--- a/src/core/model/inc/model_parameters.hpp
+++ b/src/core/model/inc/model_parameters.hpp
@@ -13,9 +13,7 @@ class Model;
 class Species;
 } // namespace libsbml
 
-namespace sme {
-
-namespace model {
+namespace sme::model {
 
 class ModelEvents;
 
@@ -29,8 +27,9 @@ struct SpatialCoordinates {
   IdName y;
 };
 
-struct IdValue {
+struct IdNameValue {
   std::string id;
+  std::string name;
   double value;
 };
 
@@ -63,12 +62,10 @@ public:
   const SpatialCoordinates &getSpatialCoordinates() const;
   void setSpatialCoordinates(SpatialCoordinates coords);
   std::vector<IdName> getSymbols() const;
-  std::vector<IdValue> getGlobalConstants() const;
+  std::vector<IdNameValue> getGlobalConstants() const;
   std::vector<IdNameExpr> getNonConstantParameters() const;
   bool getHasUnsavedChanges() const;
   void setHasUnsavedChanges(bool unsavedChanges);
 };
-
-} // namespace model
 
 } // namespace sme

--- a/src/core/model/src/model_parameters.cpp
+++ b/src/core/model/src/model_parameters.cpp
@@ -340,15 +340,15 @@ static bool isConstantParameter(const libsbml::Parameter *param) {
   return true;
 }
 
-std::vector<IdValue> ModelParameters::getGlobalConstants() const {
-  std::vector<IdValue> constants;
+std::vector<IdNameValue> ModelParameters::getGlobalConstants() const {
+  std::vector<IdNameValue> constants;
   // add all *constant* species as constants
   for (unsigned k = 0; k < sbmlModel->getNumSpecies(); ++k) {
     const auto *spec = sbmlModel->getSpecies(k);
     if (getIsSpeciesConstant(spec)) {
       SPDLOG_TRACE("found constant species {}", spec->getId());
       double init_conc = spec->getInitialConcentration();
-      constants.push_back({spec->getId(), init_conc});
+      constants.push_back({spec->getId(), spec->getName(), init_conc});
       SPDLOG_TRACE("parameter {} = {}", spec->getId(), init_conc);
     }
   }
@@ -357,7 +357,7 @@ std::vector<IdValue> ModelParameters::getGlobalConstants() const {
     const auto *param = sbmlModel->getParameter(k);
     if (isConstantParameter(param)) {
       SPDLOG_TRACE("parameter {} = {}", param->getId(), param->getValue());
-      constants.push_back({param->getId(), param->getValue()});
+      constants.push_back({param->getId(), param->getName(), param->getValue()});
     }
   }
   // also get compartment volumes (the compartmentID may be used in the
@@ -366,7 +366,7 @@ std::vector<IdValue> ModelParameters::getGlobalConstants() const {
   for (unsigned int k = 0; k < sbmlModel->getNumCompartments(); ++k) {
     const auto *comp = sbmlModel->getCompartment(k);
     SPDLOG_TRACE("parameter {} = {}", comp->getId(), comp->getSize());
-    constants.push_back({comp->getId(), comp->getSize()});
+    constants.push_back({comp->getId(), comp->getName(), comp->getSize()});
   }
   return constants;
 }

--- a/src/core/simulate/src/pde.cpp
+++ b/src/core/simulate/src/pde.cpp
@@ -63,10 +63,10 @@ Pde::Pde(const model::Model *doc_ptr,
       SPDLOG_DEBUG("Species {} Reaction {} = {}", speciesIDs.at(i), j,
                    expr.toStdString());
       auto constants{reactions.getConstants(j)};
-      if(!substitutions.empty()){
+      if (!substitutions.empty()) {
         // substitute values of any constants in substitutions map
-        for(auto& [id, v] : constants){
-          if(auto iter = substitutions.find(id); iter != substitutions.end()){
+        for (auto &[id, v] : constants) {
+          if (auto iter = substitutions.find(id); iter != substitutions.end()) {
             SPDLOG_INFO("Substituting: {} = {} -> {}", id, v, iter->second);
             v = iter->second;
           }
@@ -182,9 +182,8 @@ Reaction::Reaction(const model::Model *doc, std::vector<std::string> species,
 
       // get local parameters, append to global constants
       constants.emplace_back();
-      for (const auto &[id, value] :
-           doc->getParameters().getGlobalConstants()) {
-        constants.back().push_back({id, value});
+      for (const auto &c : doc->getParameters().getGlobalConstants()) {
+        constants.back().push_back({c.id, c.value});
       }
       for (const auto &paramId :
            doc->getReactions().getParameterIds(reacID.c_str())) {

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -1840,3 +1840,21 @@ SCENARIO("stop, then continue pixel simulation",
   sim.doMultipleTimesteps({{3, 0.01}});
   REQUIRE(m.getSimulationData().timePoints.size() == 4);
 }
+
+SCENARIO("Fish model: simulation with piecewise function in reactions",
+         "[core/simulate/simulate][core/simulate][core][simulate]") {
+  auto m{getModel(":test/models/fish_300x300.xml")};
+  // pixel
+  m.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+  simulate::Simulation simPixel(m);
+  REQUIRE(simPixel.errorMessage() == "");
+  REQUIRE(m.getSimulationData().timePoints.size() == 1);
+  simPixel.doMultipleTimesteps({{2, 0.01}});
+  REQUIRE(simPixel.errorMessage() == "");
+  REQUIRE(m.getSimulationData().timePoints.size() == 3);
+  // dune doesn't have symengine yet so no piecewise func support:
+  m.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
+  m.getSimulationData().clear();
+  simulate::Simulation simDune(m);
+  REQUIRE(simDune.errorMessage().substr(0, 29) == "IOError [handle_parser_error:");
+}

--- a/src/gui/dialogs/dialoganalytic.hpp
+++ b/src/gui/dialogs/dialoganalytic.hpp
@@ -1,47 +1,39 @@
 #pragma once
 
+#include "utils.hpp"
 #include <QDialog>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 
-#include "model.hpp"
-#include "utils.hpp"
-
 namespace Ui {
 class DialogAnalytic;
 }
 
-namespace sme {
-namespace units {
-class ModelUnits;
-}
-
-namespace Model {
-struct SpatialCoordinates;
-}
+namespace sme::model {
+struct SpeciesGeometry;
+class ModelParameters;
+class ModelFunctions;
 }
 
 class DialogAnalytic : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogAnalytic(const QString &analyticExpression,
-                          const sme::model::SpeciesGeometry &speciesGeometry,
-                          sme::model::ModelMath &modelMath,
-                          const sme::model::SpatialCoordinates &spatialCoordinates,
-                          QWidget *parent = nullptr);
-  ~DialogAnalytic();
+  explicit DialogAnalytic(
+      const QString &analyticExpression,
+      const sme::model::SpeciesGeometry &speciesGeometry,
+      const sme::model::ModelParameters &modelParameters,
+      const sme::model::ModelFunctions &modelFunctions,
+      QWidget *parent = nullptr);
+  ~DialogAnalytic() override;
   const std::string &getExpression() const;
-  const QImage& getImage() const;
+  const QImage &getImage() const;
   bool isExpressionValid() const;
 
 private:
   std::unique_ptr<Ui::DialogAnalytic> ui;
-  std::map<const std::string, std::pair<double, bool>> sbmlVars;
-  std::string xId{};
-  std::string yId{};
   // user supplied data
   const std::vector<QPoint> &points;
   double width;

--- a/src/gui/dialogs/dialoganalytic_t.cpp
+++ b/src/gui/dialogs/dialoganalytic_t.cpp
@@ -7,17 +7,16 @@
 SCENARIO("DialogAnalytic",
          "[gui/dialogs/analytic][gui/dialogs][gui][analytic]") {
   GIVEN("10x10 image, small compartment, simple expr") {
-    sme::model::Model doc;
+    sme::model::Model model;
     QFile f(":/models/ABtoC.xml");
     f.open(QIODevice::ReadOnly);
-    doc.importSBMLString(f.readAll().toStdString());
+    model.importSBMLString(f.readAll().toStdString());
     auto compartmentPoints = std::vector<QPoint>{
         QPoint(5, 5), QPoint(5, 6), QPoint(5, 7), QPoint(6, 6), QPoint(6, 7)};
     DialogAnalytic dia("x",
                        {QSize(10, 10), compartmentPoints, QPointF(0.0, 0.0), 1,
-                        doc.getUnits()},
-                       doc.getMath(),
-                       doc.getParameters().getSpatialCoordinates());
+                        model.getUnits()},
+                       model.getParameters(), model.getFunctions());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10") {
@@ -88,16 +87,17 @@ SCENARIO("DialogAnalytic",
     }
   }
   GIVEN("100x100 image") {
-    sme::model::Model doc;
+    sme::model::Model model;
     QFile f(":/models/ABtoC.xml");
     f.open(QIODevice::ReadOnly);
-    doc.importSBMLString(f.readAll().toStdString());
-    DialogAnalytic dia("x", doc.getSpeciesGeometry("B"), doc.getMath(),
-                       doc.getParameters().getSpatialCoordinates());
+    model.importSBMLString(f.readAll().toStdString());
+    DialogAnalytic dia("x", model.getSpeciesGeometry("B"),
+                       model.getParameters(), model.getFunctions());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10 & unclick grid/scale checkboxes") {
-      mwt.addUserAction({"Delete", "1", "0", "Shift+Tab", "Space", "Shift+Tab", "Space"});
+      mwt.addUserAction(
+          {"Delete", "1", "0", "Shift+Tab", "Space", "Shift+Tab", "Space"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.isExpressionValid() == true);

--- a/src/gui/tabs/tabevents.cpp
+++ b/src/gui/tabs/tabevents.cpp
@@ -37,7 +37,7 @@ void TabEvents::loadModelData(const QString &selection) {
   ui->lblSpeciesExpression->clear();
   ui->stkValue->setCurrentIndex(0);
   ui->txtExpression->clearVariables();
-  ui->txtExpression->clearFunctions();
+  ui->txtExpression->resetToDefaultFunctions();
   ui->cmbEventVariable->clear();
   variableIds.clear();
   for (const auto &cId : model.getCompartments().getIds()) {
@@ -155,6 +155,7 @@ void TabEvents::txtEventTime_editingFinished() {
   }
   ui->lblExpressionStatus->setText("");
   model.getEvents().setTime(currentEventId, time);
+  ui->lblExpressionStatus->setText(ui->txtExpression->getErrorMessage());
 }
 
 void TabEvents::cmbEventVariable_activated(int index) {
@@ -174,8 +175,7 @@ void TabEvents::cmbEventVariable_activated(int index) {
     ui->lblSpeciesExpression->setPixmap(QPixmap::fromImage(
         DialogAnalytic(model.getEvents().getExpression(currentEventId),
                        model.getSpeciesGeometry(variableIds[index]),
-                       model.getMath(),
-                       model.getParameters().getSpatialCoordinates())
+                       model.getParameters(), model.getFunctions())
             .getImage()));
     ui->txtExpression->setEnabled(false);
   } else {
@@ -194,8 +194,8 @@ void TabEvents::btnSetSpeciesConcentration_clicked() {
   }
   QString sId{variableIds[iSpecies]};
   DialogAnalytic dialog(model.getEvents().getExpression(currentEventId),
-                        model.getSpeciesGeometry(sId), model.getMath(),
-                        model.getParameters().getSpatialCoordinates());
+                        model.getSpeciesGeometry(sId), model.getParameters(),
+                        model.getFunctions());
   if (dialog.exec() == QDialog::Accepted) {
     const std::string &expr{dialog.getExpression()};
     SPDLOG_DEBUG("  - set expr: {}", expr);

--- a/src/gui/tabs/tabevents_t.cpp
+++ b/src/gui/tabs/tabevents_t.cpp
@@ -70,6 +70,7 @@ SCENARIO("Events Tab", "[gui/tabs/events][gui/tabs][gui][events]") {
     f.open(QIODevice::ReadOnly);
     model.importSBMLString(f.readAll().toStdString());
     tab.loadModelData();
+    tab.show();
     REQUIRE(events.getIds().size() == 0);
     REQUIRE(listEvents->count() == 0);
     REQUIRE(btnAddEvent->isEnabled() == true);
@@ -127,7 +128,7 @@ SCENARIO("Events Tab", "[gui/tabs/events][gui/tabs][gui][events]") {
     REQUIRE(events.getTime("p_") == dbl_approx(24.9));
     // expression -> ""
     txtExpression->setFocus();
-    sendKeyEvents(txtExpression, {"Delete", "Backspace"});
+    sendKeyEvents(txtExpression, {"Delete", "Backspace", "Backspace"});
     REQUIRE(txtExpression->toPlainText() == "");
     REQUIRE(lblExpressionStatus->text() == "Empty expression");
     // invalid expression so model expression unchanged

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -278,8 +278,8 @@ void TabSpecies::btnEditAnalyticConcentration_clicked() {
                currentSpeciesId.toStdString());
   DialogAnalytic dialog(
       model.getSpecies().getAnalyticConcentration(currentSpeciesId),
-      model.getSpeciesGeometry(currentSpeciesId), model.getMath(),
-      model.getParameters().getSpatialCoordinates());
+      model.getSpeciesGeometry(currentSpeciesId), model.getParameters(),
+      model.getFunctions());
   if (dialog.exec() == QDialog::Accepted) {
     const std::string &expr = dialog.getExpression();
     SPDLOG_DEBUG("  - set expr: {}", expr);


### PR DESCRIPTION
- now support all SBML L3 math in GUI/Pixel, including in reactions
- Symbolic changes:
  - use new symengine sbml parser and printer
- QPlainTextMathedit changes:
  - remove libsbml backend now that symengine has sbml parse/print support
  - define all built-in sbml functions & constants
  - single pass for both quoted and un-quoted names when mapping id<->names
  - print quotes as needed instead of storing them as part of the names
- update sme_deps to 2021.06.11 to get symengine sbml support
- resolves #569
