### PR TITLE
remove parametric import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - python interface: bug where compartment geometry mask was not updated after geometry image changed [#630](https://github.com/spatial-model-editor/spatial-model-editor/issues/630)
 - slow loading of models with large geometry images [#632](https://github.com/spatial-model-editor/spatial-model-editor/issues/632)
+- avoid constructing mesh twice on model load [#597](https://github.com/spatial-model-editor/spatial-model-editor/issues/597)
 
 ## [1.1.4] - 2021-08-17
 ### Added

--- a/src/core/model/inc/model_geometry.hpp
+++ b/src/core/model/inc/model_geometry.hpp
@@ -57,8 +57,6 @@ public:
                          ModelMembranes *membranes, const ModelUnits *units,
                          Settings *annotation);
   void importSampledFieldGeometry(const libsbml::Model *model);
-  void importParametricGeometry(const libsbml::Model *model,
-                                const Settings *settings);
   void importSampledFieldGeometry(const QString &filename);
   void importGeometryFromImage(const QImage &img, bool keepColourAssignments);
   void updateMesh();

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -71,7 +71,6 @@ void Model::initModelData() {
       settings.get());
   modelCompartments->setGeometryPtr(modelGeometry.get());
   modelGeometry->importSampledFieldGeometry(model);
-  modelGeometry->importParametricGeometry(model, settings.get());
   modelParameters = std::make_unique<ModelParameters>(model);
   modelSpecies = std::make_unique<ModelSpecies>(
       model, modelCompartments.get(), modelGeometry.get(),

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -247,16 +247,6 @@ void ModelGeometry::importSampledFieldGeometry(const libsbml::Model *model) {
   exportSampledFieldGeometry(geom, image);
 }
 
-void ModelGeometry::importParametricGeometry(const libsbml::Model *model,
-                                             const Settings *settings) {
-  auto importedMesh = importParametricGeometryFromSBML(
-      model, this, modelCompartments, settings);
-  if (importedMesh != nullptr) {
-    hasUnsavedChanges = true;
-    mesh = std::move(importedMesh);
-  }
-}
-
 void ModelGeometry::importSampledFieldGeometry(const QString &filename) {
   std::unique_ptr<libsbml::SBMLDocument> doc{
       libsbml::readSBMLFromFile(filename.toStdString().c_str())};
@@ -301,8 +291,9 @@ void ModelGeometry::updateMesh() {
   hasUnsavedChanges = true;
   const auto &colours{modelCompartments->getColours()};
   const auto &ids{modelCompartments->getIds()};
+  const auto &meshParams{sbmlAnnotation->meshParameters};
   mesh = std::make_unique<mesh::Mesh>(
-      image, std::vector<std::size_t>{}, std::vector<std::size_t>{}, pixelWidth,
+      image, meshParams.maxPoints, meshParams.maxAreas, pixelWidth,
       physicalOrigin, common::toStdVec(colours));
   for (int i = 0; i < ids.size(); ++i) {
     modelCompartments->setInteriorPoints(


### PR DESCRIPTION
- no longer required, it just duplicates initial mesh construction using imported mesh params
- these mesh params are now available at initial mesh construction time, so use them there instead
- resolves #597
