### PR TITLE
ensure compartment sizes are updated when pixel size is changed

### DIFF
--- a/src/core/model/inc/model_membranes.hpp
+++ b/src/core/model/inc/model_membranes.hpp
@@ -29,6 +29,7 @@ private:
   std::vector<geometry::Membrane> membranes{};
   std::unique_ptr<ImageMembranePixels> membranePixels;
   std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>> idColourPairs{};
+  libsbml::Model *sbmlModel{nullptr};
   bool hasUnsavedChanges{false};
 
 public:
@@ -40,15 +41,14 @@ public:
   const geometry::Membrane *getMembrane(const QString &id) const;
   const std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>> &
   getIdColourPairs() const;
-  void clear();
-  void updateCompartmentNames(const QStringList &compartmentNames,
-                              const libsbml::Model *model);
+  double getSize(const QString& id) const;
+  void updateCompartmentNames(const QStringList &compartmentNames);
   void updateCompartments(
       const std::vector<std::unique_ptr<geometry::Compartment>> &compartments);
   void updateCompartmentImage(const QImage &img);
-  void importMembraneIdsAndNames(const libsbml::Model *model);
-  void exportToSBML(libsbml::Model *model, double pixelWidth);
-  explicit ModelMembranes();
+  void importMembraneIdsAndNames();
+  void exportToSBML(double pixelWidth);
+  explicit ModelMembranes(libsbml::Model *model = nullptr);
   ModelMembranes(ModelMembranes &&) noexcept;
   ModelMembranes &operator=(ModelMembranes &&) noexcept;
   ModelMembranes &operator=(const ModelMembranes &) = delete;

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -60,7 +60,7 @@ void Model::initModelData() {
   modelUnits = ModelUnits(model);
   modelMath = ModelMath(model);
   modelFunctions = ModelFunctions(model);
-  modelMembranes.clear();
+  modelMembranes = ModelMembranes(model);
   // todo: reduce these cyclic dependencies: currently order of initialization
   // matters, should be possible to reduce coupling here
   modelCompartments =
@@ -151,7 +151,7 @@ void Model::exportSMEFile(const std::string &filename) {
 void Model::updateSBMLDoc() {
   modelGeometry.writeGeometryToSBML();
   setSbmlAnnotation(doc->getModel(), settings);
-  modelMembranes.exportToSBML(doc->getModel(), modelGeometry.getPixelWidth());
+  modelMembranes.exportToSBML(modelGeometry.getPixelWidth());
 }
 
 QString Model::getXml() {
@@ -237,7 +237,7 @@ void Model::clear() {
   currentFilename.clear();
   modelCompartments = ModelCompartments{};
   modelGeometry = ModelGeometry{};
-  modelMembranes.clear();
+  modelMembranes = ModelMembranes{};
   modelSpecies = ModelSpecies{};
   modelReactions = ModelReactions{};
   modelFunctions = ModelFunctions{};

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -116,7 +116,7 @@ QString ModelCompartments::add(const QString &name) {
   createDefaultCompartmentGeometryIfMissing(sbmlModel);
   modelGeometry->updateMesh();
   modelMembranes->updateCompartments(compartments);
-  modelMembranes->updateCompartmentNames(names, sbmlModel);
+  modelMembranes->updateCompartmentNames(names);
   hasUnsavedChanges = true;
   SPDLOG_INFO("Clearing simulation data");
   simulationData->clear();
@@ -190,7 +190,7 @@ bool ModelCompartments::remove(const QString &id) {
     modelSpecies->remove(s);
   }
   modelMembranes->updateCompartments(compartments);
-  modelMembranes->updateCompartmentNames(names, sbmlModel);
+  modelMembranes->updateCompartmentNames(names);
   modelGeometry->updateMesh();
   return true;
 }
@@ -219,7 +219,7 @@ QString ModelCompartments::setName(const QString &id, const QString &name) {
   auto *comp = sbmlModel->getCompartment(sId);
   SPDLOG_INFO("sId '{}' : name -> '{}'", sId, sName);
   comp->setName(sName);
-  modelMembranes->updateCompartmentNames(names, sbmlModel);
+  modelMembranes->updateCompartmentNames(names);
   return uniqueName;
 }
 
@@ -333,10 +333,10 @@ void ModelCompartments::setColour(const QString &id, QRgb colour) {
   SPDLOG_INFO("  - size {}", volume);
   modelSpecies->updateCompartmentGeometry(id);
   modelMembranes->updateCompartments(compartments);
-  modelMembranes->updateCompartmentNames(names, sbmlModel);
+  modelMembranes->updateCompartmentNames(names);
   modelGeometry->updateMesh();
   if (modelGeometry->getIsValid()) {
-    modelMembranes->exportToSBML(sbmlModel, modelGeometry->getPixelWidth());
+    modelMembranes->exportToSBML(modelGeometry->getPixelWidth());
   }
   modelReactions->makeReactionsSpatial(modelGeometry->getIsValid());
 }

--- a/src/core/model/src/model_geometry_t.cpp
+++ b/src/core/model/src/model_geometry_t.cpp
@@ -37,7 +37,7 @@ SCENARIO("Model geometry",
         libsbml::readSBMLFromString(f.readAll().toStdString().c_str()));
     model::Settings sbmlAnnotation;
     model::ModelCompartments mCompartments;
-    model::ModelMembranes mMembranes;
+    model::ModelMembranes mMembranes(doc->getModel());
     model::ModelGeometry mGeometry;
     model::ModelSpecies mSpecies;
     model::ModelReactions mReactions(doc->getModel(), &mMembranes);

--- a/src/core/model/src/model_membranes_t.cpp
+++ b/src/core/model/src/model_membranes_t.cpp
@@ -42,7 +42,7 @@ SCENARIO("SBML membranes",
       REQUIRE(ms.getMembranes().size() == 1);
       REQUIRE(ms.getNames().isEmpty());
       ms.setHasUnsavedChanges(false);
-      ms.updateCompartmentNames(names, nullptr);
+      ms.updateCompartmentNames(names);
       ms.setHasUnsavedChanges(true);
       REQUIRE(ms.getIds().size() == 1);
       REQUIRE(ms.getIds()[0] == "c1_c0_membrane");


### PR DESCRIPTION
- ModelGeometry::setPixelWidth()
  - assign each compartment colour again: this updates compartment/membrane sizes & interior points
  - remove interior point rescaling: no longer needed code duplication
  - resolves #583
- ModelMembranes
  - add getSize()
  - refactor to match other ModelX classes
    - store sbml model pointer
    - remove clear() method
