### PR TITLE
update ci

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   quality:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -37,10 +37,10 @@ jobs:
           restore-keys: sonar-${{ github.job }}-${{ matrix.script }}-${{ runner.os }}-
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Get static libs
         run: sudo ./ci/getlibs.sh linux
-      - name: Install dependencies
-        run: ./ci/linux-install.sh
+      - name: Install dependencies (and use clang 12)
+        run: ./ci/linux-install.sh 12
       - name: Run job script
         run: ./ci/${{ matrix.script }}.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Get static libs
       run: sudo ./ci/getlibs.sh linux
     - name: Install dependencies
@@ -56,7 +56,7 @@ jobs:
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Get static libs
         run: sudo ./ci/getlibs.sh osx
       - name: Build script
@@ -99,7 +99,7 @@ jobs:
 
   Release:
     needs: [linux-gui, macos-gui, win64-gui]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # upload binaries to github release if commit is tagged
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,7 @@ name: Python Wheel Builds
 on: push
 
 env:
-  CIBUILDWHEEL_VERSION: 2.0.0
+  CIBUILDWHEEL_VERSION: 2.1.1
   CIBW_TEST_COMMAND: 'python -m unittest discover -v -s {project}/sme/test'
   CIBW_BUILD_VERBOSITY: 3
   SME_EXTERNAL_SMECORE: 'true'
@@ -16,8 +16,8 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.07.13
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.07.13
+      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.09
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.09
       CIBW_SKIP: '*-manylinux_i686'
       CIBW_ENVIRONMENT: 'SME_EXTERNAL_SMECORE=on'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'
@@ -27,7 +27,7 @@ jobs:
         submodules: 'true'
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==$CIBUILDWHEEL_VERSION
     - name: Build wheels
@@ -48,7 +48,7 @@ jobs:
           submodules: 'true'
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Download static libraries
         run: sudo ./ci/getlibs.sh osx
       - name: Build wheels
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Build sdist
         run: python setup.py sdist
       - uses: actions/upload-artifact@v2
@@ -129,7 +129,7 @@ jobs:
   pypi:
     name: Upload to PyPI
     needs: [linux-wheel, macos-wheel, win64-wheel, win32-wheel, sdist]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # upload pypi wheels if commit is tagged with "1.*"
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/1.')
     steps:

--- a/ci/linux-install.sh
+++ b/ci/linux-install.sh
@@ -6,13 +6,10 @@ set -e -x
 
 sudo apt-get update -yy
 
-# temporary fix (?) for https://github.com/actions/virtual-environments/issues/3376
-sudo apt-get remove -yy libgcc-11-dev gcc-11
-
 # install build/test dependencies
 sudo apt-get install -yy ccache xvfb jwm lcov
 
-# install qt5 build dependencies
+# install qt build dependencies
 sudo apt-get install -yy libglu1-mesa-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev '^libxcb.*-dev'
 
 # use gcc 9
@@ -20,10 +17,11 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100
 sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-9 100
 
-# use clang 9
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100
-sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-9 100
+# use specified clang version (or 9 by default)
+CLANG_VERSION=${1:-9}
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-"${CLANG_VERSION}" 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-"${CLANG_VERSION}" 100
+sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-"${CLANG_VERSION}" 100
 
 # check versions
 cmake --version

--- a/ci/linux-wheels.sh
+++ b/ci/linux-wheels.sh
@@ -6,7 +6,16 @@ set -e -x
 
 mkdir /project/build
 cd /project/build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/smelibs -DBUILD_BENCHMARKS=off -DBUILD_GUI=OFF -DBUILD_CLI=off -DBUILD_TESTING=off -DBUILD_PYTHON_LIBRARY=off -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DSME_EXTERNAL_SMECORE=off
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/opt/smelibs \
+  -DBUILD_BENCHMARKS=off \
+  -DBUILD_GUI=OFF \
+  -DBUILD_CLI=off \
+  -DBUILD_TESTING=off \
+  -DBUILD_PYTHON_LIBRARY=off \
+  -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+  -DSME_EXTERNAL_SMECORE=off
 make -j2 core
 make install
 cd ..

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -4,7 +4,7 @@
 
 set -e -x
 
-PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.8.*)
+PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.9.*)
 export PATH="$PYDIR/x64:$PYDIR/x64/Scripts:$PATH"
 echo "PATH=$PATH"
 
@@ -42,7 +42,7 @@ make -j2 VERBOSE=1
 ccache -s
 
 # check dependencies
-objdump.exe -x sme/sme.cp38-win_amd64.pyd > sme_obj.txt
+objdump.exe -x sme/sme.cp39-win_amd64.pyd > sme_obj.txt
 head -n 20 sme_obj.txt
 head -n 1000 sme_obj.txt | grep "DLL Name"
 
@@ -53,7 +53,7 @@ tail -n 100 tests.txt
 
 # python tests
 cd ..
-mv build/sme/sme.cp38-win_amd64.pyd .
+mv build/sme/sme.cp39-win_amd64.pyd .
 python -m unittest discover -s sme/test -v
 
 # display version

--- a/ci/windows-wheels.sh
+++ b/ci/windows-wheels.sh
@@ -4,7 +4,7 @@
 
 set -e -x
 
-PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.8.*)
+PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.9.*)
 export PATH="$PYDIR/x64:$PYDIR/x64/Scripts:$PATH"
 echo "PATH=$PATH"
 


### PR DESCRIPTION
- use ubuntu 20.04 for code quality ci
  - more recent ccache works better with coverage
  - also allows use of latest clang
- bump cibuildwheel version to 2.1.1
  - now builds python 3.10 wheels
- use python 3.9 by default in ci
- manylinux image -> 2021.08.09
