### PR TITLE
python interface: add option to simulate without returning simulation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [latest]
+## [1.1.3] - 2021-08-10
+### Added
+- python interface: add option to simulate without returning the results to reduce RAM usage [#610](https://github.com/spatial-model-editor/spatial-model-editor/issues/610)
+- more detailed error message when a model cannot be loaded [#449](https://github.com/spatial-model-editor/spatial-model-editor/issues/449)
+
 ### Fixed
 - bug where invalid reaction rate expression caused simulation to crash [#609](https://github.com/spatial-model-editor/spatial-model-editor/issues/609)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.13...3.20)
+cmake_minimum_required(VERSION 3.13...3.21)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.1.2
+  VERSION 1.1.3
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="1.1.2",
+    version="1.1.3",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",
@@ -119,6 +119,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/sme/README.md
+++ b/sme/README.md
@@ -26,22 +26,22 @@ Supported platforms and python versions:
 
 - linux
 
-  - CPython: 3.6, 3.7, 3.8, 3.9
+  - CPython: 3.6, 3.7, 3.8, 3.9, 3.10
 
   - PyPy: 3.7
 
 - macOS 10.14+
 
-  - CPython: 3.6, 3.7, 3.8, 3.9
+  - CPython: 3.6, 3.7, 3.8, 3.9, 3.10
 
   - PyPy: 3.7
 
 - windows 64-bit
 
-  - CPython: 3.6, 3.7, 3.8, 3.9
+  - CPython: 3.6, 3.7, 3.8, 3.9, 3.10
+
+  - PyPy: 3.7
 
 - windows 32-bit
 
-  - CPython: 3.6, 3.7, 3.8, 3.9
-
-  - PyPy: 3.7
+  - CPython: 3.6, 3.7, 3.8, 3.9, 3.10

--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -39,11 +39,13 @@ public:
   simulateString(const std::string &lengths, const std::string &intervals,
                  int timeoutSeconds, bool throwOnTimeout,
                  simulate::SimulatorType simulatorType,
-                 bool continueExistingSimulation);
+                 bool continueExistingSimulation,
+                 bool returnResults);
   std::vector<SimulationResult>
   simulateFloat(double simulationTime, double imageInterval, int timeoutSeconds,
                 bool throwOnTimeout, simulate::SimulatorType simulatorType,
-                bool continueExistingSimulation);
+                bool continueExistingSimulation,
+                bool returnResults);
   [[nodiscard]] std::string getStr() const;
 };
 

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -144,20 +144,29 @@ class TestModel(unittest.TestCase):
         res2 = m.simulate(10000, 10000, 1, False)
         self.assertEqual(len(res2), 1)
 
-    def test_import_geometry_from_image(self):
-        imgfile_original = _get_abs_path("concave-cell-nucleus-100x100.png")
-        imgfile_modified = _get_abs_path("modified-concave-cell-nucleus-100x100.png")
-        m = sme.open_example_model()
-        comp_img_0 = m.compartment_image
-        nucl_mask_0 = m.compartments["Nucleus"].geometry_mask
-        m.import_geometry_from_image(imgfile_modified)
-        comp_img_1 = m.compartment_image
-        nucl_mask_1 = m.compartments["Nucleus"].geometry_mask
-        self.assertGreater(_rms(nucl_mask_0), _rms(nucl_mask_1))
-        self.assertNotEqual(comp_img_0, comp_img_1)
-        m.import_geometry_from_image(imgfile_original)
-        comp_img_2 = m.compartment_image
-        nucl_mask_2 = m.compartments["Nucleus"].geometry_mask
-        self.assertEqual(_rms(nucl_mask_0), _rms(nucl_mask_2))
-        self.assertEqual(comp_img_0, comp_img_2)
-        self.assertEqual(nucl_mask_0, nucl_mask_2)
+        # don't return simulation results
+        for sim_type in [sme.SimulatorType.DUNE, sme.SimulatorType.Pixel]:
+            m = sme.open_example_model()
+            sim_results = m.simulate(
+                0.002, 0.001, simulator_type=sim_type, return_results=False
+            )
+            self.assertEqual(len(sim_results), 0)
+
+
+def test_import_geometry_from_image(self):
+    imgfile_original = _get_abs_path("concave-cell-nucleus-100x100.png")
+    imgfile_modified = _get_abs_path("modified-concave-cell-nucleus-100x100.png")
+    m = sme.open_example_model()
+    comp_img_0 = m.compartment_image
+    nucl_mask_0 = m.compartments["Nucleus"].geometry_mask
+    m.import_geometry_from_image(imgfile_modified)
+    comp_img_1 = m.compartment_image
+    nucl_mask_1 = m.compartments["Nucleus"].geometry_mask
+    self.assertGreater(_rms(nucl_mask_0), _rms(nucl_mask_1))
+    self.assertNotEqual(comp_img_0, comp_img_1)
+    m.import_geometry_from_image(imgfile_original)
+    comp_img_2 = m.compartment_image
+    nucl_mask_2 = m.compartments["Nucleus"].geometry_mask
+    self.assertEqual(_rms(nucl_mask_0), _rms(nucl_mask_2))
+    self.assertEqual(comp_img_0, comp_img_2)
+    self.assertEqual(nucl_mask_0, nucl_mask_2)


### PR DESCRIPTION
- add `return_results` boolean option to `sme.Model.simulate()`
- default value 'True', i.e. doesn't change behaviour of any existing code
- minimal short term fix for #610
