### PR TITLE
refactor mouseover location code

### DIFF
--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -25,6 +25,7 @@ namespace model {
 
 class ModelCompartments;
 class ModelMembranes;
+class ModelUnits;
 struct Settings;
 
 class ModelGeometry {
@@ -42,6 +43,7 @@ private:
   libsbml::Model *sbmlModel{nullptr};
   ModelCompartments *modelCompartments{nullptr};
   ModelMembranes *modelMembranes{nullptr};
+  const ModelUnits *modelUnits{nullptr};
   Settings *sbmlAnnotation = nullptr;
   bool hasUnsavedChanges{false};
   int importDimensions(const libsbml::Model *model);
@@ -52,7 +54,7 @@ private:
 public:
   ModelGeometry();
   explicit ModelGeometry(libsbml::Model *model, ModelCompartments *compartments,
-                         ModelMembranes *membranes, Settings *annotation);
+                         ModelMembranes *membranes, const ModelUnits *units, Settings *annotation);
   void importSampledFieldGeometry(const libsbml::Model *model);
   void importParametricGeometry(const libsbml::Model *model,
                                 const Settings *settings);
@@ -68,6 +70,8 @@ public:
   double getZOrigin() const;
   const QPointF &getPhysicalOrigin() const;
   const QSizeF &getPhysicalSize() const;
+  QPointF getPhysicalPoint(const QPoint pixel) const;
+  QString getPhysicalPointAsString(const QPoint pixel) const;
   const QImage &getImage() const;
   mesh::Mesh *getMesh() const;
   bool getIsValid() const;

--- a/src/core/model/inc/model_units.hpp
+++ b/src/core/model/inc/model_units.hpp
@@ -9,9 +9,7 @@ namespace libsbml {
 class Model;
 }
 
-namespace sme {
-
-namespace model {
+namespace sme::model {
 
 struct Unit {
   QString name;
@@ -109,7 +107,5 @@ public:
 double rescale(double val, const Unit &oldUnit, const Unit &newUnit);
 
 double getVolOverL3(const Unit &lengthUnit, const Unit &volumeUnit);
-
-} // namespace model
 
 } // namespace sme

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -67,7 +67,7 @@ void Model::initModelData() {
       ModelCompartments(model, &modelGeometry, &modelMembranes, &modelSpecies,
                         &modelReactions, &modelUnits, &getSimulationData());
   modelGeometry =
-      ModelGeometry(model, &modelCompartments, &modelMembranes, &settings);
+      ModelGeometry(model, &modelCompartments, &modelMembranes, &modelUnits, &settings);
   modelGeometry.importSampledFieldGeometry(model);
   modelGeometry.importParametricGeometry(model, &settings);
   modelParameters = ModelParameters(model, &modelEvents);

--- a/src/core/model/src/model_geometry_t.cpp
+++ b/src/core/model/src/model_geometry_t.cpp
@@ -42,7 +42,7 @@ SCENARIO("Model geometry",
         doc->getModel(), &mGeometry, &mMembranes, &mSpecies, &mReactions, &mUnits,
         &smeFileContents.simulationData);
     mGeometry = model::ModelGeometry(doc->getModel(), &mCompartments,
-                                     &mMembranes, &sbmlAnnotation);
+                                     &mMembranes, &mUnits, &sbmlAnnotation);
     auto &m = mGeometry;
     REQUIRE(m.getIsValid() == false);
     REQUIRE(m.getMesh() == nullptr);
@@ -55,6 +55,9 @@ SCENARIO("Model geometry",
       mGeometry.importSampledFieldGeometry(doc->getModel());
       REQUIRE(m.getHasUnsavedChanges() == true);
       REQUIRE(mGeometry.getHasUnsavedChanges() == true);
+      REQUIRE(mGeometry.getPhysicalPoint({0,0}).x() == dbl_approx(0.0));
+      REQUIRE(mGeometry.getPhysicalPoint({0,0}).y() == dbl_approx(99.0));
+      REQUIRE(mGeometry.getPhysicalPointAsString({0,0}) == "x: 0 m, y: 99 m");
       model::ModelParameters mParameters(doc->getModel());
       simulate::SimulationData data;
       mSpecies = model::ModelSpecies(doc->getModel(), &mCompartments,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -100,7 +100,7 @@ MainWindow::~MainWindow() = default;
 
 void MainWindow::setupTabs() {
   tabGeometry = new TabGeometry(model, ui->lblGeometry,
-                                statusBarPermanentMessage, ui->tabReactions);
+                                statusBar(), ui->tabReactions);
   ui->tabGeometry->layout()->addWidget(tabGeometry);
 
   tabSpecies = new TabSpecies(model, ui->lblGeometry, ui->tabSpecies);
@@ -286,8 +286,7 @@ void MainWindow::validateSBMLDoc(const QString &filename) {
   ui->actionGeometry_scale->setChecked(
       model.getDisplayOptions().showGeometryScale);
   actionGeometry_scale_triggered(model.getDisplayOptions().showGeometryScale);
-  ui->actionInvert_y_axis->setChecked(
-      model.getDisplayOptions().invertYAxis);
+  ui->actionInvert_y_axis->setChecked(model.getDisplayOptions().invertYAxis);
   actionInvert_y_axis_triggered(model.getDisplayOptions().invertYAxis);
   this->setWindowTitle(QString("Spatial Model Editor [%1]").arg(filename));
 }
@@ -472,10 +471,9 @@ void MainWindow::actionEdit_geometry_image_triggered() {
   if (!isValidModelAndGeometryImage()) {
     return;
   }
-  DialogGeometryImage dialog(model.getGeometry().getImage(),
-                             model.getGeometry().getPixelWidth(),
-                             model.getGeometry().getPixelDepth(),
-                             model.getUnits());
+  DialogGeometryImage dialog(
+      model.getGeometry().getImage(), model.getGeometry().getPixelWidth(),
+      model.getGeometry().getPixelDepth(), model.getUnits());
   if (dialog.exec() == QDialog::Accepted) {
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     double pixelDepth = dialog.getPixelDepth();
@@ -524,7 +522,7 @@ void MainWindow::actionGeometry_scale_triggered(bool checked) {
   model.setDisplayOptions(options);
 }
 
-void MainWindow::actionInvert_y_axis_triggered(bool checked){
+void MainWindow::actionInvert_y_axis_triggered(bool checked) {
   ui->lblGeometry->invertYAxis(checked);
   tabGeometry->invertYAxis(checked);
   tabSimulate->invertYAxis(checked);
@@ -532,7 +530,6 @@ void MainWindow::actionInvert_y_axis_triggered(bool checked){
   options.invertYAxis = checked;
   model.setDisplayOptions(options);
 }
-
 
 void MainWindow::actionSimulation_options_triggered() {
   DialogSimulationOptions dialog(model.getSimulationSettings().options);
@@ -613,18 +610,7 @@ void MainWindow::lblGeometry_mouseOver(QPoint point) {
   if (!model.getGeometry().getHasImage()) {
     return;
   }
-  double pixelWidth{model.getGeometry().getPixelWidth()};
-  const auto &origin{model.getGeometry().getPhysicalOrigin()};
-  auto lengthUnit{model.getUnits().getLength().name};
-  auto height{model.getGeometry().getImage().height()};
-  QPointF physical;
-  physical.setX(origin.x() + pixelWidth * static_cast<double>(point.x()));
-  physical.setY(origin.x() +
-                pixelWidth * static_cast<double>(height - 1 - point.y()));
-  statusBar()->showMessage(QString("x=%1 %2, y=%3 %2")
-                               .arg(physical.x())
-                               .arg(lengthUnit)
-                               .arg(physical.y()));
+  statusBar()->showMessage(model.getGeometry().getPhysicalPointAsString(point));
 }
 
 void MainWindow::spinGeometryZoom_valueChanged(int value) {

--- a/src/gui/tabs/tabgeometry.hpp
+++ b/src/gui/tabs/tabgeometry.hpp
@@ -5,9 +5,11 @@
 #include <QWidget>
 #include <memory>
 
+
 class QLabel;
 class QListWidgetItem;
 class QLabelMouseTracker;
+class QStatusBar;
 
 namespace sme::model {
 class Model;
@@ -22,8 +24,8 @@ class TabGeometry : public QWidget {
 
 public:
   explicit TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
-                       QLabel *statusBarMsg, QWidget *parent = nullptr);
-  ~TabGeometry();
+                       QStatusBar *statusBar = nullptr, QWidget *parent = nullptr);
+  ~TabGeometry() override;
   void loadModelData(const QString &selection = {});
   void enableTabs();
   void invertYAxis(bool enable);
@@ -36,7 +38,7 @@ private:
   std::unique_ptr<Ui::TabGeometry> ui;
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
-  QLabel *statusBarPermanentMessage;
+  QStatusBar *statusBar{};
   bool waitingForCompartmentChoice{false};
   bool membraneSelected{false};
 
@@ -46,6 +48,7 @@ private:
   void btnChangeCompartment_clicked();
   void txtCompartmentName_editingFinished();
   void tabCompartmentGeometry_currentChanged(int index);
+  void lblCompShape_mouseOver(QPoint point);
   void lblCompBoundary_mouseClicked(QRgb col, QPoint point);
   void spinBoundaryIndex_valueChanged(int value);
   void spinMaxBoundaryPoints_valueChanged(int value);

--- a/src/gui/tabs/tabgeometry.ui
+++ b/src/gui/tabs/tabgeometry.ui
@@ -276,9 +276,6 @@
                <property name="toolTip">
                 <string>The shape of the compartment</string>
                </property>
-               <property name="statusTip">
-                <string>The shape of the compartment</string>
-               </property>
                <property name="whatsThis">
                 <string>&lt;h4&gt;Compartment Geometry&lt;/h4&gt;
 &lt;p&gt;The compartment geometry is generated from all the pixels in the compartment geometry image on the left that have the colour assigned to this compartment&lt;/p&gt;
@@ -340,6 +337,14 @@
                 <bool>true</bool>
                </property>
                <widget class="QWidget" name="scrollBoundaryLinesContents">
+                <property name="geometry">
+                 <rect>
+                  <x>0</x>
+                  <y>0</y>
+                  <width>797</width>
+                  <height>559</height>
+                 </rect>
+                </property>
                 <layout class="QVBoxLayout" name="verticalLayout">
                  <item>
                   <widget class="QLabelMouseTracker" name="lblCompBoundary" native="true">
@@ -492,7 +497,7 @@
                   <x>0</x>
                   <y>0</y>
                   <width>797</width>
-                  <height>560</height>
+                  <height>559</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/src/gui/tabs/tabgeometry_t.cpp
+++ b/src/gui/tabs/tabgeometry_t.cpp
@@ -18,7 +18,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
   mouseTracker.show();
   waitFor(&mouseTracker);
   QLabel statusBarMsg;
-  auto tab = TabGeometry(model, &mouseTracker, &statusBarMsg);
+  auto tab = TabGeometry(model, &mouseTracker);
   tab.show();
   waitFor(&tab);
   ModalWidgetTimer mwt;


### PR DESCRIPTION
- ModelGeometry
  - add getPhysicalPoint(), getPhysicalPointAsString() methods
- MainWindow
  - use getPhysicalPointAsString() for statusbar text
- TabGeometry
  - display location mouseover status text for lblCompShape
- resolves #578
