### PR TITLE
improve mesh error handling

### DIFF
--- a/src/core/mesh/inc/mesh.hpp
+++ b/src/core/mesh/inc/mesh.hpp
@@ -36,7 +36,6 @@ class Boundary;
  */
 class Mesh {
 private:
-  bool validMesh{true};
   // input data
   QImage img;
   QPointF origin;
@@ -50,6 +49,8 @@ private:
   std::size_t nTriangles{};
   std::vector<std::vector<QTriangleF>> triangles;
   std::vector<std::vector<TriangulateTriangleIndex>> triangleIndices;
+  bool validMesh{true};
+  std::string errorMessage{};
   // convert point in pixel units to point in physical units
   QPointF pixelPointToPhysicalPoint(const QPointF &pixelPoint) const noexcept;
   void constructMesh();
@@ -77,6 +78,10 @@ public:
    * @brief Returns true if the mesh is valid
    */
   bool isValid() const;
+  /**
+   * @brief Returns an error message if the mesh is invalid
+   */
+  const std::string& getErrorMessage() const;
   /**
    * @brief The number of boundary lines in the mesh
    */

--- a/src/core/mesh/src/mesh.cpp
+++ b/src/core/mesh/src/mesh.cpp
@@ -72,6 +72,8 @@ Mesh::~Mesh() = default;
 
 bool Mesh::isValid() const { return validMesh; }
 
+const std::string &Mesh::getErrorMessage() const { return errorMessage; };
+
 std::size_t Mesh::getNumBoundaries() const { return boundaries->size(); }
 
 void Mesh::setBoundaryMaxPoints(std::size_t boundaryIndex,
@@ -168,9 +170,12 @@ void Mesh::constructMesh() {
             {{vertices[t[0]], vertices[t[1]], vertices[t[2]]}});
       }
     }
