### PR TITLE
improve handling of invalid reaction expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [latest]
+### Fixed
+- bug where invalid reaction rate expression caused simulation to crash [#609](https://github.com/spatial-model-editor/spatial-model-editor/issues/609)
+
 ## [1.1.2] - 2021-07-13
 ### Added
 - autocomplete when editing maths [#559](https://github.com/spatial-model-editor/spatial-model-editor/issues/559)

--- a/src/core/common/src/symbolic.cpp
+++ b/src/core/common/src/symbolic.cpp
@@ -186,7 +186,17 @@ void Symbolic::SymEngineImpl::compile(bool doCSE, unsigned optLevel) {
     }
   }
 #endif
-  lambdaLLVM.init(varVec, exprInlined, doCSE, optLevel);
+  try {
+    lambdaLLVM.init(varVec, exprInlined, doCSE, optLevel);
+  } catch (const std::exception &e) {
+    // if SymEngine failed to compile, capture error message
+    SPDLOG_WARN("{}", e.what());
+    valid = false;
+    compiled = false;
+    errorMessage = "Failed to compile expression: ";
+    errorMessage.append(e.what());
+    return;
+  }
   compiled = true;
 }
 
@@ -346,4 +356,4 @@ const std::string &Symbolic::getErrorMessage() const {
   return pSymEngineImpl->errorMessage;
 }
 
-} // namespace sme
+} // namespace sme::utils

--- a/src/core/common/src/symbolic_t.cpp
+++ b/src/core/common/src/symbolic_t.cpp
@@ -403,13 +403,36 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(symEq(QString("0.9999999999"), QString("1")) == false);
     REQUIRE(symEq(QString("0.99999999999999"), QString("1")) == true);
     REQUIRE(symEq(QString("9999999999"), QString("10000000000")) == false);
-    REQUIRE(symEq(QString("99999999999999"), QString("100000000000000")) == true);
+    REQUIRE(symEq(QString("99999999999999"), QString("100000000000000")) ==
+            true);
     REQUIRE(symEq(QString("0.999999999999999999999"), QString("1")) == true);
     REQUIRE(symEq(QString("1e-3*x+y"),
-                  QString("9.99999999999e-4*x + 1.000000000001*y")) ==
-            false);
+                  QString("9.99999999999e-4*x + 1.000000000001*y")) == false);
     REQUIRE(symEq(QString("1e-3*x+y"),
                   QString("9.999999999999999e-4*x + 1.0000000000000001*y")) ==
             true);
+  }
+  GIVEN("expression with 1/0") {
+    // 1/0 evaluates to complex infinity in symengine
+    utils::Symbolic sym("1/0", {}, {}, {});
+    CAPTURE(sym.getErrorMessage());
+    REQUIRE(!sym.isValid());
+    REQUIRE(sym.getErrorMessage() == "Failed to compile expression: LLVMDouble "
+                                     "can only represent real valued infinity");
+  }
+  GIVEN("expression with inf") {
+    // real infinity is ok both for parsing & for llvm compilation
+    utils::Symbolic sym("inf", {}, {}, {});
+    CAPTURE(sym.getErrorMessage());
+    REQUIRE(sym.isValid());
+    REQUIRE(sym.getErrorMessage().empty());
+  }
+  GIVEN("expression with nan") {
+    // nan parses ok but not supported by llvm compilation
+    utils::Symbolic sym("nan", {}, {}, {});
+    CAPTURE(sym.getErrorMessage());
+    REQUIRE(!sym.isValid());
+    REQUIRE(sym.getErrorMessage() ==
+            "Failed to compile expression: Not implemented.");
   }
 }

