### PR TITLE
optionally keep existing compartment colours on image resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## latest
+### Changed
+- compartment colour assignments are now preserved when the geometry image is resized [#587](https://github.com/spatial-model-editor/spatial-model-editor/issues/587)
+
+### Fixed
+- python interface: bug where compartment geometry mask was not updated after geometry image changed [#630](https://github.com/spatial-model-editor/spatial-model-editor/issues/630)
+
 ## [1.1.4] - 2021-08-17
 ### Added
 - python interface: `Model.simulation_results()` provides access to existing model simulation data [#622](https://github.com/spatial-model-editor/spatial-model-editor/issues/622)

--- a/sme/src/sme_compartment.cpp
+++ b/sme/src/sme_compartment.cpp
@@ -72,6 +72,10 @@ Compartment::Compartment(model::Model *sbmlDocWrapper, const std::string &sId)
       reactions.emplace_back(s, reac.toStdString());
     }
   }
+  updateMask();
+}
+
+void Compartment::updateMask() {
   geometry_mask = toPyImageMask(
       s->getCompartments().getCompartment(id.c_str())->getCompartmentImage());
 }

--- a/sme/src/sme_compartment.hpp
+++ b/sme/src/sme_compartment.hpp
@@ -23,6 +23,7 @@ private:
 public:
   Compartment() = default;
   explicit Compartment(model::Model *sbmlDocWrapper, const std::string &sId);