+    validMesh = true;
+    errorMessage.clear();
   } catch (const std::exception &e) {
-    SPDLOG_WARN("constructMesh failed with exception: {}", e.what());
     validMesh = false;
+    errorMessage = e.what();
+    SPDLOG_WARN("constructMesh failed with exception: {}", errorMessage);
     vertices.clear();
     triangleIndices.clear();
     triangles.clear();
@@ -316,27 +321,27 @@ QString Mesh::getGMSH() const {
   std::size_t nElem = 0;
   std::size_t compartmentIndex = 1;
   for (const auto &comp : triangleIndices) {
-      SPDLOG_TRACE("Adding compartment of triangles, index: {}",
-                   compartmentIndex);
-      nElem += comp.size();
+    SPDLOG_TRACE("Adding compartment of triangles, index: {}",
+                 compartmentIndex);
+    nElem += comp.size();
     compartmentIndex++;
   }
   msh.append(QString("%1\n").arg(nElem));
   std::size_t elementIndex{1};
   compartmentIndex = 1;
   for (const auto &comp : triangleIndices) {
-       SPDLOG_TRACE("Writing triangles for compartment index: {}",
-                   compartmentIndex);
-      for (const auto &t : comp) {
-        msh.append(QString("%1 2 2 %2 %2 %3 %4 %5\n")
-                       .arg(elementIndex)
-                       .arg(compartmentIndex)
-                       .arg(t[0] + 1)
-                       .arg(t[1] + 1)
-                       .arg(t[2] + 1));
-        ++elementIndex;
-      }
-      ++compartmentIndex;
+    SPDLOG_TRACE("Writing triangles for compartment index: {}",
+                 compartmentIndex);
+    for (const auto &t : comp) {
+      msh.append(QString("%1 2 2 %2 %2 %3 %4 %5\n")
+                     .arg(elementIndex)
+                     .arg(compartmentIndex)
+                     .arg(t[0] + 1)
+                     .arg(t[1] + 1)
+                     .arg(t[2] + 1));
+      ++elementIndex;
+    }
+    ++compartmentIndex;
   }
   msh.append("$EndElements\n");
   return msh;

--- a/src/core/mesh/src/triangulate.cpp
+++ b/src/core/mesh/src/triangulate.cpp
@@ -48,8 +48,18 @@ static void addTriangleAndNeighbours(
       // check each edge of this face (aka triangle)
       if (!face->is_constrained(edgeIndex)) {
         // edge is not a boundary, so look at connected face
-        if (const auto connectedFace{face->neighbor(edgeIndex)};
-            !cdt.is_infinite(connectedFace) && !connectedFace->is_marked()) {
+        const auto connectedFace{face->neighbor(edgeIndex)};
+        if (cdt.is_infinite(connectedFace)) {
+          // if the edge is not constrained, but the neighbouring face is
+          // infinite, we are outside of the boundary lines (since any infinite
+          // face should be separated from the rest of the triangulation by a
+          // constrained edge) which probably means the interior point was
+          // outside of the appropriate region
+          std::string msg{"Triangle is outside of the boundary lines"};
+          SPDLOG_WARN("{}", msg);
+          throw std::runtime_error(msg);
+        }
+        if (!connectedFace->is_marked()) {
           // connected face is valid and has not already been added, so add it
           addTriangle(connectedFace, faces, triangleIndices);
         }

--- a/test/resources/models/single-pixel-meshing.xml
+++ b/test/resources/models/single-pixel-meshing.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:spatial="http://www.sbml.org/sbml/level3/version1/spatial/version1" level="3" version="2" spatial:required="true">
+  <model id="ABtoC" substanceUnits="units_of_substance" timeUnits="unit_of_time" volumeUnits="unit_of_volume" areaUnits="area" lengthUnits="unit_of_length" extentUnits="units_of_substance">
+    <annotation>
+      <spatialModelEditor xmlns="https://github.com/spatial-model-editor">
+        <settings>
+          <cereal_class_version>0</cereal_class_version>
+          <simulationSettings>
+            <cereal_class_version>1</cereal_class_version>
+            <times size="dynamic"/>
+            <options>
+              <cereal_class_version>0</cereal_class_version>
+              <dune>
+                <cereal_class_version>0</cereal_class_version>
+                <discretization>0</discretization>
+                <integrator>alexander_2</integrator>
+                <dt>0.10000000000000001</dt>
+                <minDt>1e-10</minDt>
+                <maxDt>10000</maxDt>
+                <increase>1.5</increase>
+                <decrease>0.5</decrease>
+                <writeVTKfiles>false</writeVTKfiles>
+                <newtonRelErr>1e-08</newtonRelErr>
+                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+              </dune>
+              <pixel>
+                <cereal_class_version>0</cereal_class_version>
+                <integrator>1</integrator>
+                <maxErr>
+                  <cereal_class_version>0</cereal_class_version>
+                  <abs>1.7976931348623157e+308</abs>
+                  <rel>0.0050000000000000001</rel>
+                </maxErr>
+                <maxTimestep>1.7976931348623157e+308</maxTimestep>
+                <enableMultiThreading>false</enableMultiThreading>
+                <maxThreads>0</maxThreads>
+                <doCSE>true</doCSE>
+                <optLevel>3</optLevel>
+              </pixel>
+            </options>
+            <simulatorType>0</simulatorType>
+          </simulationSettings>
+          <displayOptions>
+            <cereal_class_version>1</cereal_class_version>
+            <showSpecies size="dynamic"/>
+            <showMinMax>true</showMinMax>
+            <normaliseOverAllTimepoints>true</normaliseOverAllTimepoints>
+            <normaliseOverAllSpecies>true</normaliseOverAllSpecies>
+            <showGeometryGrid>false</showGeometryGrid>
+            <showGeometryScale>false</showGeometryScale>
+            <invertYAxis>false</invertYAxis>
+          </displayOptions>
+          <meshParameters>
+            <cereal_class_version>0</cereal_class_version>
+            <maxPoints size="dynamic">
+              <value0>4</value0>
+            </maxPoints>
+            <maxAreas size="dynamic">
+              <value0>40</value0>
+            </maxAreas>
+          </meshParameters>
+          <speciesColours size="dynamic">
+            <value0>
+              <key>A</key>
+              <value>4293263363</value>
+            </value0>
+            <value1>
+              <key>B</key>
+              <value>4278236187</value>
+            </value1>
+            <value2>
+              <key>C</key>
+              <value>4294704896</value>
+            </value2>
+          </speciesColours>
+        </settings>
+      </spatialModelEditor>
+    </annotation>
+    <listOfUnitDefinitions>
+      <unitDefinition id="perConcentration_perSecond">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+          <unit kind="mole" exponent="-1" scale="0" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area" name="m_squared">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_time" name="s">
+        <listOfUnits>
+          <unit kind="second" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_length" name="m">
+        <listOfUnits>
+          <unit kind="metre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_volume" name="L">
+        <listOfUnits>
+          <unit kind="litre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="units_of_substance" name="mol">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="diffusion_constant_units" name="diffusion_constant_units">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="comp" name="comp" spatialDimensions="2" size="1" units="area" constant="true">
+        <spatial:compartmentMapping spatial:id="comp_compartmentMapping" spatial:domainType="comp_domainType" spatial:unitSize="1"/>
+      </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" name="A" compartment="comp" initialConcentration="1" substanceUnits="mole" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+      <species id="B" name="B" compartment="comp" initialConcentration="1" substanceUnits="mole" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+      <species id="C" name="C" compartment="comp" initialConcentration="0" substanceUnits="mole" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="B_diffusionConstant" value="0.4" units="diffusion_constant_units" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="B" spatial:type="isotropic"/>
+      </parameter>
+      <parameter id="A_diffusionConstant" value="0.4" units="diffusion_constant_units" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="A" spatial:type="isotropic"/>
+      </parameter>
+      <parameter id="C_diffusionConstant" value="25" units="diffusion_constant_units" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="C" spatial:type="isotropic"/>
+      </parameter>
+      <parameter id="x" name="x" value="0" units="unit_of_length" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" name="y" value="0" units="unit_of_length" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
+    </listOfParameters>
+    <listOfInitialAssignments/>
+    <listOfReactions>
+      <reaction id="r1" name="r1" reversible="false" compartment="comp" spatial:isLocal="true">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+          <speciesReference species="B" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="C" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> A </ci>
+              <ci> B </ci>
+              <ci> k1 </ci>
+            </apply>
+          </math>
+          <listOfLocalParameters>
+            <localParameter id="k1" name="k1" value="0.1" units="perConcentration_perSecond"/>
+          </listOfLocalParameters>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+    <spatial:geometry spatial:coordinateSystem="cartesian">
+      <spatial:listOfCoordinateComponents>
+        <spatial:coordinateComponent spatial:id="xCoord" spatial:type="cartesianX">
+          <spatial:boundaryMin spatial:id="xBoundaryMin" spatial:value="0"/>
+          <spatial:boundaryMax spatial:id="xBoundaryMax" spatial:value="3"/>
+        </spatial:coordinateComponent>
+        <spatial:coordinateComponent spatial:id="yCoord" spatial:type="cartesianY">
+          <spatial:boundaryMin spatial:id="yBoundaryMin" spatial:value="0"/>
+          <spatial:boundaryMax spatial:id="yBoundaryMax" spatial:value="1"/>
+        </spatial:coordinateComponent>
+      </spatial:listOfCoordinateComponents>
+      <spatial:listOfDomainTypes>
+        <spatial:domainType spatial:id="comp_domainType" spatial:spatialDimensions="2"/>
+      </spatial:listOfDomainTypes>
+      <spatial:listOfDomains>
+        <spatial:domain spatial:id="comp_domain" spatial:domainType="comp_domainType">
+          <spatial:listOfInteriorPoints>
+            <spatial:interiorPoint spatial:coord1="1.5" spatial:coord2="0.5"/>
+          </spatial:listOfInteriorPoints>
+        </spatial:domain>
+      </spatial:listOfDomains>
+      <spatial:listOfGeometryDefinitions>
+        <spatial:sampledFieldGeometry spatial:id="geometry" spatial:isActive="true" spatial:sampledField="geometryImage">
+          <spatial:listOfSampledVolumes>
+            <spatial:sampledVolume spatial:id="comp_sampledVolume" spatial:domainType="comp_domainType" spatial:sampledValue="4289374890"/>
+          </spatial:listOfSampledVolumes>
+        </spatial:sampledFieldGeometry>
+        <spatial:parametricGeometry spatial:id="parametricGeometry" spatial:isActive="true">
+          <spatial:spatialPoints spatial:id="spatialPoints" spatial:compression="uncompressed" spatial:arrayDataLength="8" spatial:dataType="double">1 1 1 0 2 0 2 1 </spatial:spatialPoints>
+          <spatial:listOfParametricObjects>
+            <spatial:parametricObject spatial:id="comp_triangles" spatial:polygonType="triangle" spatial:domainType="comp_domainType" spatial:pointIndexLength="6" spatial:compression="uncompressed" spatial:dataType="uint32">3 0 2 0 1 2 </spatial:parametricObject>
+          </spatial:listOfParametricObjects>
+        </spatial:parametricGeometry>
+      </spatial:listOfGeometryDefinitions>
+      <spatial:listOfSampledFields>
+        <spatial:sampledField spatial:id="geometryImage" spatial:dataType="uint32" spatial:numSamples1="3" spatial:numSamples2="1" spatial:interpolationType="nearestNeighbor" spatial:compression="uncompressed" spatial:samplesLength="3">4294967295 4289374890 4283585106</spatial:sampledField>
+      </spatial:listOfSampledFields>
+    </spatial:geometry>
+  </model>
+</sbml>

--- a/test/resources/test_resources.qrc
+++ b/test/resources/test_resources.qrc
@@ -14,6 +14,7 @@
         <file>models/example2D.xml</file>
         <file>models/fish_300x300.xml</file>
         <file>models/non-spatial-multi-compartment.xml</file>
+        <file>models/single-pixel-meshing.xml</file>
         <file>geometry/gt1.png</file>
         <file>geometry/gt2.png</file>
         <file>geometry/gt3.png</file>


### PR DESCRIPTION
- Triangulate
  - check for neighbour with infinite face when adding triangle to compartment
  - if found, we are outside of our boundary lines, i.e. invalid interior point
  - throw exception with error message to set mesh state to invalid
  - resolves #585
- Mesh
  - add getErrorMessage() method to complement isValid()
- TabGeometry
  - display error message instead of empty mesh when mesh is invalid