### PR TITLE
version 1.1.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,7 @@ name: Python Wheel Builds
 on: push
 
 env:
-  CIBUILDWHEEL_VERSION: 1.11.1
+  CIBUILDWHEEL_VERSION: 2.0.0
   CIBW_TEST_COMMAND: 'python -m unittest discover -v -s {project}/sme/test'
   CIBW_BUILD_VERBOSITY: 3
   SME_EXTERNAL_SMECORE: 'true'
@@ -16,9 +16,9 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.06.11
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010-pypy_x86_64:2021.06.11
-      CIBW_SKIP: '*-manylinux_i686 *p27-* *p35-*'
+      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.07.13
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.07.13
+      CIBW_SKIP: '*-manylinux_i686'
       CIBW_ENVIRONMENT: 'SME_EXTERNAL_SMECORE=on'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'
     steps:
@@ -42,8 +42,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      CIBW_SKIP: '*p27-* *p35-*'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -66,7 +64,6 @@ jobs:
       run:
         shell: msys2 {0}
     env:
-      CIBW_SKIP: '*p27-* *p35-*'
       CIBW_BUILD: '*-win_amd64'
       SME_EXTRA_CORE_DEFS: '_hypot=hypot;MS_WIN64'
     steps:
@@ -93,7 +90,6 @@ jobs:
       run:
         shell: msys2 {0}
     env:
-      CIBW_SKIP: '*p27-* *p35-*'
       CIBW_BUILD: '*-win32'
       SME_EXTRA_CORE_DEFS: '_hypot=hypot'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## [latest]
