### PR TITLE
add gray scott to sim sme notebook

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,11 @@
 
 version: 2
 
+build:
+  image: latest
+  apt_packages:
+    - ffmpeg
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/developer/core.rst
+++ b/docs/developer/core.rst
@@ -54,7 +54,7 @@ Simulating the model, either with Pixel or dune-copasi.
 .. _core-common:
 
 ``sme::common``
---------------
+---------------
 
 Symbolic math, TIFF import/export, other utility functions.
 

--- a/docs/sme/notebooks/visualization.ipynb
+++ b/docs/sme/notebooks/visualization.ipynb
@@ -59,9 +59,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "species = [\"B_nucl\", \"B_cell\", \"B_out\"]\n",
+    "species = [\"B_cell\", \"B_out\"]\n",
     "\n",
-    "fig, axs = plt.subplots(ncols=len(species), figsize=(24, 6))\n",
+    "fig, axs = plt.subplots(constrained_layout=True, ncols=len(species), figsize=(9, 4))\n",
     "\n",
     "# set normalization of each plot to maximum concentration of species over entire simulation\n",
     "norms = []\n",
@@ -80,7 +80,12 @@
     "    artist = []\n",
     "    for spec, ax, norm in zip(species, axs, norms):\n",
     "        artist.append(\n",
-    "            ax.imshow(sim_result.species_concentration[spec], animated=True, norm=norm)\n",
+    "            ax.imshow(\n",
+    "                sim_result.species_concentration[spec],\n",
+    "                animated=True,\n",
+    "                norm=norm,\n",
+    "                interpolation=None,\n",
+    "            )\n",
     "        )\n",
     "        artist.append(\n",
     "            ax.text(\n",
@@ -97,8 +102,65 @@
     "# make an animation from the list of artists\n",
     "anim = animation.ArtistAnimation(fig, artists, interval=200, blit=True, repeat=False)\n",
     "plt.close()\n",
-    "HTML(anim.to_jshtml())"
+    "HTML(anim.to_html5_video())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gray-Scott Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# simulate for a few different reaction parameter values & store concentrations of species V\n",
+    "gray_scott = sme.open_example_model(\"gray-scott\")\n",
+    "fs = [\"0.03\", \"0.04\", \"0.05\"]\n",
+    "vs = []\n",
+    "for f in fs:\n",
+    "    gray_scott.parameters[\"f\"].value = f\n",
+    "    sim_results = gray_scott.simulate(\n",
+    "        simulation_time=10000.0,\n",
+    "        image_interval=100,\n",
+    "        simulator_type=sme.SimulatorType.Pixel,\n",
+    "    )\n",
+    "    times = [r.time_point for r in sim_results]\n",
+    "    vs.append([r.species_concentration[\"V\"] for r in sim_results])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(constrained_layout=True, nrows=len(fs), figsize=(9, 16))\n",
+    "for ax, f in zip(axs, fs):\n",
+    "    ax.set_title(f\"f = {f}\")\n",
+    "\n",
+    "artists = []\n",
+    "for i in range(len(vs[0])):\n",
+    "    artist = []\n",
+    "    for ax, v in zip(axs, vs):\n",
+    "        artist.append(ax.imshow(v[i], animated=True, interpolation=None))\n",
+    "    artists.append(artist)\n",
+    "\n",
+    "anim = animation.ArtistAnimation(fig, artists, interval=200, blit=True, repeat=False)\n",
+    "plt.close()\n",
+    "HTML(anim.to_html5_video())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Add access to all example models from python sme
- add gray-scott example to visualization notebook