--- a/src/core/simulate/src/pde.cpp
+++ b/src/core/simulate/src/pde.cpp
@@ -86,6 +86,9 @@ Pde::Pde(const model::Model *doc_ptr,
     SPDLOG_DEBUG("Species {} Reparsing all reaction terms", speciesIDs.at(i));
     // parse expression with symengine to simplify
     utils::Symbolic sym(r.toStdString(), vars, {}, {}, false);
+    if (!sym.isValid()) {
+      throw PdeError(sym.getErrorMessage());
+    }
     // rescale species (but not the extra variables)
     SPDLOG_DEBUG("rescaling species");
     sym.rescale(pdeScaleFactors.species, extraVariables);

--- a/src/core/simulate/src/pde_t.cpp
+++ b/src/core/simulate/src/pde_t.cpp
@@ -35,6 +35,19 @@ SCENARIO("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     REQUIRE_THROWS(reac.getMatrixElement(0, 3));
     REQUIRE_THROWS(reac.getMatrixElement(1, 0));
   }
+  GIVEN("ABtoC model with invalid reaction rate expression") {
+    model::Model s;
+    QFile f(":/models/ABtoC.xml");
+    f.open(QIODevice::ReadOnly);
+    s.importSBMLString(f.readAll().toStdString());
+    s.getReactions().add("r2", "comp", "A * A / idontexist");
+    s.getReactions().setSpeciesStoichiometry("r2", "A", 1.0);
+    s.getReactions().add("r3", "comp", "A / 0");
+    s.getReactions().setSpeciesStoichiometry("r3", "A", 1.0);
+    std::vector<std::string> speciesIDs{"A", "B", "C"};
+    REQUIRE_THROWS_WITH(simulate::Pde(&s, speciesIDs, {"r1", "r2", "r3"}),
+                        "Unknown symbol: idontexist");
+  }
   GIVEN("simple model") {
     std::unique_ptr<libsbml::SBMLDocument> doc(
         libsbml::readSBMLFromString(sbml_test_data::invalid_dune_names().xml));

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -38,7 +38,6 @@ private:
   void doRKSubstep(double dt, double g1, double g2, double g3, double beta,
                    double delta);
   double doRKAdaptive(double dtMax);
-  double doTimestep(double dt, double dtMax);
   std::size_t discardedSteps{0};
   PixelIntegratorType integrator;
   PixelIntegratorError errMax;

--- a/src/core/simulate/src/pixelsim_impl.cpp
+++ b/src/core/simulate/src/pixelsim_impl.cpp
@@ -54,6 +54,13 @@ ReacEval::ReacEval(
   }
   // compile all expressions with symengine
   sym = utils::Symbolic(rhs, sIds, {}, {}, true, doCSE, optLevel);
+  if (!sym.isValid()) {
+    std::string msg{sym.getErrorMessage()};
+    msg.append("\nExpression: \"");
+    msg.append(sym.expr());
+    msg.append("\"");
+    throw ReacEvalError(msg);
+  }
 }
 
 void ReacEval::evaluate(double *output, const double *input) const {

--- a/src/core/simulate/src/pixelsim_impl.hpp
+++ b/src/core/simulate/src/pixelsim_impl.hpp
@@ -28,6 +28,12 @@ class Membrane;
 
 namespace simulate {
 
+class ReacEvalError : public std::runtime_error {
+public:
+  explicit ReacEvalError(const std::string &message)
+      : std::runtime_error(message) {}
+};
+
 class ReacEval {
 private:
   // symengine reaction expression
@@ -35,12 +41,13 @@ private:
 
 public:
   ReacEval() = default;
-  ReacEval(const model::Model &doc, const std::vector<std::string> &speciesID,
-           const std::vector<std::string> &reactionID,
-           double reactionScaleFactor = 1.0, bool doCSE = true,
-           unsigned optLevel = 3, bool timeDependent = false,
-           bool spaceDependent = false,
-           const std::map<std::string, double, std::less<>> &substitutions = {});
+  ReacEval(
+      const model::Model &doc, const std::vector<std::string> &speciesID,
+      const std::vector<std::string> &reactionID,
+      double reactionScaleFactor = 1.0, bool doCSE = true,
+      unsigned optLevel = 3, bool timeDependent = false,
+      bool spaceDependent = false,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
   ReacEval(ReacEval &&) noexcept = default;
   ReacEval(const ReacEval &) = delete;
   ReacEval &operator=(ReacEval &&) noexcept = default;
@@ -151,11 +158,12 @@ private:
   std::size_t nExtraVars{0};
 
 public:
-  SimMembrane(const model::Model &doc, const geometry::Membrane *membrane_ptr,
-              SimCompartment *simCompA, SimCompartment *simCompB,
-              bool doCSE = true, unsigned optLevel = 3,
-              bool timeDependent = false, bool spaceDependent = false,
-              const std::map<std::string, double, std::less<>> &substitutions = {});
+  SimMembrane(
+      const model::Model &doc, const geometry::Membrane *membrane_ptr,
+      SimCompartment *simCompA, SimCompartment *simCompB, bool doCSE = true,
+      unsigned optLevel = 3, bool timeDependent = false,
+      bool spaceDependent = false,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
   SimMembrane(SimMembrane &&) noexcept = default;
   SimMembrane(const SimMembrane &) = delete;
   SimMembrane &operator=(SimMembrane &&) noexcept = default;

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -1410,7 +1410,8 @@ SCENARIO(
     auto mPixel{getModel(":/test/models/membrane-reaction-circle.xml")};
     mDune.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
     simulate::Simulation simDune(mDune);
-    mPixel.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+    mPixel.getSimulationSettings().simulatorType =
+        simulate::SimulatorType::Pixel;
     simulate::Simulation simPixel(mPixel);
     REQUIRE(simDune.getAvgMinMax(0, 1, 0).avg == dbl_approx(0.0));
     REQUIRE(simPixel.getAvgMinMax(0, 1, 0).avg == dbl_approx(0.0));
@@ -1445,7 +1446,8 @@ SCENARIO(
     auto mPixel{getModel(":/test/models/membrane-reaction-pixels.xml")};
     mDune.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
     simulate::Simulation simDune(mDune);
-    mPixel.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+    mPixel.getSimulationSettings().simulatorType =
+        simulate::SimulatorType::Pixel;
     simulate::Simulation simPixel(mPixel);
     REQUIRE(simDune.getAvgMinMax(0, 1, 0).avg == dbl_approx(0.0));
     REQUIRE(simPixel.getAvgMinMax(0, 1, 0).avg == dbl_approx(0.0));
@@ -1841,6 +1843,19 @@ SCENARIO("stop, then continue pixel simulation",
   REQUIRE(m.getSimulationData().timePoints.size() == 4);
 }
 
+SCENARIO("pixel simulation with invalid reaction rate expression",
+         "[core/simulate/simulate][core/simulate][core][simulate]") {
+  auto m{getModel(":/models/ABtoC.xml")};
+  m.getReactions().add("r2", "comp", "A * A / idontexist");
+  m.getReactions().setSpeciesStoichiometry("r2", "A", 1.0);
+  m.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+  REQUIRE(simulate::Simulation(m).errorMessage() ==
+          "Unknown symbol: idontexist");
+  m.getReactions().setRateExpression("r2", "1/0");
+  REQUIRE(simulate::Simulation(m).errorMessage().substr(0, 28) ==
+          "Failed to compile expression");
+}
+
 SCENARIO("Fish model: simulation with piecewise function in reactions",
          "[core/simulate/simulate][core/simulate][core][simulate]") {
   auto m{getModel(":test/models/fish_300x300.xml")};
@@ -1856,5 +1871,6 @@ SCENARIO("Fish model: simulation with piecewise function in reactions",
   m.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
   m.getSimulationData().clear();
   simulate::Simulation simDune(m);
-  REQUIRE(simDune.errorMessage().substr(0, 29) == "IOError [handle_parser_error:");
+  REQUIRE(simDune.errorMessage().substr(0, 29) ==
+          "IOError [handle_parser_error:");
 }

--- a/test/test_utils/catch_wrapper.hpp
+++ b/test/test_utils/catch_wrapper.hpp
@@ -22,6 +22,7 @@ std::ostream &operator<<(std::ostream &os,
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 // add custom Approximation convenience function for doubles
 inline Catch::Approx dbl_approx(double x) {


### PR DESCRIPTION
- catch symengine compilation errors in Symbolic
- check final expression parsed successfully in Pde
- check expression compiled successfully in ReacEval
- resolves #609
