### PR TITLE
fix slow geometry::Compartment construction with no valid pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - python interface: bug where compartment geometry mask was not updated after geometry image changed [#630](https://github.com/spatial-model-editor/spatial-model-editor/issues/630)
+- slow loading of models with large geometry images [#632](https://github.com/spatial-model-editor/spatial-model-editor/issues/632)
 
 ## [1.1.4] - 2021-08-17
 ### Added

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -101,7 +101,9 @@ Compartment::Compartment(std::string compId, const QImage &img, QRgb col)
 #endif
 
   // for pixels outside compartment, find nearest pixel in compartment
-  fillMissingByDilation(arrayPoints, img.width(), img.height(), invalidIndex);
+  if (!ix.empty()) {
+    fillMissingByDilation(arrayPoints, img.width(), img.height(), invalidIndex);
+  }
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
   saveDebuggingIndicesImage(arrayPoints, img.size(), ixIndex,

--- a/src/core/model/src/geometry_bench.cpp
+++ b/src/core/model/src/geometry_bench.cpp
@@ -4,6 +4,15 @@
 using namespace sme;
 
 template <typename T>
+static void geometry_Compartment_zero(benchmark::State &state) {
+  T data;
+  geometry::Compartment compartment;
+  for (auto _ : state) {
+    compartment = geometry::Compartment("id", data.img, 0);
+  }
+}
+
+template <typename T>
 static void geometry_Compartment(benchmark::State &state) {
   T data;
   geometry::Compartment compartment;
@@ -46,6 +55,7 @@ static void geometry_Field_getConcentrationImageArray(benchmark::State &state) {
   }
 }
 
+SME_BENCHMARK(geometry_Compartment_zero);
 SME_BENCHMARK(geometry_Compartment);
 SME_BENCHMARK(geometry_Membrane);
 SME_BENCHMARK(geometry_Field);


### PR DESCRIPTION
- skip fillMissingByDilation step if compartment has no pixels
- resolves #632