+## [1.1.2] - 2021-07-13
+### Added
+- autocomplete when editing maths [#559](https://github.com/spatial-model-editor/spatial-model-editor/issues/559)
+- support for all L3 sbml math in reaction rates (with Pixel simulator) [#569](https://github.com/spatial-model-editor/spatial-model-editor/issues/569)
+- option to invert y-axis of images [#568](https://github.com/spatial-model-editor/spatial-model-editor/issues/568)
+- option to set size of geometry image in third dimension [#582](https://github.com/spatial-model-editor/spatial-model-editor/issues/582)
+- `umol` unit of amount added to built-in units [#600](https://github.com/spatial-model-editor/spatial-model-editor/issues/600)
+
+### Changed
+- simulation length/intervals only loaded from model on 'reset' click or new model load [#565](https://github.com/spatial-model-editor/spatial-model-editor/issues/565)
+- models exported as 3d SBML models (to be consistent with our 3d units for species concentrations and volumes) [#588](https://github.com/spatial-model-editor/spatial-model-editor/issues/588)
+
+### Fixed
+- bug when clicking on simulation results plot selected wrong timepoint [#570](https://github.com/spatial-model-editor/spatial-model-editor/issues/570)
+- reaction rates involving species from unrelated compartments now displays an error, instead of only giving an error on simulation [#552](https://github.com/spatial-model-editor/spatial-model-editor/issues/552)
+- simulation crash when species is changed to constant & simulation data are re-loaded [#561](https://github.com/spatial-model-editor/spatial-model-editor/issues/561)
+- inaccuracy when re-starting a simulation that was stopped early [#388](https://github.com/spatial-model-editor/spatial-model-editor/issues/388)
+- bug where compartment sizes were not updated when compartment image resolution was altered [#583](https://github.com/spatial-model-editor/spatial-model-editor/issues/583)
+- bug where invalid mesh could cause a crash [#585](https://github.com/spatial-model-editor/spatial-model-editor/issues/585)
+- bug where simulating after changing geometry image size could cause a crash [#591](https://github.com/spatial-model-editor/spatial-model-editor/issues/591)
+- incorrect units used for compartment volumes when referenced in reaction rates [#584](https://github.com/spatial-model-editor/spatial-model-editor/issues/584)
+- bug where membrane area could be incorrect on model load [#595](https://github.com/spatial-model-editor/spatial-model-editor/issues/595)
 
 ## [1.1.1] - 2021-05-30
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.1.1
+  VERSION 1.1.2
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 
@@ -59,6 +59,13 @@ set(CMAKE_AUTORCC ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+# stop Qt from defining UNICODE on windows to avoid dune issues: this used to be
+# opt-in, but now done by default for Qt >= 6.1.2. See
+# https://codereview.qt-project.org/c/qt/qtbase/+/350443
+set(SME_QT_DISABLE_UNICODE
+    FALSE
+    CACHE BOOL "Disable Qt UNICODE option")
 
 set(SME_LOG_LEVEL
     "INFO"

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -14,3 +14,9 @@ target_link_libraries(
   PUBLIC sme::core
          benchmark::benchmark
          ${SME_EXTRA_EXE_LIBS})
+
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(benchmark)
+  qt6_disable_unicode_defines(pixel)
+  qt6_disable_unicode_defines(bench)
+endif()

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2021.06.11"
+SME_DEPS_VERSION="2021.07.13"
 OS=$1
 
 set -e -x

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -11,6 +11,10 @@ echo "PATH=$PATH"
 export CMAKE_PREFIX_PATH="C:/smelibs;C:/smelibs/CMake;C:/smelibs/lib/cmake"
 export SME_EXTRA_EXE_LIBS="-static;-static-libgcc;-static-libstdc++"
 export CMAKE_GENERATOR="Unix Makefiles"
+# stop Qt from defining UNICODE on windows to avoid dune issues
+# used to be opt-in, done by default for Qt >= 6.1.2 see
+# https://codereview.qt-project.org/c/qt/qtbase/+/350443
+export SME_QT_DISABLE_UNICODE=TRUE
 export SME_EXTRA_CORE_DEFS="_hypot=hypot"
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
@@ -30,6 +34,7 @@ cmake .. \
   -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
   -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS \
   -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER \
+  -DSME_QT_DISABLE_UNICODE=$SME_QT_DISABLE_UNICODE \
   -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
   -DSME_WITH_TBB=ON
 make -j2 VERBOSE=1

--- a/ci/windows-wheels.sh
+++ b/ci/windows-wheels.sh
@@ -11,6 +11,10 @@ echo "PATH=$PATH"
 export CMAKE_GENERATOR="Unix Makefiles"
 export CMAKE_PREFIX_PATH="C:/smelibs;C:/smelibs/CMake;C:/smelibs/lib/cmake"
 export SME_EXTRA_EXE_LIBS="-static;-static-libgcc;-static-libstdc++"
+# stop Qt from defining UNICODE on windows to avoid dune issues
+# used to be opt-in, done by default for Qt >= 6.1.2 see
+# https://codereview.qt-project.org/c/qt/qtbase/+/350443
+export SME_QT_DISABLE_UNICODE=TRUE
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 export CCACHE_NOHASHDIR="true"
 export SME_EXTERNAL_SMECORE=on
@@ -39,6 +43,7 @@ cmake .. \
   -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
   -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS \
   -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER \
+  -DSME_QT_DISABLE_UNICODE=$SME_QT_DISABLE_UNICODE \
   -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
   -DSME_EXTERNAL_SMECORE=off
 make -j2 core

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -16,9 +16,19 @@ if(BUILD_TESTING)
            testlib)
 endif()
 
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(cli)
+  if(BUILD_TESTING)
+    qt6_disable_unicode_defines(cli_tests)
+  endif()
+endif()
+
 add_subdirectory(src)
 
 add_executable(spatial-cli spatial-cli.cpp)
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(spatial-cli)
+endif()
 target_link_libraries(spatial-cli PRIVATE cli)
 qt_import_plugins(
   spatial-cli

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -47,7 +47,7 @@ Command line parameters
 
 .. code-block:: bash
 
-    Spatial Model Editor CLI v1.1.1
+    Spatial Model Editor CLI v1.1.2
     Usage: ./cli/spatial-cli [OPTIONS] file times image-intervals
 
     Positionals:

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ class CMakeBuild(build_ext):
             "SME_EXTRA_CORE_DEFS",
             "SME_EXTRA_EXE_LIBS",
             "SME_EXTERNAL_SMECORE",
+            "SME_QT_DISABLE_UNICODE",
             "PYTHON_LIBRARY",
             "CMAKE_CXX_COMPILER_LAUNCHER",
             "SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM",
@@ -91,7 +92,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="1.1.1",
+    version="1.1.2",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",

--- a/sme/CMakeLists.txt
+++ b/sme/CMakeLists.txt
@@ -1,12 +1,7 @@
-if(WIN32)
-  # don't use pybind11_add_module() on windows due to issues with flto and
-  # mingw32
-  add_library(sme MODULE)
-  target_link_libraries(sme PRIVATE pybind11::module)
-  set_target_properties(sme PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}"
-                                       SUFFIX "${PYTHON_MODULE_EXTENSION}")
-else()
-  pybind11_add_module(sme MODULE)
+pybind11_add_module(sme MODULE)
+
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(sme)
 endif()
 
 target_link_libraries(sme PRIVATE sme::core ${SME_EXTRA_EXE_LIBS})
@@ -20,10 +15,6 @@ set_target_properties(sme PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # https://github.com/pybind/pybind11/issues/1818#issuecomment-506031452
 target_compile_options(sme
                        PUBLIC $<$<CXX_COMPILER_ID:Clang>:-fsized-deallocation>)
-
-# including python 2.7 headers gives -Wregister warnings with gcc (and errors
-# with clang)
-target_compile_options(sme PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-register>)
 
 qt_import_plugins(
   sme

--- a/sme/README.md
+++ b/sme/README.md
@@ -28,13 +28,13 @@ Supported platforms and python versions:
 
   - CPython: 3.6, 3.7, 3.8, 3.9
 
-  - PyPy: 3.6, 3.7
+  - PyPy: 3.7
 
 - macOS 10.14+
 
   - CPython: 3.6, 3.7, 3.8, 3.9
 
-  - PyPy: 3.6, 3.7
+  - PyPy: 3.7
 
 - windows 64-bit
 
@@ -44,4 +44,4 @@ Supported platforms and python versions:
 
   - CPython: 3.6, 3.7, 3.8, 3.9
 
-  - PyPy: 3.6, 3.7
+  - PyPy: 3.7

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 if(BUILD_GUI)
   add_executable(spatial-model-editor)
+  if(SME_QT_DISABLE_UNICODE)
+    qt6_disable_unicode_defines(spatial-model-editor)
+  endif()
   target_sources(spatial-model-editor PRIVATE spatial-model-editor.cpp icon.rc)
   if(WIN32)
     set_target_properties(spatial-model-editor PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -57,6 +57,13 @@ if(BUILD_TESTING)
   add_library(core_tests STATIC)
 endif()
 
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(core)
+  if(BUILD_TESTING)
+    qt6_disable_unicode_defines(core_tests)
+  endif()
+endif()
+
 # find SymEngine and check it is compiled with LLVM enabled
 find_package(
   SymEngine

--- a/src/core/common/src/version.cpp.in
+++ b/src/core/common/src/version.cpp.in
@@ -1,11 +1,7 @@
 #include "version.hpp"
 
-namespace sme {
-
-namespace utils {
+namespace sme::utils {
 
 const char *const SPATIAL_MODEL_EDITOR_VERSION = "@PROJECT_VERSION@";
-
-}
 
 } // namespace sme

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,14 @@
 add_library(gui STATIC)
-add_library(gui_tests STATIC)
+if(BUILD_TESTING)
+  add_library(gui_tests STATIC)
+endif()
+
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(gui)
+  if(BUILD_TESTING)
+    qt6_disable_unicode_defines(gui_tests)
+  endif()
+endif()
 
 target_sources(gui PRIVATE mainwindow.cpp guiutils.cpp)
 target_include_directories(gui PUBLIC .)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,9 @@ target_link_libraries(
           gui_tests
           cli_tests
           ${SME_EXTRA_EXE_LIBS})
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(tests)
+endif()
 
 if(SME_WITH_QT6)
   find_package(Qt6 QUIET COMPONENTS Test)
@@ -19,6 +22,9 @@ endif()
 set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
 add_library(testlib resources/test_resources.qrc)
+if(SME_QT_DISABLE_UNICODE)
+  qt6_disable_unicode_defines(testlib)
+endif()
 target_link_libraries(
   testlib
   PUBLIC Catch2::Catch2


### PR DESCRIPTION
- cibuildwheel -> 2.0.0
- smedeps -> 2021.07.13
- manylinux -> 2021.07.13
- add SME_QT_DISABLE_UNICODE cmake option
  - stops Qt from defining UNICODE on windows
  - otherwise causes dune compilation problems
  - Qt does this by default from version 6.1.1
  - https://codereview.qt-project.org/c/qt/qtbase/+/350443
- remove pybind11/windows cmake module workaround