### PR TITLE
Don't allow invalid species in reaction rates

### DIFF
--- a/src/core/model/inc/model_parameters.hpp
+++ b/src/core/model/inc/model_parameters.hpp
@@ -46,11 +46,12 @@ private:
   SpatialCoordinates spatialCoordinates;
   libsbml::Model *sbmlModel{nullptr};
   bool hasUnsavedChanges{false};
-  ModelEvents* modelEvents{nullptr};
+  ModelEvents *modelEvents{nullptr};
 
 public:
   ModelParameters();
-  explicit ModelParameters(libsbml::Model *model, ModelEvents* events= nullptr);
+  explicit ModelParameters(libsbml::Model *model,
+                           ModelEvents *events = nullptr);
   const QStringList &getIds() const;
   const QStringList &getNames() const;
   QString setName(const QString &id, const QString &name);
@@ -61,11 +62,11 @@ public:
   void remove(const QString &id);
   const SpatialCoordinates &getSpatialCoordinates() const;
   void setSpatialCoordinates(SpatialCoordinates coords);
-  std::vector<IdName> getSymbols() const;
+  std::vector<IdName> getSymbols(const QStringList &compartments = {}) const;
   std::vector<IdNameValue> getGlobalConstants() const;
   std::vector<IdNameExpr> getNonConstantParameters() const;
   bool getHasUnsavedChanges() const;
   void setHasUnsavedChanges(bool unsavedChanges);
 };
 
-} // namespace sme
+} // namespace sme::model