+  void updateMask();
   [[nodiscard]] std::string getName() const;
   void setName(const std::string &name);
   std::vector<Species> species;

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -339,10 +339,6 @@ std::string Model::getName() const { return s->getName().toStdString(); }
 void Model::setName(const std::string &name) { s->setName(name.c_str()); }
 
 void Model::importGeometryFromImage(const std::string &filename) {
-  // store existing compartment colours
-  auto ids{s->getCompartments().getIds()};
-  auto colours{s->getCompartments().getColours()};
-  // import geometry image
   QImage img;
   sme::common::TiffReader tiffReader(filename);
   if (tiffReader.size() > 0) {
@@ -350,12 +346,10 @@ void Model::importGeometryFromImage(const std::string &filename) {
   } else {
     img = QImage(filename.c_str());
   }
-  // this resets all compartment colours
-  s->getGeometry().importGeometryFromImage(img);
+  s->getGeometry().importGeometryFromImage(img, true);
   compartment_image = toPyImageRgb(s->getGeometry().getImage());
-  // try to re-assign previous colour to each compartment
-  for (int i = 0; i < ids.size(); ++i) {
-    s->getCompartments().setColour(ids[i], colours[i]);
+  for (auto &compartment : compartments) {
+    compartment.updateMask();
   }
 }
 

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -165,21 +165,19 @@ class TestModel(unittest.TestCase):
             sim_results2 = m.simulation_results()
             self.assertEqual(len(sim_results2), 3)
 
-
-def test_import_geometry_from_image(self):
-    imgfile_original = _get_abs_path("concave-cell-nucleus-100x100.png")
-    imgfile_modified = _get_abs_path("modified-concave-cell-nucleus-100x100.png")
-    m = sme.open_example_model()
-    comp_img_0 = m.compartment_image
-    nucl_mask_0 = m.compartments["Nucleus"].geometry_mask
-    m.import_geometry_from_image(imgfile_modified)
-    comp_img_1 = m.compartment_image
-    nucl_mask_1 = m.compartments["Nucleus"].geometry_mask
-    self.assertGreater(_rms(nucl_mask_0), _rms(nucl_mask_1))
-    self.assertNotEqual(comp_img_0, comp_img_1)
-    m.import_geometry_from_image(imgfile_original)
-    comp_img_2 = m.compartment_image
-    nucl_mask_2 = m.compartments["Nucleus"].geometry_mask
-    self.assertEqual(_rms(nucl_mask_0), _rms(nucl_mask_2))
-    self.assertEqual(comp_img_0, comp_img_2)
-    self.assertEqual(nucl_mask_0, nucl_mask_2)
+    def test_import_geometry_from_image(self):
+        imgfile_original = _get_abs_path("concave-cell-nucleus-100x100.png")
+        imgfile_modified = _get_abs_path("modified-concave-cell-nucleus-100x100.png")
+        m = sme.open_example_model()
+        comp_img_0 = m.compartment_image
+        nucl_mask_0 = m.compartments["Nucleus"].geometry_mask
+        m.import_geometry_from_image(imgfile_modified)
+        comp_img_1 = m.compartment_image
+        nucl_mask_1 = m.compartments["Nucleus"].geometry_mask
+        self.assertFalse(np.array_equal(nucl_mask_0, nucl_mask_1))
+        self.assertFalse(np.array_equal(comp_img_0, comp_img_1))
+        m.import_geometry_from_image(imgfile_original)
+        comp_img_2 = m.compartment_image
+        nucl_mask_2 = m.compartments["Nucleus"].geometry_mask
+        self.assertTrue(np.array_equal(comp_img_0, comp_img_2))
+        self.assertTrue(np.array_equal(nucl_mask_0, nucl_mask_2))

--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -60,7 +60,7 @@ public:
   void importParametricGeometry(const libsbml::Model *model,
                                 const Settings *settings);
   void importSampledFieldGeometry(const QString &filename);
-  void importGeometryFromImage(const QImage &img);
+  void importGeometryFromImage(const QImage &img, bool keepColourAssignments);
   void updateMesh();
   void clear();
   [[nodiscard]] int getNumDimensions() const;

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -303,6 +303,11 @@ void ModelCompartments::setInteriorPoints(const QString &id,
 void ModelCompartments::setColour(const QString &id, QRgb colour) {
   auto i = ids.indexOf(id);
   if (i < 0) {
+    SPDLOG_WARN("Compartment '{}' not found: ignoring", id.toStdString());
+    return;
+  }
+  if (colour != 0 && !modelGeometry->getImage().colorTable().contains(colour)) {
+    SPDLOG_WARN("Image has no pixels with colour '{:x}': ignoring", colour);
     return;
   }
   hasUnsavedChanges = true;

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -101,7 +101,7 @@ SCENARIO("SBML: import SBML doc without geometry",
   WHEN("import geometry & assign compartments") {
     // import geometry image & assign compartments to colours
     s.getGeometry().importGeometryFromImage(
-        QImage(":/geometry/single-pixels-3x1.png"));
+        QImage(":/geometry/single-pixels-3x1.png"), false);
     s.getCompartments().setColour("compartment0", 0xffaaaaaa);
     s.getCompartments().setColour("compartment1", 0xff525252);
     // export it again
@@ -276,7 +276,7 @@ SCENARIO("SBML: import SBML level 2 document",
 
   // import geometry image & assign compartments to colours
   s.getGeometry().importGeometryFromImage(
-      QImage(":/geometry/single-pixels-3x1.png"));
+      QImage(":/geometry/single-pixels-3x1.png"), false);
   s.getCompartments().setColour("compartment0", 0xffaaaaaa);
   s.getCompartments().setColour("compartment1", 0xff525252);
 
@@ -311,9 +311,7 @@ SCENARIO("SBML: import SBML level 2 document",
     WHEN("exportSBMLFile called") {
       THEN("exported file is a SBML level (3,2) document with spatial "
            "extension enabled & required") {
-        s.exportSBMLFile("export.xml");
-        std::unique_ptr<libsbml::SBMLDocument> doc(
-            libsbml::readSBMLFromFile("export.xml"));
+        auto doc{toSbmlDoc(s)};
         REQUIRE(doc->getLevel() == 3);
         REQUIRE(doc->getVersion() == 2);
         REQUIRE(doc->getPackageRequired("spatial") == true);
@@ -382,7 +380,7 @@ SCENARIO("SBML: create new model, import geometry from image",
     QRgb col = QColor(12, 243, 154).rgba();
     img.setPixel(0, 0, col);
     img.save("tmp.png");
-    s.getGeometry().importGeometryFromImage(QImage("tmp.png"));
+    s.getGeometry().importGeometryFromImage(QImage("tmp.png"), false);
     REQUIRE(s.getIsValid() == true);
     REQUIRE(s.getErrorMessage().isEmpty());
     REQUIRE(s.getGeometry().getHasImage() == true);
@@ -581,7 +579,7 @@ SCENARIO("SBML: ABtoC.xml", "[core/model/model][core/model][core][model]") {
       QRgb col = QColor(144, 97, 193).rgba();
       REQUIRE(img.pixel(50, 50) == col);
       img.save("tmp.png");
-      s.getGeometry().importGeometryFromImage(QImage("tmp.png"));
+      s.getGeometry().importGeometryFromImage(QImage("tmp.png"), false);
       s.getCompartments().setColour("comp", col);
       THEN("getCompartmentImage returns image") {
         REQUIRE(s.getGeometry().getImage().size() == QSize(100, 100));
@@ -948,7 +946,7 @@ SCENARIO("SBML: import multi-compartment SBML doc without spatial geometry",
                 "Henri_Michaelis_Menten__irreversible(A, Km, V)"));
   REQUIRE(reactions.getLocation("ex") == "");
   REQUIRE(symEq(reactions.getRateExpression("ex"), "k1 * D"));
-  geometry.importGeometryFromImage(QImage(":test/geometry/cell.png"));
+  geometry.importGeometryFromImage(QImage(":test/geometry/cell.png"), false);
   auto colours{geometry.getImage().colorTable()};
   REQUIRE(colours.size() == 4);
   // assign each compartment to a colour region in the image

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -11,9 +11,6 @@
 #include <algorithm>
 #include <cmath>
 #include <future>
-#include <sbml/SBMLDocument.h>
-#include <sbml/SBMLReader.h>
-#include <sbml/SBMLWriter.h>
 
 using namespace sme;
 using namespace sme::test;
@@ -32,7 +29,7 @@ SCENARIO("Simulate: very_simple_model, single pixel geometry",
   img.setPixel(0, 1, col2);
   img.setPixel(0, 2, col3);
   img.save("tmp.bmp");
-  s.getGeometry().importGeometryFromImage(QImage("tmp.bmp"));
+  s.getGeometry().importGeometryFromImage(QImage("tmp.bmp"), false);
   s.getGeometry().setPixelWidth(1.0);
   s.getCompartments().setColour("c1", col1);
   s.getCompartments().setColour("c2", col2);

--- a/src/gui/dialogs/dialoggeometryimage.cpp
+++ b/src/gui/dialogs/dialoggeometryimage.cpp
@@ -85,9 +85,9 @@ double DialogGeometryImage::getPixelWidth() const { return pixelModelUnits; }
 
 double DialogGeometryImage::getPixelDepth() const { return depthModelUnits; }
 
-bool DialogGeometryImage::imageAltered() const {
-  return alteredSize || alteredColours;
-}
+bool DialogGeometryImage::imageSizeAltered() const { return alteredSize; }
+
+bool DialogGeometryImage::imageColoursAltered() const { return alteredColours; }
 
 const QImage &DialogGeometryImage::getAlteredImage() const {
   return ui->lblImage->getImage();

--- a/src/gui/dialogs/dialoggeometryimage.hpp
+++ b/src/gui/dialogs/dialoggeometryimage.hpp
@@ -19,7 +19,8 @@ public:
   ~DialogGeometryImage() override;
   [[nodiscard]] double getPixelWidth() const;
   [[nodiscard]] double getPixelDepth() const;
-  [[nodiscard]] bool imageAltered() const;
+  [[nodiscard]] bool imageSizeAltered() const;
+  [[nodiscard]] bool imageColoursAltered() const;
   [[nodiscard]] const QImage &getAlteredImage() const;
 
 private:

--- a/src/gui/dialogs/dialoggeometryimage_t.cpp
+++ b/src/gui/dialogs/dialoggeometryimage_t.cpp
@@ -41,7 +41,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(0.01));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets width to 1e-8, pixel size -> 1e-10") {
       mwt.addUserAction({"1", "e", "-", "8"});
@@ -49,7 +50,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(1e-10));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets height to 10, pixel size -> 0.2") {
       mwt.addUserAction({"Tab", "Tab", "1", "0"});
@@ -57,7 +59,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(0.2));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets height to 10, units to dm, pixel size -> 0.02") {
       mwt.addUserAction({"Tab", "Down", "Tab", "1", "0"});
@@ -65,7 +68,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(0.02));
       REQUIRE(dim.getPixelDepth() == dbl_approx(0.1));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets height to 10, units to cm, pixel size -> 0.002") {
       mwt.addUserAction({"Tab", "Down", "Down", "Tab", "1", "0"});
@@ -73,7 +77,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(0.002));
       REQUIRE(dim.getPixelDepth() == dbl_approx(0.01));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets width to 9 & units to dm, then height 10, units um,"
          " pixel size -> 0.0000002") {
@@ -83,7 +88,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(0.0000002));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1e-6));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("user sets depth to 4, no change of units") {
       mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Backspace", "4"});
@@ -91,7 +97,8 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
       REQUIRE(dim.getPixelDepth() == dbl_approx(4.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("default units changed to mm, user sets width = 1, units = m") {
       modelUnits.setLengthIndex(3); // mm
@@ -102,17 +109,20 @@ SCENARIO("DialogGeometryImage",
       dim2.exec();
       REQUIRE(dim2.getPixelWidth() == dbl_approx(10.0));
       REQUIRE(dim2.getPixelDepth() == dbl_approx(1000.0));
-      REQUIRE(dim2.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
     }
     WHEN("x pixels reduced from 100 to 98") {
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Down"});
       mwt.start();
       dim.exec();
-      REQUIRE(dim.imageAltered() == true);
+      REQUIRE(dim.imageSizeAltered() == true);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0 / 0.98));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
       REQUIRE(dim.getAlteredImage().width() == 98);
@@ -120,13 +130,15 @@ SCENARIO("DialogGeometryImage",
     }
     WHEN("y pixels reduced from 50 to 5") {
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "5"});
       mwt.start();
       dim.exec();
-      REQUIRE(dim.imageAltered() == true);
+      REQUIRE(dim.imageSizeAltered() == true);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getPixelWidth() == dbl_approx(10.0));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
       REQUIRE(dim.getAlteredImage().width() == 10);
@@ -134,14 +146,16 @@ SCENARIO("DialogGeometryImage",
     }
     WHEN("x pixels reduced, y pixels reduced, reset pixels pressed") {
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Tab", "5",
                          "Tab", "Space", "Tab", "Tab", "Tab"});
       mwt.start();
       dim.exec();
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       // width/height both altered as aspect ratio changes slightly due to
@@ -151,7 +165,8 @@ SCENARIO("DialogGeometryImage",
     }
     WHEN("select colours pressed, then reset colours") {
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab",
@@ -160,14 +175,16 @@ SCENARIO("DialogGeometryImage",
       dim.exec();
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
     }
     WHEN("select colours pressed, then one chosen") {
       dim.show();
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == false);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == false);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       REQUIRE(dim.getAlteredImage().colorCount() == 3);
@@ -176,7 +193,8 @@ SCENARIO("DialogGeometryImage",
       sendMouseClick(btnApplyColours);
       REQUIRE(dim.getPixelWidth() == dbl_approx(1.0));
       REQUIRE(dim.getPixelDepth() == dbl_approx(1.0));
-      REQUIRE(dim.imageAltered() == true);
+      REQUIRE(dim.imageSizeAltered() == false);
+      REQUIRE(dim.imageColoursAltered() == true);
       REQUIRE(dim.getAlteredImage().width() == 100);
       REQUIRE(dim.getAlteredImage().height() == 50);
       REQUIRE(dim.getAlteredImage().colorCount() == 1);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -442,7 +442,7 @@ void MainWindow::menuExample_geometry_image_triggered(const QAction *action) {
 void MainWindow::importGeometryImage(const QImage &image) {
   QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   tabSimulate->reset();
-  model.getGeometry().importGeometryFromImage(image);
+  model.getGeometry().importGeometryFromImage(image, false);
   ui->tabMain->setCurrentIndex(0);
   tabMain_currentChanged(0);
   // set default pixel width in case user doesn't set image physical size
@@ -480,16 +480,18 @@ void MainWindow::actionEdit_geometry_image_triggered() {
       model.getGeometry().getPixelDepth(), model.getUnits());
   if (dialog.exec() == QDialog::Accepted) {
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    double pixelDepth = dialog.getPixelDepth();
+    double pixelDepth{dialog.getPixelDepth()};
     SPDLOG_INFO("Set new pixel depth = {}", pixelDepth);
     model.getGeometry().setPixelDepth(pixelDepth);
-    double pixelWidth = dialog.getPixelWidth();
+    double pixelWidth{dialog.getPixelWidth()};
     SPDLOG_INFO("Set new pixel width = {}", pixelWidth);
     model.getGeometry().setPixelWidth(pixelWidth);
     tabSimulate->reset();
-    if (dialog.imageAltered()) {
+    if (dialog.imageSizeAltered() || dialog.imageColoursAltered()) {
       SPDLOG_INFO("Importing altered geometry image");
-      model.getGeometry().importGeometryFromImage(dialog.getAlteredImage());
+      bool keepColourAssignments{!dialog.imageColoursAltered()};
+      model.getGeometry().importGeometryFromImage(dialog.getAlteredImage(),
+                                                  keepColourAssignments);
       ui->tabMain->setCurrentIndex(0);
       tabMain_currentChanged(0);
     }

--- a/test/test_utils/model_test_utils.cpp
+++ b/test/test_utils/model_test_utils.cpp
@@ -26,25 +26,33 @@ getSbmlDoc(const QString &filename) {
       libsbml::readSBMLFromString(getXml(filename).c_str())};
 }
 
-model::Model getExampleModel(Mod exampleModel) {
+static const char *getExampleFilename(Mod exampleModel) {
   switch (exampleModel) {
   case Mod::ABtoC:
-    return getModel(":/models/ABtoC.xml");
+    return ":/models/ABtoC.xml";
   case Mod::Brusselator:
-    return getModel(":/models/brusselator-model.xml");
+    return ":/models/brusselator-model.xml";
   case Mod::CircadianClock:
-    return getModel(":/models/circadian-clock.xml");
+    return ":/models/circadian-clock.xml";
   case Mod::GrayScott:
-    return getModel(":/models/gray-scott.xml");
+    return ":/models/gray-scott.xml";
   case Mod::LiverSimplified:
-    return getModel(":/models/liver-simplified.xml");
+    return ":/models/liver-simplified.xml";
   case Mod::LiverCells:
-    return getModel(":/models/liver-cells.xml");
+    return ":/models/liver-cells.xml";
   case Mod::SingleCompartmentDiffusion:
-    return getModel(":/models/single-compartment-diffusion.xml");
+    return ":/models/single-compartment-diffusion.xml";
   case Mod::VerySimpleModel:
-    return getModel(":/models/very-simple-model.xml");
+    return ":/models/very-simple-model.xml";
   }
+}
+
+model::Model getExampleModel(Mod exampleModel) {
+  return getModel(getExampleFilename(exampleModel));
+}
+
+std::unique_ptr<libsbml::SBMLDocument> getExampleSbmlDoc(Mod exampleModel) {
+  return getSbmlDoc(getExampleFilename(exampleModel));
 }
 
 model::Model getTestModel(const QString &filename) {

--- a/test/test_utils/model_test_utils.hpp
+++ b/test/test_utils/model_test_utils.hpp
@@ -26,6 +26,8 @@ model::Model getExampleModel(Mod exampleModel);
 
 model::Model getTestModel(const QString &filename);
 
+std::unique_ptr<libsbml::SBMLDocument> getExampleSbmlDoc(Mod exampleModel);
+
 std::unique_ptr<libsbml::SBMLDocument> getTestSbmlDoc(const QString &filename);
 
 std::unique_ptr<libsbml::SBMLDocument> toSbmlDoc(model::Model &model);


### PR DESCRIPTION
- ModelGeometry::importGeometryFromImage: add keepColourAssignments option
- DialogGeometryImage: separate imageSizeAltered() and imageColoursAltered()
- ModelCompartments::setColour: now a no-op if no pixels of that colour in image
- refactor python sme to use this functionality
