### PR TITLE
Add access to all example models from python sme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## latest
+### Added
+- python interface: access to all built-in example models [#637](https://github.com/spatial-model-editor/spatial-model-editor/pull/637)
+
 ### Changed
 - compartment colour assignments are now preserved when the geometry image is resized [#587](https://github.com/spatial-model-editor/spatial-model-editor/issues/587)
 

--- a/sme/src/sme_module.cpp
+++ b/sme/src/sme_module.cpp
@@ -38,8 +38,27 @@ void pybindModule(pybind11::module &m) {
             Model: the spatial model
         )");
   m.def("open_example_model", openExampleModel,
+        pybind11::arg("name") = "very-simple-model",
         R"(
         opens a built in example spatial model
+
+        The model name can optionally be specified to one of the following built
+        in models:
+
+        * "ABtoC"
+        * "brusselator-model"
+        * "circadian-clock"
+        * "gray-scott"
+        * "liver-simplified"
+        * "liver-cells"
+        * "single-compartment-diffusion"
+        * "very-simple-model"
+
+        If the name is not specified the the default
+        example model is "very-simple-model".
+
+        Args:
+            name (str, optional): name of the example model to open, default: "very-simple-model"
 
         Returns:
             Model: the example spatial model
@@ -67,14 +86,16 @@ Model openFile(const std::string &filename) { return Model(filename); }
 
 Model openSbmlFile(const std::string &filename) { return Model(filename); }
 
-Model openExampleModel() {
+Model openExampleModel(const std::string &name) {
   Model m;
   std::string xml;
-  if (QFile f(":/models/very-simple-model.xml");
+  if (QFile f(QString(":/models/%1.xml").arg(name.c_str()));
       f.open(QIODevice::ReadOnly | QIODevice::Text)) {
     xml = f.readAll().toStdString();
   } else {
-    throw SmeInvalidArgument("Failed to open example model");
+    throw SmeInvalidArgument("Failed to open example model '" + name +
+                             "'. Type help(sme.open_example_model) to see the "
+                             "available built-in models.");
   }
   m.importSbmlString(xml);
   return m;

--- a/sme/src/sme_module.hpp
+++ b/sme/src/sme_module.hpp
@@ -9,6 +9,6 @@ void pybindModule(pybind11::module &m);
 
 Model openFile(const std::string &filename);
 Model openSbmlFile(const std::string &filename);
-Model openExampleModel();
+Model openExampleModel(const std::string &name);
 
 } // namespace sme

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -35,6 +35,22 @@ class TestModel(unittest.TestCase):
         m.name = "Model !"
         self.assertEqual(m.name, "Model !")
 
+        self.assertRaises(
+            sme.InvalidArgument, lambda: sme.open_example_model("idontexist")
+        )
+        self.assertRaises(sme.InvalidArgument, lambda: sme.open_example_model(""))
+        self.assertRaises(TypeError, lambda: sme.open_example_model([1, 2, 3]))
+
+        m = sme.open_example_model("brusselator-model")
+        self.assertEqual(repr(m), "<sme.Model named 'The Brusselator'>")
+        self.assertEqual(len(m.compartments), 1)
+        self.assertEqual(len(m.membranes), 0)
+
+        m = sme.open_example_model("gray-scott")
+        self.assertEqual(repr(m), "<sme.Model named 'Gray-Scott Model'>")
+        self.assertEqual(len(m.compartments), 1)
+        self.assertEqual(len(m.membranes), 0)
+
     def test_export_sbml_file(self):
         m = sme.open_example_model()
         m.name = "Mod"


### PR DESCRIPTION
- `Model.open_example_model("abc")` now tries to open ":/models/abc.xml"
- if this fails, throws exception
- default behaviour unchanged
