### PR TITLE
allow user to set geometry size in z-direction

### DIFF
--- a/src/core/common/src/symbolic_t.cpp
+++ b/src/core/common/src/symbolic_t.cpp
@@ -399,11 +399,14 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(utils::symbolicContains("z*unknown(y)", "x") == false);
     REQUIRE(utils::symbolicContains("(cos(symbol))^2+3", "symbol") == true);
   }
-  GIVEN("expressions equal up to double prec in coefficients test equal") {
-    REQUIRE(symEq(QString("0.999999999999"), QString("1")) == false);
+  GIVEN("expressions with relative difference < 1e-13 test equal") {
+    REQUIRE(symEq(QString("0.9999999999"), QString("1")) == false);
+    REQUIRE(symEq(QString("0.99999999999999"), QString("1")) == true);
+    REQUIRE(symEq(QString("9999999999"), QString("10000000000")) == false);
+    REQUIRE(symEq(QString("99999999999999"), QString("100000000000000")) == true);
     REQUIRE(symEq(QString("0.999999999999999999999"), QString("1")) == true);
     REQUIRE(symEq(QString("1e-3*x+y"),
-                  QString("9.9999999999999e-4*x + 1.00000000000001*y")) ==
+                  QString("9.99999999999e-4*x + 1.000000000001*y")) ==
             false);
     REQUIRE(symEq(QString("1e-3*x+y"),
                   QString("9.999999999999999e-4*x + 1.0000000000000001*y")) ==

--- a/src/core/model/inc/model_compartments.hpp
+++ b/src/core/model/inc/model_compartments.hpp
@@ -26,6 +26,7 @@ class ModelGeometry;
 class ModelMembranes;
 class ModelSpecies;
 class ModelReactions;
+class ModelUnits;
 
 class ModelCompartments {
 private:
@@ -38,6 +39,7 @@ private:
   ModelMembranes *modelMembranes = nullptr;
   ModelSpecies *modelSpecies = nullptr;
   ModelReactions *modelReactions = nullptr;
+  const ModelUnits *modelUnits{nullptr};
   simulate::SimulationData *simulationData = nullptr;
   bool hasUnsavedChanges{false};
 
@@ -45,7 +47,7 @@ public:
   ModelCompartments();
   ModelCompartments(libsbml::Model *model, ModelGeometry *geometry,
                     ModelMembranes *membranes, ModelSpecies *species,
-                    ModelReactions *reactions, simulate::SimulationData *data);
+                    ModelReactions *reactions, const ModelUnits *units, simulate::SimulationData *data);
   const QStringList &getIds() const;
   const QStringList &getNames() const;
   const QVector<QRgb> &getColours() const;

--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -30,7 +30,9 @@ struct Settings;
 class ModelGeometry {
 private:
   double pixelWidth{1.0};
+  double pixelDepth{1.0};
   QPointF physicalOrigin{QPointF(0, 0)};
+  double zOrigin{0.0};
   QSizeF physicalSize{QSizeF(0, 0)};
   int numDimensions{3};
   QImage image;
@@ -45,6 +47,7 @@ private:
   int importDimensions(const libsbml::Model *model);
   void convertSBMLGeometryTo3d();
   void writeDefaultGeometryToSBML();
+  void updateCompartmentAndMembraneSizes();
 
 public:
   ModelGeometry();
@@ -59,7 +62,10 @@ public:
   void clear();
   int getNumDimensions() const;
   double getPixelWidth() const;
-  void setPixelWidth(double width);
+  void setPixelWidth(double width, bool updateSBML = true);
+  double getPixelDepth() const;
+  void setPixelDepth(double depth);
+  double getZOrigin() const;
   const QPointF &getPhysicalOrigin() const;
   const QSizeF &getPhysicalSize() const;
   const QImage &getImage() const;

--- a/src/core/model/inc/model_membranes.hpp
+++ b/src/core/model/inc/model_membranes.hpp
@@ -47,7 +47,7 @@ public:
       const std::vector<std::unique_ptr<geometry::Compartment>> &compartments);
   void updateCompartmentImage(const QImage &img);
   void importMembraneIdsAndNames();
-  void exportToSBML(double pixelWidth);
+  void exportToSBML(double pixelArea);
   explicit ModelMembranes(libsbml::Model *model = nullptr);
   ModelMembranes(ModelMembranes &&) noexcept;
   ModelMembranes &operator=(ModelMembranes &&) noexcept;

--- a/src/core/model/inc/model_parameters.hpp
+++ b/src/core/model/inc/model_parameters.hpp
@@ -25,6 +25,7 @@ struct IdName {
 struct SpatialCoordinates {
   IdName x;
   IdName y;
+  IdName z;
 };
 
 struct IdNameValue {

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -6,6 +6,7 @@
 #include "utils.hpp"
 #include "validation.hpp"
 #include "xml_annotation.hpp"
+#include <QFileInfo>
 #include <algorithm>
 #include <sbml/SBMLTransforms.h>
 #include <sbml/SBMLTypes.h>
@@ -14,7 +15,6 @@
 #include <sbml/packages/spatial/extension/SpatialExtension.h>
 #include <stdexcept>
 #include <utility>
-#include <QFileInfo>
 
 namespace sme::model {
 
@@ -65,8 +65,9 @@ void Model::initModelData() {
   // matters, should be possible to reduce coupling here
   modelCompartments =
       ModelCompartments(model, &modelGeometry, &modelMembranes, &modelSpecies,
-                        &modelReactions, &getSimulationData());
-  modelGeometry = ModelGeometry(model, &modelCompartments, &modelMembranes, &settings);
+                        &modelReactions, &modelUnits, &getSimulationData());
+  modelGeometry =
+      ModelGeometry(model, &modelCompartments, &modelMembranes, &settings);
   modelGeometry.importSampledFieldGeometry(model);
   modelGeometry.importParametricGeometry(model, &settings);
   modelParameters = ModelParameters(model, &modelEvents);
@@ -151,7 +152,8 @@ void Model::exportSMEFile(const std::string &filename) {
 void Model::updateSBMLDoc() {
   modelGeometry.writeGeometryToSBML();
   setSbmlAnnotation(doc->getModel(), settings);
-  modelMembranes.exportToSBML(modelGeometry.getPixelWidth());
+  modelMembranes.exportToSBML(modelGeometry.getPixelWidth() *
+                              modelGeometry.getPixelDepth());
 }
 
 QString Model::getXml() {

--- a/src/core/model/src/model_compartments_t.cpp
+++ b/src/core/model/src/model_compartments_t.cpp
@@ -40,13 +40,13 @@ SCENARIO("SBML compartments",
     REQUIRE(c.getIds().size() == 3);
     REQUIRE(c.getIds()[0] == "c1");
     REQUIRE(c.getName("c1") == "Outside");
-    REQUIRE(c.getSize("c1") == dbl_approx(5441));
+    REQUIRE(c.getSize("c1") == dbl_approx(5441000));
     REQUIRE(c.getIds()[1] == "c2");
     REQUIRE(c.getName("c2") == "Cell");
-    REQUIRE(c.getSize("c2") == dbl_approx(4034));
+    REQUIRE(c.getSize("c2") == dbl_approx(4034000));
     REQUIRE(c.getIds()[2] == "c3");
     REQUIRE(c.getName("c3") == "Nucleus");
-    REQUIRE(c.getSize("c3") == dbl_approx(525));
+    REQUIRE(c.getSize("c3") == dbl_approx(525000));
 
     // initial membranes
     REQUIRE(m.getIds().size() == 2);

--- a/src/core/model/src/model_geometry_t.cpp
+++ b/src/core/model/src/model_geometry_t.cpp
@@ -1,12 +1,7 @@
 #include "catch_wrapper.hpp"
 #include "mesh.hpp"
-#include "model_compartments.hpp"
+#include "model.hpp"
 #include "model_geometry.hpp"
-#include "model_membranes.hpp"
-#include "model_parameters.hpp"
-#include "model_reactions.hpp"
-#include "model_settings.hpp"
-#include "model_species.hpp"
 #include "serialization.hpp"
 #include <QFile>
 #include <sbml/SBMLTypes.h>
@@ -37,13 +32,14 @@ SCENARIO("Model geometry",
         libsbml::readSBMLFromString(f.readAll().toStdString().c_str()));
     model::Settings sbmlAnnotation;
     model::ModelCompartments mCompartments;
+    model::ModelUnits mUnits(doc->getModel());
     model::ModelMembranes mMembranes(doc->getModel());
     model::ModelGeometry mGeometry;
     model::ModelSpecies mSpecies;
     model::ModelReactions mReactions(doc->getModel(), &mMembranes);
     utils::SmeFileContents smeFileContents;
     mCompartments = model::ModelCompartments(
-        doc->getModel(), &mGeometry, &mMembranes, &mSpecies, &mReactions,
+        doc->getModel(), &mGeometry, &mMembranes, &mSpecies, &mReactions, &mUnits,
         &smeFileContents.simulationData);
     mGeometry = model::ModelGeometry(doc->getModel(), &mCompartments,
                                      &mMembranes, &sbmlAnnotation);

--- a/src/core/model/src/model_membranes.cpp
+++ b/src/core/model/src/model_membranes.cpp
@@ -142,7 +142,7 @@ void ModelMembranes::updateCompartmentImage(const QImage &img) {
 }
 
 void ModelMembranes::importMembraneIdsAndNames() {
-  if(sbmlModel == nullptr){
+  if (sbmlModel == nullptr) {
     return;
   }
   auto nDim = getNumSpatialDimensions(sbmlModel);
@@ -175,17 +175,17 @@ void ModelMembranes::importMembraneIdsAndNames() {
   }
 }
 
-void ModelMembranes::exportToSBML(double pixelWidth) {
-  if(sbmlModel == nullptr){
+void ModelMembranes::exportToSBML(double pixelArea) {
+  if (sbmlModel == nullptr) {
     SPDLOG_WARN("no sbml model to export to - ignoring");
   }
   // ensure all membranes have a corresponding n-1 dim compartment in SBML
-  auto *geom = getOrCreateGeometry(sbmlModel);
-  auto nDimMinusOne = geom->getNumCoordinateComponents() - 1;
+  auto *geom{getOrCreateGeometry(sbmlModel)};
+  auto nDimMinusOne{geom->getNumCoordinateComponents() - 1};
   for (int i = 0; i < ids.size(); ++i) {
     std::string sId{ids[i].toStdString()};
     SPDLOG_INFO("Membrane id: '{}'", sId);
-    libsbml::Compartment *comp = sbmlModel->getCompartment(sId);
+    auto *comp{sbmlModel->getCompartment(sId)};
     if (comp == nullptr) {
       SPDLOG_INFO("  - creating Membrane compartment in SBML");
       comp = sbmlModel->createCompartment();
@@ -195,8 +195,12 @@ void ModelMembranes::exportToSBML(double pixelWidth) {
     SPDLOG_INFO("  - name: {}", comp->getName());
     comp->setConstant(true);
     comp->setSpatialDimensions(nDimMinusOne);
+    if (comp->isSetUnits()) {
+      // we set the model units, compartment units are then inferred from that
+      comp->unsetUnits();
+    }
     auto nPixels{membranes[static_cast<std::size_t>(i)].getIndexPairs().size()};
-    double area{static_cast<double>(nPixels) * pixelWidth};
+    double area{static_cast<double>(nPixels) * pixelArea};
     SPDLOG_INFO("  - size: {}", area);
     comp->setSize(area);
     auto *scp = dynamic_cast<libsbml::SpatialCompartmentPlugin *>(

--- a/src/core/model/src/model_parameters.cpp
+++ b/src/core/model/src/model_parameters.cpp
@@ -293,7 +293,7 @@ const SpatialCoordinates &ModelParameters::getSpatialCoordinates() const {
 void ModelParameters::setSpatialCoordinates(SpatialCoordinates coords) {
   hasUnsavedChanges = true;
   spatialCoordinates = std::move(coords);
-  auto *x = sbmlModel->getParameter(spatialCoordinates.x.id);
+  auto *x{sbmlModel->getParameter(spatialCoordinates.x.id)};
   if (x == nullptr) {
     SPDLOG_ERROR("x-coordinate parameter '{}' not found in model",
                  spatialCoordinates.x.id);
@@ -302,7 +302,7 @@ void ModelParameters::setSpatialCoordinates(SpatialCoordinates coords) {
   x->setName(spatialCoordinates.x.name);
   SPDLOG_INFO("Setting x-coord parameter '{}' name to '{}'", x->getId(),
               x->getName());
-  auto *y = sbmlModel->getParameter(spatialCoordinates.y.id);
+  auto *y{sbmlModel->getParameter(spatialCoordinates.y.id)};
   if (y == nullptr) {
     SPDLOG_ERROR("y-coordinate parameter '{}' not found in model",
                  spatialCoordinates.y.id);
@@ -311,7 +311,15 @@ void ModelParameters::setSpatialCoordinates(SpatialCoordinates coords) {
   y->setName(spatialCoordinates.y.name);
   SPDLOG_INFO("Setting y-coord parameter '{}' name to '{}'", y->getId(),
               y->getName());
-  // todo: z
+  auto *z{sbmlModel->getParameter(spatialCoordinates.z.id)};
+  if (z == nullptr) {
+    SPDLOG_ERROR("z-coordinate parameter '{}' not found in model",
+                 spatialCoordinates.z.id);
+    return;
+  }
+  z->setName(spatialCoordinates.z.name);
+  SPDLOG_INFO("Setting z-coord parameter '{}' name to '{}'", z->getId(),
+              z->getName());
 }
 
 std::vector<IdName>
@@ -337,8 +345,7 @@ ModelParameters::getSymbols(const QStringList &compartments) const {
   }
   symbols.push_back({spatialCoordinates.x.id, spatialCoordinates.x.name});
   symbols.push_back({spatialCoordinates.y.id, spatialCoordinates.y.name});
-  // todo: use actual z id/name
-  symbols.push_back({"z", "z"});
+  symbols.push_back({spatialCoordinates.z.id, spatialCoordinates.z.name});
   symbols.push_back({"time", "t"});
   return symbols;
 }

--- a/src/core/simulate/src/duneconverter_t.cpp
+++ b/src/core/simulate/src/duneconverter_t.cpp
@@ -120,13 +120,13 @@ SCENARIO("DUNE: DuneConverter",
       ++line;
     }
     REQUIRE(*line++ == "[model.comp.reaction]");
-    REQUIRE(symEq(*line++, "dim_ = -1e-7*x__*dim_"));
-    REQUIRE(symEq(*line++, "x__ = -1e-7*x__*dim_"));
-    REQUIRE(symEq(*line++, "x_ = 1e-7*x__*dim_"));
+    REQUIRE(symEq(*line++, "dim_ = -0.1*x__*dim_"));
+    REQUIRE(symEq(*line++, "x__ = -0.1*x__*dim_"));
+    REQUIRE(symEq(*line++, "x_ = 0.1*x__*dim_"));
     REQUIRE(*line++ == "");
     REQUIRE(*line++ == "[model.comp.reaction.jacobian]");
-    REQUIRE(symEq(*line++, "ddim___ddim_ = -1e-7*x__"));
-    REQUIRE(symEq(*line++, "ddim___dx__ = -1e-7*dim_"));
+    REQUIRE(symEq(*line++, "ddim___ddim_ = -0.1*x__"));
+    REQUIRE(symEq(*line++, "ddim___dx__ = -0.1*dim_"));
     REQUIRE(symEq(*line++, "ddim___dx_ = 0"));
   }
   GIVEN("brusselator model with substitutions") {

--- a/src/core/simulate/src/pde_t.cpp
+++ b/src/core/simulate/src/pde_t.cpp
@@ -26,7 +26,7 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     REQUIRE(symEq(reac.getExpression(0), "A * B * k1"));
     REQUIRE_THROWS(reac.getExpression(1));
     REQUIRE(reac.getConstants(0)[5].first == "comp");
-    REQUIRE(reac.getConstants(0)[5].second == dbl_approx(3149.0));
+    REQUIRE(reac.getConstants(0)[5].second == dbl_approx(3149000.0));
     REQUIRE(reac.getConstants(0)[6].first == "k1");
     REQUIRE(reac.getConstants(0)[6].second == dbl_approx(0.1));
     REQUIRE(reac.getMatrixElement(0, 0) == dbl_approx(-1.0));
@@ -42,16 +42,16 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     model::Model s;
     s.importSBMLFile("tmp.xml");
     simulate::Pde pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"});
-    REQUIRE(symEq(pde.getRHS()[0], "-0.1*x*dim"));
-    REQUIRE(symEq(pde.getRHS()[1], "-0.1*x*dim"));
-    REQUIRE(symEq(pde.getRHS()[2], "0.1*x*dim"));
-    REQUIRE(symEq(pde.getJacobian()[0][0], "-0.1*x"));
-    REQUIRE(symEq(pde.getJacobian()[0][1], "-0.1*dim"));
+    REQUIRE(symEq(pde.getRHS()[0], "-1e5*x*dim"));
+    REQUIRE(symEq(pde.getRHS()[1], "-1e5*x*dim"));
+    REQUIRE(symEq(pde.getRHS()[2], "1e5*x*dim"));
+    REQUIRE(symEq(pde.getJacobian()[0][0], "-1e5*x"));
+    REQUIRE(symEq(pde.getJacobian()[0][1], "-1e5*dim"));
     REQUIRE(symEq(pde.getJacobian()[0][2], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][3], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][4], "0"));
-    REQUIRE(symEq(pde.getJacobian()[2][0], "0.1*x"));
-    REQUIRE(symEq(pde.getJacobian()[2][1], "0.1*dim"));
+    REQUIRE(symEq(pde.getJacobian()[2][0], "1e5*x"));
+    REQUIRE(symEq(pde.getJacobian()[2][1], "1e5*dim"));
     REQUIRE(symEq(pde.getJacobian()[2][2], "0"));
   }
   GIVEN("simple model with relabeling of variables") {
@@ -62,16 +62,16 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     s.importSBMLFile("tmp.xml");
     simulate::Pde pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"},
                       {"dim_", "x__", "x_", "cos__", "cos_"});
-    REQUIRE(symEq(pde.getRHS()[0], "-0.1*x__*dim_"));
-    REQUIRE(symEq(pde.getRHS()[1], "-0.1*x__*dim_"));
-    REQUIRE(symEq(pde.getRHS()[2], "0.1*x__*dim_"));
-    REQUIRE(symEq(pde.getJacobian()[0][0], "-0.1*x__"));
-    REQUIRE(symEq(pde.getJacobian()[0][1], "-0.1*dim_"));
+    REQUIRE(symEq(pde.getRHS()[0], "-1e5*x__*dim_"));
+    REQUIRE(symEq(pde.getRHS()[1], "-1e5*x__*dim_"));
+    REQUIRE(symEq(pde.getRHS()[2], "1e5*x__*dim_"));
+    REQUIRE(symEq(pde.getJacobian()[0][0], "-1e5*x__"));
+    REQUIRE(symEq(pde.getJacobian()[0][1], "-1e5*dim_"));
     REQUIRE(symEq(pde.getJacobian()[0][2], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][3], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][4], "0"));
-    REQUIRE(symEq(pde.getJacobian()[2][0], "0.1*x__"));
-    REQUIRE(symEq(pde.getJacobian()[2][1], "0.1*dim_"));
+    REQUIRE(symEq(pde.getJacobian()[2][0], "1e5*x__"));
+    REQUIRE(symEq(pde.getJacobian()[2][1], "1e5*dim_"));
     REQUIRE(symEq(pde.getJacobian()[2][2], "0"));
   }
   GIVEN("invalid relabeling of variables") {
@@ -83,16 +83,16 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
       s.importSBMLFile("tmp.xml");
       simulate::Pde pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"},
                         {"z", "y"});
-      REQUIRE(symEq(pde.getRHS()[0], "-0.1*x*dim"));
-      REQUIRE(symEq(pde.getRHS()[1], "-0.1*x*dim"));
-      REQUIRE(symEq(pde.getRHS()[2], "0.1*x*dim"));
-      REQUIRE(symEq(pde.getJacobian()[0][0], "-0.1*x"));
-      REQUIRE(symEq(pde.getJacobian()[0][1], "-0.1*dim"));
+      REQUIRE(symEq(pde.getRHS()[0], "-1e5*x*dim"));
+      REQUIRE(symEq(pde.getRHS()[1], "-1e5*x*dim"));
+      REQUIRE(symEq(pde.getRHS()[2], "1e5*x*dim"));
+      REQUIRE(symEq(pde.getJacobian()[0][0], "-1e5*x"));
+      REQUIRE(symEq(pde.getJacobian()[0][1], "-1e5*dim"));
       REQUIRE(symEq(pde.getJacobian()[0][2], "0"));
       REQUIRE(symEq(pde.getJacobian()[0][3], "0"));
       REQUIRE(symEq(pde.getJacobian()[0][4], "0"));
-      REQUIRE(symEq(pde.getJacobian()[2][0], "0.1*x"));
-      REQUIRE(symEq(pde.getJacobian()[2][1], "0.1*dim"));
+      REQUIRE(symEq(pde.getJacobian()[2][0], "1e5*x"));
+      REQUIRE(symEq(pde.getJacobian()[2][1], "1e5*dim"));
       REQUIRE(symEq(pde.getJacobian()[2][2], "0"));
     }
   }
@@ -107,16 +107,16 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     scaleFactors.species = 1.0;
     simulate::Pde pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"},
                       {"dim_", "x__", "x_", "cos__", "cos_"}, scaleFactors);
-    REQUIRE(symEq(pde.getRHS()[0], "-0.02*x__*dim_"));
-    REQUIRE(symEq(pde.getRHS()[1], "-0.02*x__*dim_"));
-    REQUIRE(symEq(pde.getRHS()[2], "0.02*x__*dim_"));
-    REQUIRE(symEq(pde.getJacobian()[0][0], "-0.02*x__"));
-    REQUIRE(symEq(pde.getJacobian()[0][1], "-0.02*dim_"));
+    REQUIRE(symEq(pde.getRHS()[0], "-2e4*x__*dim_"));
+    REQUIRE(symEq(pde.getRHS()[1], "-2e4*x__*dim_"));
+    REQUIRE(symEq(pde.getRHS()[2], "2e4*x__*dim_"));
+    REQUIRE(symEq(pde.getJacobian()[0][0], "-2e4*x__"));
+    REQUIRE(symEq(pde.getJacobian()[0][1], "-2e4*dim_"));
     REQUIRE(symEq(pde.getJacobian()[0][2], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][3], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][4], "0"));
-    REQUIRE(symEq(pde.getJacobian()[2][0], "0.02*x__"));
-    REQUIRE(symEq(pde.getJacobian()[2][1], "0.02*dim_"));
+    REQUIRE(symEq(pde.getJacobian()[2][0], "2e4*x__"));
+    REQUIRE(symEq(pde.getJacobian()[2][1], "2e4*dim_"));
     REQUIRE(symEq(pde.getJacobian()[2][2], "0"));
   }
   GIVEN("rescaling of species & reactions") {
@@ -131,16 +131,16 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
 
     simulate::Pde pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"}, {},
                       scaleFactors);
-    REQUIRE(symEq(pde.getRHS()[0], "-2.7*x*dim"));
-    REQUIRE(symEq(pde.getRHS()[1], "-2.7*x*dim"));
-    REQUIRE(symEq(pde.getRHS()[2], "2.7*x*dim"));
-    REQUIRE(symEq(pde.getJacobian()[0][0], "-2.7*x"));
-    REQUIRE(symEq(pde.getJacobian()[0][1], "-2.7*dim"));
+    REQUIRE(symEq(pde.getRHS()[0], "-2.7e6*x*dim"));
+    REQUIRE(symEq(pde.getRHS()[1], "-2.7e6*x*dim"));
+    REQUIRE(symEq(pde.getRHS()[2], "2.7e6*x*dim"));
+    REQUIRE(symEq(pde.getJacobian()[0][0], "-2.7e6*x"));
+    REQUIRE(symEq(pde.getJacobian()[0][1], "-2.7e6*dim"));
     REQUIRE(symEq(pde.getJacobian()[0][2], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][3], "0"));
     REQUIRE(symEq(pde.getJacobian()[0][4], "0"));
-    REQUIRE(symEq(pde.getJacobian()[2][0], "2.7*x"));
-    REQUIRE(symEq(pde.getJacobian()[2][1], "2.7*dim"));
+    REQUIRE(symEq(pde.getJacobian()[2][0], "2.7e6*x"));
+    REQUIRE(symEq(pde.getJacobian()[2][1], "2.7e6*dim"));
     REQUIRE(symEq(pde.getJacobian()[2][2], "0"));
   }
 }

--- a/src/gui/dialogs/dialoggeometryimage.hpp
+++ b/src/gui/dialogs/dialoggeometryimage.hpp
@@ -12,11 +12,12 @@ class DialogGeometryImage : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogGeometryImage(const QImage &image, double pixelWidth,
+  explicit DialogGeometryImage(const QImage &image, double pixelWidth, double pixelDepth,
                            const sme::model::ModelUnits &modelUnits,
                            QWidget *parent = nullptr);
   ~DialogGeometryImage() override;
   [[nodiscard]] double getPixelWidth() const;
+  [[nodiscard]] double getPixelDepth() const;
   [[nodiscard]] bool imageAltered() const;
   [[nodiscard]] const QImage &getAlteredImage() const;
 
@@ -31,6 +32,8 @@ private:
   QVector<QRgb> colorTable;
   double pixelLocalUnits;
   double pixelModelUnits;
+  double depthLocalUnits;
+  double depthModelUnits;
   const sme::model::ModelUnits &units;
   QString modelUnitSymbol;
 
@@ -40,6 +43,7 @@ private:
   void lblImage_mouseClicked(QRgb col, QPoint point);
   void txtImageWidth_editingFinished();
   void txtImageHeight_editingFinished();
+  void txtImageDepth_editingFinished();
   void spinPixelsX_valueChanged(int value);
   void spinPixelsY_valueChanged(int value);
   void btnResetPixels_clicked();

--- a/src/gui/dialogs/dialoggeometryimage.ui
+++ b/src/gui/dialogs/dialoggeometryimage.ui
@@ -19,35 +19,35 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="0">
-      <widget class="QLabel" name="lblLabelColours">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+     <item row="2" column="1" colspan="3">
+      <widget class="QLineEdit" name="txtImageHeight"/>
+     </item>
+     <item row="1" column="4">
+      <widget class="QComboBox" name="cmbUnitsWidth"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="spinPixelsX">
+       <property name="suffix">
+        <string>px</string>
        </property>
-       <property name="text">
-        <string>Colours:</string>
+       <property name="minimum">
+        <number>1</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <property name="maximum">
+        <number>4096</number>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblLabelImageWidth">
+     <item row="4" column="2">
+      <widget class="QLabel" name="lblLabelPixelsTimes">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Image width:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <string>x</string>
        </property>
       </widget>
      </item>
@@ -84,8 +84,45 @@
      <item row="2" column="4">
       <widget class="QComboBox" name="cmbUnitsHeight"/>
      </item>
-     <item row="2" column="1" colspan="3">
-      <widget class="QLineEdit" name="txtImageHeight"/>
+     <item row="5" column="0">
+      <widget class="QLabel" name="lblLabelColours">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Colours:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QPushButton" name="btnApplyColours">
+       <property name="text">
+        <string>Apply selection</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="2">
+      <widget class="QPushButton" name="btnSelectColours">
+       <property name="text">
+        <string>Select colours...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="4">
+      <widget class="QLabel" name="lblColours">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
      <item row="4" column="4">
       <widget class="QPushButton" name="btnResetPixels">
@@ -98,22 +135,6 @@
       <widget class="QLabel" name="lblPixelSize">
        <property name="text">
         <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="3">
-      <widget class="QLineEdit" name="txtImageWidth"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="QSpinBox" name="spinPixelsX">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>4096</number>
        </property>
       </widget>
      </item>
@@ -133,8 +154,44 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="4">
-      <widget class="QComboBox" name="cmbUnitsWidth"/>
+     <item row="6" column="4">
+      <widget class="QPushButton" name="btnResetColours">
+       <property name="text">
+        <string>Reset colours</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblLabelImageWidth">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Image width:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblLabelImageDepth">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Image depth:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="lblLabelImageHeight">
@@ -152,18 +209,8 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
-      <widget class="QLabel" name="lblLabelPixelsTimes">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>x</string>
-       </property>
-      </widget>
+     <item row="3" column="1" colspan="3">
+      <widget class="QLineEdit" name="txtImageDepth"/>
      </item>
      <item row="7" column="0">
       <widget class="QLabel" name="lblLabelPixelSize">
@@ -181,34 +228,13 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
-      <widget class="QPushButton" name="btnApplyColours">
-       <property name="text">
-        <string>Apply selection</string>
-       </property>
-      </widget>
+     <item row="1" column="1" colspan="3">
+      <widget class="QLineEdit" name="txtImageWidth"/>
      </item>
-     <item row="6" column="4">
-      <widget class="QPushButton" name="btnResetColours">
-       <property name="text">
-        <string>Reset colours</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1" colspan="4">
-      <widget class="QLabel" name="lblColours">
+     <item row="3" column="4">
+      <widget class="QLabel" name="lblUnitsDepth">
        <property name="text">
         <string/>
-       </property>
-       <property name="scaledContents">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1" colspan="2">
-      <widget class="QPushButton" name="btnSelectColours">
-       <property name="text">
-        <string>Select colours...</string>
        </property>
       </widget>
      </item>
@@ -238,6 +264,7 @@
   <tabstop>cmbUnitsWidth</tabstop>
   <tabstop>txtImageHeight</tabstop>
   <tabstop>cmbUnitsHeight</tabstop>
+  <tabstop>txtImageDepth</tabstop>
   <tabstop>spinPixelsX</tabstop>
   <tabstop>spinPixelsY</tabstop>
   <tabstop>btnResetPixels</tabstop>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -474,9 +474,13 @@ void MainWindow::actionEdit_geometry_image_triggered() {
   }
   DialogGeometryImage dialog(model.getGeometry().getImage(),
                              model.getGeometry().getPixelWidth(),
+                             model.getGeometry().getPixelDepth(),
                              model.getUnits());
   if (dialog.exec() == QDialog::Accepted) {
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+    double pixelDepth = dialog.getPixelDepth();
+    SPDLOG_INFO("Set new pixel depth = {}", pixelDepth);
+    model.getGeometry().setPixelDepth(pixelDepth);
     double pixelWidth = dialog.getPixelWidth();
     SPDLOG_INFO("Set new pixel width = {}", pixelWidth);
     model.getGeometry().setPixelWidth(pixelWidth);

--- a/src/gui/tabs/tabgeometry.cpp
+++ b/src/gui/tabs/tabgeometry.cpp
@@ -417,9 +417,9 @@ void TabGeometry::listCompartments_itemSelectionChanged() {
         ui->tabCompartmentGeometry->currentIndex());
     // update compartment size
     double volume{model.getCompartments().getSize(compId)};
-    ui->lblCompSize->setText(QString("Area: %1 %2^2 (%3 pixels)")
+    ui->lblCompSize->setText(QString("Volume: %1 %2 (%3 pixels)")
                                  .arg(QString::number(volume, 'g', 13))
-                                 .arg(model.getUnits().getLength().name)
+                                 .arg(model.getUnits().getVolume().name)
                                  .arg(comp->nPixels()));
   }
 }
@@ -459,10 +459,9 @@ void TabGeometry::listMembranes_itemSelectionChanged() {
   ui->lblCompartmentColour->setPixmap(QPixmap::fromImage(img));
   ui->lblCompartmentColour->setText("");
   // update membrane length
-  double length =
-      static_cast<double>(nPixels) * model.getGeometry().getPixelWidth();
-  ui->lblCompSize->setText(QString("Length: %1 %2 (%3 pixels)")
-                               .arg(QString::number(length, 'g', 13))
+  double area{model.getMembranes().getSize(membraneId)};
+  ui->lblCompSize->setText(QString("Area: %1 %2^2 (%3 pixels)")
+                               .arg(QString::number(area, 'g', 13))
                                .arg(model.getUnits().getLength().name)
                                .arg(nPixels));
   ui->lblCompMesh->setImages(model.getGeometry().getMesh()->getMeshImages(

--- a/src/gui/tabs/tabgeometry_t.cpp
+++ b/src/gui/tabs/tabgeometry_t.cpp
@@ -69,7 +69,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       // select compartments
       REQUIRE(listCompartments->currentItem()->text() == "Outside");
       REQUIRE(txtCompartmentName->text() == "Outside");
-      REQUIRE(lblCompSize->text() == "Area: 5441 m^2 (5441 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 5441000 L (5441 pixels)");
       REQUIRE(tabCompartmentGeometry->currentIndex() == 0);
       REQUIRE(lblCompShape->getImage().pixel(1, 1) == 0xff000200);
       // change compartment name
@@ -86,7 +86,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Cell");
-      REQUIRE(lblCompSize->text() == "Area: 4034 m^2 (4034 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 4034000 L (4034 pixels)");
       REQUIRE(lblCompShape->getImage().pixel(20, 20) == 0xff9061c1);
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Cell");
@@ -95,7 +95,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       sendKeyEvents(listMembranes, {" "});
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(listMembranes->currentItem()->text() == "Outside <-> Cell");
-      REQUIRE(lblCompSize->text() == "Length: 338 m (338 pixels)");
+      REQUIRE(lblCompSize->text() == "Area: 338 m^2 (338 pixels)");
       REQUIRE(txtCompartmentName->text() == "Outside <-> Cell");
       // change membrane name
       txtCompartmentName->setFocus();
@@ -111,7 +111,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Nucleus");
-      REQUIRE(lblCompSize->text() == "Area: 525 m^2 (525 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 525000 L (525 pixels)");
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Nucleus");
       REQUIRE(lblCompShape->getImage().pixel(50, 50) == 0xffc58560);

--- a/test/resources/models/example2D.xml
+++ b/test/resources/models/example2D.xml
@@ -19,11 +19,11 @@
         <spatial:adjacentDomains id="Nucleus0_Cytosol0_membrane_Cytosol0" spatial:domain1="Nucleus_Cytosol_membrane0" spatial:domain2="Cytosol0" spatial:id="Nucleus0_Cytosol0_membrane_Cytosol0"/>
       </spatial:listOfAdjacentDomains>
       <spatial:listOfCoordinateComponents>
-        <spatial:coordinateComponent id="coordx" spatial:id="coordx" spatial:type="cartesianX" spatial:unit="um">
+        <spatial:coordinateComponent id="coordx" spatial:id="coordx" spatial:type="cartesianX" spatial:unit="length">
           <spatial:boundaryMin id="Xmin" spatial:id="Xmin" spatial:value="0.0"/>
           <spatial:boundaryMax id="Xmax" spatial:id="Xmax" spatial:value="174.0"/>
         </spatial:coordinateComponent>
-        <spatial:coordinateComponent id="coordy" spatial:id="coordy" spatial:type="cartesianY" spatial:unit="um">
+        <spatial:coordinateComponent id="coordy" spatial:id="coordy" spatial:type="cartesianY" spatial:unit="length">
           <spatial:boundaryMin id="Ymin" spatial:id="Ymin" spatial:value="0.0"/>
           <spatial:boundaryMax id="Ymax" spatial:id="Ymax" spatial:value="131.0"/>
         </spatial:coordinateComponent>

--- a/test/test_utils/math_test_utils.cpp
+++ b/test/test_utils/math_test_utils.cpp
@@ -11,6 +11,8 @@ bool symEq(const QString &exprA, const QString &exprB) {
   if (a.size() != b.size()) {
     return false;
   }
+  std::cout << "symEq: " << exprA.toStdString() << " == " << exprB.toStdString()
+            << std::endl;
   for (int i = 0; i < a.size(); ++i) {
     auto lhs{parser.parse(a[i].toStdString())};
     auto rhs{parser.parse(b[i].toStdString())};
@@ -30,12 +32,21 @@ bool symEq(const QString &exprA, const QString &exprB) {
         mapSymbolsToNumbers[s] = num;
         num = SymEngine::add(num, SymEngine::number(0.1645344));
       }
-      diff = diff->subs(mapSymbolsToNumbers);
-      std::cout << "numerical result: " << *diff << std::endl;
-      if (std::abs(SymEngine::eval_double(*diff)) > 1e-14) {
+      double numerical_diff =
+          std::abs(SymEngine::eval_double(*diff->subs(mapSymbolsToNumbers)));
+      std::cout << "numerical difference: " << numerical_diff << std::endl;
+      double numerical_sum{0.0};
+      for (const auto &expr : {lhs, rhs}) {
+        numerical_sum +=
+            std::abs(SymEngine::eval_double(*expr->subs(mapSymbolsToNumbers)));
+      }
+      std::cout << "numerical sum: " << numerical_sum << std::endl;
+      double rel_diff{2.0 * numerical_diff / numerical_sum};
+      std::cout << "relative difference: " << rel_diff << std::endl;
+      if (rel_diff > 1e-13) {
         return false;
       } else {
-        std::cout << "is < 1e-14 so assuming expressions are equal"
+        std::cout << "is < 1e-13 so assuming expressions are equal"
                   << std::endl;
       }
     }


### PR DESCRIPTION
- add depth to geometry image dialog
- resolves #582

use/display compartment/membrane sizes in correct units

- use volume units for Compartment sizes
- use area units for Membrane sizes
- resolves #584
