### PR TITLE
bump rtd versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,6 @@ formats:
   - pdf
 
 python:
-  version: 3
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,6 @@ myst_parser
 nbsphinx
 numpy
 pandoc
-sme
-sphinx<4
+https://github.com/spatial-model-editor/spatial-model-editor/releases/latest/download/sme-1.1.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+sphinx==4.1.2
 sphinx_rtd_theme


### PR DESCRIPTION
- sme -> cp38 wheel from latest github release instead of pypi release
- python -> 3.8
- sphinx -> 4.1.2