--- a/src/core/model/src/model_parameters_t.cpp
+++ b/src/core/model/src/model_parameters_t.cpp
@@ -24,6 +24,14 @@ SCENARIO("SBML parameters",
     REQUIRE(params.getHasUnsavedChanges() == false);
     REQUIRE(params.getIds().size() == 0);
     REQUIRE(params.getNames().size() == 0);
+    // 1 compartment + 25 species + 2 space + time
+    REQUIRE(params.getSymbols().size() == 29);
+    // specify non-existent compartment: species not included
+    REQUIRE(params.getSymbols({"idontexist"}).size() == 4);
+    // specify multiple compartments including the real one:
+    REQUIRE(
+        params.getSymbols({"idontexist", "meneither", "compartment"}).size() ==
+        29);
     // default geometry spatial coordinates:
     const auto &coords = params.getSpatialCoordinates();
     REQUIRE(coords.x.id == "x");

--- a/src/gui/tabs/tabevents.cpp
+++ b/src/gui/tabs/tabevents.cpp
@@ -37,7 +37,7 @@ void TabEvents::loadModelData(const QString &selection) {
   ui->lblSpeciesExpression->clear();
   ui->stkValue->setCurrentIndex(0);
   ui->txtExpression->clearVariables();
-  ui->txtExpression->resetToDefaultFunctions();
+  ui->txtExpression->reset();
   ui->cmbEventVariable->clear();
   variableIds.clear();
   for (const auto &cId : model.getCompartments().getIds()) {

--- a/src/gui/tabs/tabfunctions.cpp
+++ b/src/gui/tabs/tabfunctions.cpp
@@ -64,7 +64,7 @@ void TabFunctions::listFunctions_currentRowChanged(int row) {
   ui->txtFunctionName->setText(funcs.getName(id));
   auto args = funcs.getArguments(id);
   // reset variables to only built-in functions
-  ui->txtFunctionDef->resetToDefaultFunctions();
+  ui->txtFunctionDef->reset();
   ui->txtFunctionDef->setVariables(sme::utils::toStdString(args));
   // add model functions
   for (const auto &function : model.getFunctions().getSymbolicFunctions()) {

--- a/src/gui/tabs/tabparameters.cpp
+++ b/src/gui/tabs/tabparameters.cpp
@@ -28,7 +28,7 @@ void TabParameters::loadModelData(const QString &selection) {
   currentParameterId.clear();
   ui->listParameters->clear();
   ui->txtExpression->clearVariables();
-  ui->txtExpression->resetToDefaultFunctions();
+  ui->txtExpression->reset();
   for (const auto &[id, name] : model.getParameters().getSymbols()) {
     ui->txtExpression->addVariable(id, name);
   }

--- a/src/gui/tabs/tabreactions.cpp
+++ b/src/gui/tabs/tabreactions.cpp
@@ -163,17 +163,11 @@ void TabReactions::listReactions_currentItemChanged(
   ui->txtReactionName->setText(model.getReactions().getName(currentReacId));
   ui->lblReactionScheme->setText(model.getReactions().getScheme(currentReacId));
   ui->cmbReactionLocation->setCurrentIndex(locationIndex);
-  // reset variables to only built-in functions
-  ui->txtReactionRate->resetToDefaultFunctions();
+  ui->txtReactionRate->reset();
   // add model parameters
-  for (const auto &[id, name] : model.getParameters().getSymbols()) {
+  for (const auto &[id, name] :
+       model.getParameters().getSymbols(compartments)) {
     ui->txtReactionRate->addVariable(id, name);
-  }
-  // add any reaction localParameters
-  for (const auto &id : model.getReactions().getParameterIds(currentReacId)) {
-    ui->txtReactionRate->addVariable(
-        id.toStdString(),
-        model.getReactions().getParameterName(currentReacId, id).toStdString());
   }
   // add model functions
   for (const auto &function : model.getFunctions().getSymbolicFunctions()) {
@@ -219,9 +213,9 @@ void TabReactions::listReactions_currentItemChanged(
   ui->listReactionParams->blockSignals(true);
   for (const auto &paramId :
        model.getReactions().getParameterIds(currentReacId)) {
-    auto name = model.getReactions().getParameterName(currentReacId, paramId);
-    double value =
-        model.getReactions().getParameterValue(currentReacId, paramId);
+    auto name{model.getReactions().getParameterName(currentReacId, paramId)};
+    double value{
+        model.getReactions().getParameterValue(currentReacId, paramId)};
     auto *itemName = newQTableWidgetItem(name);
     auto *itemValue =
         newQTableWidgetItem(QString("%1").arg(value, 14, 'g', 14));

--- a/src/gui/widgets/qplaintextmathedit.cpp
+++ b/src/gui/widgets/qplaintextmathedit.cpp
@@ -124,10 +124,11 @@ void QPlainTextMathEdit::removeVariable(const std::string &variable) {
   qPlainTextEdit_textChanged();
 }
 
-void QPlainTextMathEdit::resetToDefaultFunctions() {
+void QPlainTextMathEdit::reset() {
   // reset to all built-in sbml L3 math functions and constants
   // http://model.caltech.edu/software/libsbml/5.18.0/docs/formatted/c-api/libsbml-math.html#math-l3
   clearFunctions();
+  clearVariables();
   for (const auto &f :
        {"sin",   "cos",      "tan",   "cot",       "csc",   "sec",
         "asin",  "arcsin",   "acos",  "arccos",    "atan",  "arctan",
@@ -208,7 +209,7 @@ void QPlainTextMathEdit::updateCompleter() {
 
 QPlainTextMathEdit::QPlainTextMathEdit(QWidget *parent)
     : QPlainTextEdit(parent) {
-  resetToDefaultFunctions();
+  reset();
   completer.setWidget(this);
   completer.setCompletionMode(QCompleter::PopupCompletion);
   completer.setCaseSensitivity(Qt::CaseSensitive);

--- a/src/gui/widgets/qplaintextmathedit.hpp
+++ b/src/gui/widgets/qplaintextmathedit.hpp
@@ -32,7 +32,7 @@ public:
   void addVariable(const std::string &variable,
                    const std::string &displayName = {});
   void removeVariable(const std::string &variable);
-  void resetToDefaultFunctions();
+  void reset();
   void addFunction(const sme::utils::Function &function);
   void removeFunction(const std::string &functionId);
   void setConstants(const std::vector<sme::model::IdNameValue> &constants = {});


### PR DESCRIPTION
- ModelParameters::getSymbols() now takes an optional list of compartments
- if provided, only species from these compartments are included
- TabReactions specifies the compartments when calling getSymbols
- QPlainTextMathEdit::reset() now also clears any variables
- resolves #552
