### PR TITLE
add species initial concentrations to sme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## latest
 ### Added
 - python interface: access to all built-in example models [#637](https://github.com/spatial-model-editor/spatial-model-editor/pull/637)
+- python interface: view and edit uniform/analytic/image species initial concentrations [#644](https://github.com/spatial-model-editor/spatial-model-editor/issues/644)
 
 ### Changed
 - compartment colour assignments are now preserved when the geometry image is resized [#587](https://github.com/spatial-model-editor/spatial-model-editor/issues/587)
@@ -11,6 +12,7 @@
 - python interface: bug where compartment geometry mask was not updated after geometry image changed [#630](https://github.com/spatial-model-editor/spatial-model-editor/issues/630)
 - slow loading of models with large geometry images [#632](https://github.com/spatial-model-editor/spatial-model-editor/issues/632)
 - avoid constructing mesh twice on model load [#597](https://github.com/spatial-model-editor/spatial-model-editor/issues/597)
+- crash when importing geometry image after importing non-spatial model [#651](https://github.com/spatial-model-editor/spatial-model-editor/issues/651)
 
 ## [1.1.4] - 2021-08-17
 ### Added

--- a/sme/src/sme_common.hpp
+++ b/sme/src/sme_common.hpp
@@ -74,4 +74,23 @@ template <typename T> void bindList(pybind11::module &m, const char *typeName) {
           pybind11::keep_alive<0, 1>());
 }
 
+// return the contents of a std::vector as an ndarray, with optional shape,
+// without making a copy of the data, based on
+// https://github.com/pybind/pybind11/issues/1042#issuecomment-642215028
+template <typename T>
+static inline pybind11::array_t<T>
+as_ndarray(std::vector<T> &&v, const std::vector<ssize_t> &shape = {}) {
+  auto data{v.data()};
+  auto size{static_cast<ssize_t>(v.size())};
+  auto ptr{std::make_unique<std::vector<T>>(std::move(v))};
+  auto capsule{pybind11::capsule(ptr.get(), [](void *p) {
+    std::unique_ptr<std::vector<T>>(reinterpret_cast<std::vector<T> *>(p));
+  })};
+  ptr.release();
+  if (shape.empty()) {
+    return pybind11::array(size, data, capsule);
+  }
+  return pybind11::array(shape, data, capsule);
+}
+
 } // namespace sme

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -237,25 +237,6 @@ void pybindModel(pybind11::module &m) {
       .def("__str__", &sme::Model::getStr);
 }
 
-// return the contents of a std::vector as an ndarray, with optional shape,
-// without making a copy of the data, based on
-// https://github.com/pybind/pybind11/issues/1042#issuecomment-642215028
-template <typename T>
-static inline pybind11::array_t<T>
-as_ndarray(std::vector<T> &&v, const std::vector<ssize_t> &shape = {}) {
-  auto data{v.data()};
-  auto size{static_cast<ssize_t>(v.size())};
-  auto ptr{std::make_unique<std::vector<T>>(std::move(v))};
-  auto capsule{pybind11::capsule(ptr.get(), [](void *p) {
-    std::unique_ptr<std::vector<T>>(reinterpret_cast<std::vector<T> *>(p));
-  })};
-  ptr.release();
-  if (shape.empty()) {
-    return pybind11::array(size, data, capsule);
-  }
-  return pybind11::array(shape, data, capsule);
-}
-
 static std::vector<SimulationResult>
 constructSimulationResults(const simulate::Simulation *sim, bool getDcdt) {
   std::vector<SimulationResult> results;

--- a/sme/src/sme_species.cpp
+++ b/sme/src/sme_species.cpp
@@ -10,6 +10,10 @@ namespace sme {
 
 void pybindSpecies(pybind11::module &m) {
   sme::bindList<Species>(m, "Species");
+  pybind11::enum_<model::ConcentrationType>(m, "ConcentrationType")
+      .value("Uniform", model::ConcentrationType::Uniform)
+      .value("Analytic", model::ConcentrationType::Analytic)
+      .value("Image", model::ConcentrationType::Image);
   pybind11::class_<Species>(m, "Species",
                             R"(
                             a species that lives in a compartment
@@ -22,6 +26,29 @@ void pybindSpecies(pybind11::module &m) {
                     &Species::setDiffusionConstant,
                     R"(
                     float: the diffusion constant of this species
+                    )")
+      .def_property_readonly("concentration_type",
+                             &Species::getInitialConcentrationType,
+                             R"(
+                    Species.ConcentrationType: the type of initial concentration of this species (Uniform, Analytic or Image)
+                    )")
+      .def_property("uniform_concentration",
+                    &Species::getUniformInitialConcentration,
+                    &Species::setUniformInitialConcentration,
+                    R"(
+                    float: the uniform initial concentration of this species as a float
+                    )")
+      .def_property("analytic_concentration",
+                    &Species::getAnalyticInitialConcentration,
+                    &Species::setAnalyticInitialConcentration,
+                    R"(
+                    str: the initial concentration of this species as an analytic expression
+                    )")
+      .def_property("concentration_image",
+                    &Species::getImageInitialConcentration,
+                    &Species::setImageInitialConcentration,
+                    R"(
+                    np.ndarray(float): the initial concentration of this species as a 2d array of floats, one for each pixel in the geometry image
                     )")
       .def("__repr__",
            [](const Species &a) {
@@ -47,6 +74,65 @@ void Species::setDiffusionConstant(double diffusionConstant) {
 
 double Species::getDiffusionConstant() const {
   return s->getSpecies().getDiffusionConstant(id.c_str());
+}
+
+[[nodiscard]] model::ConcentrationType
+Species::getInitialConcentrationType() const {
+  return s->getSpecies().getInitialConcentrationType(id.c_str());
+}
+
+[[nodiscard]] double Species::getUniformInitialConcentration() const {
+  return s->getSpecies().getInitialConcentration(id.c_str());
+}
+
+void Species::setUniformInitialConcentration(double value) {
+  s->getSpecies().setInitialConcentration(id.c_str(), value);
+}
+
+[[nodiscard]] std::string Species::getAnalyticInitialConcentration() const {
+  return s->getSpecies().getAnalyticConcentration(id.c_str()).toStdString();
+}
+
+void Species::setAnalyticInitialConcentration(const std::string &expression) {
+  s->getSpecies().setAnalyticConcentration(id.c_str(), expression.c_str());
+}
+
+[[nodiscard]] pybind11::array_t<double>
+Species::getImageInitialConcentration() const {
+  auto size{s->getGeometry().getImage().size()};
+  return as_ndarray(
+      s->getSpecies().getSampledFieldConcentration(id.c_str(), true),
+      {size.height(), size.width()});
+}
+
+void Species::setImageInitialConcentration(pybind11::array_t<double> array) {
+  const auto size{s->getGeometry().getImage().size()};
+  auto h{size.height()};
+  auto w{size.width()};
+  std::string err{"Invalid concentration image array"};
+  if (array.ndim() != 2) {
+    throw sme::SmeInvalidArgument(fmt::format(
+        "{}: is {}-dimensional, should be 2-dimensional", err, array.ndim()));
+  }
+  if (array.shape(0) != size.height()) {
+    throw sme::SmeInvalidArgument(
+        fmt::format("{}: height is {}, should be {}", err, array.shape(0), h));
+  }
+  if (array.shape(1) != size.width()) {
+    throw sme::SmeInvalidArgument(
+        fmt::format("{}: width is {}, should be {}", err, array.shape(1), w));
+  }
+  std::vector<double> sampledFieldConcentration(static_cast<std::size_t>(h * w),
+                                                0.0);
+  auto r{array.unchecked<2>()};
+  for (pybind11::ssize_t y = 0; y < array.shape(0); y++) {
+    for (pybind11::ssize_t x = 0; x < array.shape(1); x++) {
+      auto sampledFieldIndex{static_cast<std::size_t>(x + w * (h - 1 - y))};
+      sampledFieldConcentration[sampledFieldIndex] = r(y, x);
+    }
+  }
+  s->getSpecies().setSampledFieldConcentration(id.c_str(),
+                                               sampledFieldConcentration);
 }
 
 std::string Species::getStr() const {

--- a/sme/src/sme_species.hpp
+++ b/sme/src/sme_species.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "model.hpp"
+#include "sme_common.hpp"
 #include <pybind11/pybind11.h>
 #include <string>
 
@@ -23,6 +25,13 @@ public:
   void setName(const std::string &name);
   [[nodiscard]] double getDiffusionConstant() const;
   void setDiffusionConstant(double diffusionConstant);
+  [[nodiscard]] model::ConcentrationType getInitialConcentrationType() const;
+  [[nodiscard]] double getUniformInitialConcentration() const;
+  void setUniformInitialConcentration(double value);
+  [[nodiscard]] std::string getAnalyticInitialConcentration() const;
+  void setAnalyticInitialConcentration(const std::string &expression);
+  [[nodiscard]] pybind11::array_t<double> getImageInitialConcentration() const;
+  void setImageInitialConcentration(pybind11::array_t<double> array);
   [[nodiscard]] std::string getStr() const;
 };
 

--- a/sme/test/test_species.py
+++ b/sme/test/test_species.py
@@ -1,5 +1,6 @@
 import unittest
 import sme
+import numpy as np
 
 
 class TestSpecies(unittest.TestCase):
@@ -14,19 +15,106 @@ class TestSpecies(unittest.TestCase):
         self.assertEqual(str(s)[0:32], "<sme.Species>\n  - name: 'A_cell'")
         self.assertEqual(s.name, "A_cell")
         self.assertEqual(s.diffusion_constant, 6.0)
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Uniform)
+        self.assertEqual(s.uniform_concentration, 0.0)
+        self.assertEqual(s.analytic_concentration, "")
+        self.assertEqual(s.concentration_image.shape, (100, 100))
+        self.assertEqual(s.concentration_image[1, 2], 0.0)
+        self.assertEqual(s.concentration_image[23, 40], 0.0)
 
         # assign new values
         s.name = "New A!"
         s.diffusion_constant = 1.0
+        s.uniform_concentration = 0.3
         self.assertEqual(repr(s), "<sme.Species named 'New A!'>")
         self.assertEqual(str(s)[0:32], "<sme.Species>\n  - name: 'New A!'")
         self.assertEqual(s.name, "New A!")
         self.assertEqual(s.diffusion_constant, 1.0)
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Uniform)
+        self.assertEqual(s.uniform_concentration, 0.3)
+        self.assertEqual(s.analytic_concentration, "")
+        self.assertEqual(s.concentration_image.shape, (100, 100))
+        self.assertAlmostEqual(s.concentration_image[1, 2], 0.0)
+        self.assertAlmostEqual(s.concentration_image[23, 40], 0.3)
 
-        # check change was propagated to model
+        # check changes were propagated to model
         self.assertRaises(
             sme.InvalidArgument,
             lambda: m.compartments["Cell"].species["A_cell"],
         )
         s2 = m.compartments["Cell"].species["New A!"]
         self.assertEqual(s, s2)
+
+        # set an analytic initial concentration
+        s.analytic_concentration = "cos(x)+1"
+        # type of initial concentration changes:
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Analytic)
+        # uniform concentration value is unchanged:
+        self.assertEqual(s.uniform_concentration, 0.3)
+        # analytic concentration expression is no longer empty:
+        self.assertEqual(s.analytic_concentration, "cos(x) + 1")
+        self.assertEqual(s.concentration_image.shape, (100, 100))
+        self.assertAlmostEqual(s.concentration_image[1, 2], 0.0)
+        self.assertAlmostEqual(s.concentration_image[23, 40], 0.05748050894911694)
+
+        # set a uniform initial concentration
+        s.uniform_concentration = 2.0
+        # type of initial concentration changes:
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Uniform)
+        self.assertEqual(s.uniform_concentration, 2.0)
+        # analytic concentration expression is now empty:
+        self.assertEqual(s.analytic_concentration, "")
+        self.assertEqual(s.concentration_image.shape, (100, 100))
+        self.assertAlmostEqual(s.concentration_image[1, 2], 0.0)
+        self.assertAlmostEqual(s.concentration_image[23, 40], 2.0)
+
+        # round trip check of image concentration
+        a1 = np.random.default_rng().uniform(0, 1, (100, 100))
+        s.concentration_image = a1
+        # uniform concentration value is unchanged:
+        self.assertEqual(s.uniform_concentration, 2.0)
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Image)
+        # get concentration image
+        a2 = s.concentration_image
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Image)
+        self.assertAlmostEqual(a1[23, 48], a2[23, 48])
+        # pixels outside of compartment are ignored
+        compartment_mask = m.compartments["Cell"].geometry_mask
+        self.assertLess(np.sum(np.square(a2[~compartment_mask])), 1e-7)
+        a1[~compartment_mask] = 0.0
+        self.assertLess(np.sum(np.square(a1 - a2)), 1e-7)
+        # set concentration to output concentration image
+        s.concentration_image = a2
+        a3 = s.concentration_image
+        self.assertEqual(s.concentration_type, sme.ConcentrationType.Image)
+        self.assertAlmostEqual(a2[23, 48], a3[23, 48])
+        self.assertLess(np.sum(np.square(a2 - a3)), 1e-7)
+
+        # invalid image assignments throw with helpful message
+        with self.assertRaises(sme.InvalidArgument) as err:
+            s.concentration_image = np.random.default_rng().uniform(0, 1, 100)
+        self.assertEqual(
+            "Invalid concentration image array: is 1-dimensional, should be 2-dimensional",
+            str(err.exception),
+        )
+
+        with self.assertRaises(sme.InvalidArgument) as err:
+            s.concentration_image = np.random.default_rng().uniform(0, 1, (10, 10, 10))
+        self.assertEqual(
+            "Invalid concentration image array: is 3-dimensional, should be 2-dimensional",
+            str(err.exception),
+        )
+
+        with self.assertRaises(sme.InvalidArgument) as err:
+            s.concentration_image = np.random.default_rng().uniform(0, 1, (10, 100))
+        self.assertEqual(
+            "Invalid concentration image array: height is 10, should be 100",
+            str(err.exception),
+        )
+
+        with self.assertRaises(sme.InvalidArgument) as err:
+            s.concentration_image = np.random.default_rng().uniform(0, 1, (100, 101))
+        self.assertEqual(
+            "Invalid concentration image array: width is 101, should be 100",
+            str(err.exception),
+        )

--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -115,7 +115,8 @@ public:
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);
   void setConcentration(const std::vector<double> &concentration);
   [[nodiscard]] QImage getConcentrationImage() const;
-  [[nodiscard]] std::vector<double> getConcentrationImageArray() const;
+  [[nodiscard]] std::vector<double>
+  getConcentrationImageArray(bool maskAndInvertY = false) const;
   void setCompartment(const Compartment *comp);
 };
 

--- a/src/core/model/inc/model_species.hpp
+++ b/src/core/model/inc/model_species.hpp
@@ -26,6 +26,8 @@ class ModelParameters;
 class ModelReactions;
 struct Settings;
 
+enum struct ConcentrationType { Uniform, Analytic, Image };
+
 class ModelSpecies {
 private:
   QStringList ids;
@@ -63,6 +65,8 @@ public:
   [[nodiscard]] bool getIsSpatial(const QString &id) const;
   void setDiffusionConstant(const QString &id, double diffusionConstant);
   [[nodiscard]] double getDiffusionConstant(const QString &id) const;
+  [[nodiscard]] ConcentrationType
+  getInitialConcentrationType(const QString &id) const;
   void setInitialConcentration(const QString &id, double concentration);
   [[nodiscard]] double getInitialConcentration(const QString &id) const;
   void setAnalyticConcentration(const QString &id,
@@ -75,7 +79,8 @@ public:
   setSampledFieldConcentration(const QString &id,
                                const std::vector<double> &concentrationArray);
   [[nodiscard]] std::vector<double>
-  getSampledFieldConcentration(const QString &id) const;
+  getSampledFieldConcentration(const QString &id,
+                               bool maskAndInvertY = false) const;
   [[nodiscard]] QImage getConcentrationImage(const QString &id) const;
   void setColour(const QString &id, QRgb colour);
   [[nodiscard]] QRgb getColour(const QString &id) const;

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -296,12 +296,24 @@ QImage Field::getConcentrationImage() const {
   return img;
 }
 
-std::vector<double> Field::getConcentrationImageArray() const {
+std::vector<double>
+Field::getConcentrationImageArray(bool maskAndInvertY) const {
   std::vector<double> a;
-  const auto &img = comp->getCompartmentImage();
-  a.reserve(static_cast<std::size_t>(img.width() * img.height()));
-  for (std::size_t i : comp->getArrayPoints()) {
-    a.push_back(conc[i]);
+  const auto &img{comp->getCompartmentImage()};
+  auto n{static_cast<std::size_t>(img.width() * img.height())};
+  if (maskAndInvertY) {
+    // y=0 at top of image & set pixels outside of compartment to zero
+    a.resize(n, 0.0);
+    for (std::size_t i = 0; i < comp->nPixels(); ++i) {
+      auto p{comp->getPixel(i)};
+      a[static_cast<std::size_t>(p.x() + img.width() * p.y())] = conc[i];
+    }
+  } else {
+    // y=0 at bottom, set pixels outside of compartment to nearest valid pixel
+    a.reserve(n);
+    for (std::size_t i : comp->getArrayPoints()) {
+      a.push_back(conc[i]);
+    }
   }
   return a;
 }

--- a/src/core/model/src/geometry_t.cpp
+++ b/src/core/model/src/geometry_t.cpp
@@ -79,6 +79,10 @@ SCENARIO("Geometry: Compartments and Fields",
     REQUIRE(a.size() == 1);
     REQUIRE(a[0] == dbl_approx(1.23));
 
+    auto a2{field.getConcentrationImageArray(true)};
+    REQUIRE(a2.size() == 1);
+    REQUIRE(a2[0] == dbl_approx(1.23));
+
     // set zero concentration, get image
     // (must avoid dividing by zero in normalisation)
     field.setUniformConcentration(0.0);
@@ -112,18 +116,28 @@ SCENARIO("Geometry: Compartments and Fields",
     // (3,4)
     REQUIRE(field.getConcentration()[1] == dbl_approx(1.3));
 
-    auto a = field.getConcentrationImageArray();
+    auto a{field.getConcentrationImageArray()};
     REQUIRE(a.size() == static_cast<std::size_t>(img.width() * img.height()));
     REQUIRE(a.front() == dbl_approx(1.3));
     REQUIRE(a[20] == dbl_approx(1.3));
-    REQUIRE(a[21] == dbl_approx(1.3));
-    REQUIRE(a[15] == dbl_approx(1.3));
-    REQUIRE(a[23] == dbl_approx(1.3));
+    REQUIRE(a[21] == dbl_approx(1.3)); // (3,3)
+    REQUIRE(a[15] == dbl_approx(1.3)); // (3,4)
+    REQUIRE(a[27] == dbl_approx(1.3));
     REQUIRE(a.back() == dbl_approx(1.3));
 
+    // true -> inverted y-axis & zero outside of compartment
+    auto a2{field.getConcentrationImageArray(true)};
+    REQUIRE(a2.size() == static_cast<std::size_t>(img.width() * img.height()));
+    REQUIRE(a2.front() == dbl_approx(0.0));
+    REQUIRE(a2[20] == dbl_approx(0.0));
+    REQUIRE(a2[21] == dbl_approx(1.3)); // (3,3)
+    REQUIRE(a2[15] == dbl_approx(0.0));
+    REQUIRE(a2[27] == dbl_approx(1.3)); // (3,4)
+    REQUIRE(a2.back() == dbl_approx(0));
+
     std::vector<double> arr(6 * 7, 0.0);
-    arr[21] = 3.1;
-    arr[15] = 9.9;
+    arr[21] = 3.1; // (3,3)
+    arr[15] = 9.9; // (3,4)
     field.importConcentration(arr);
     REQUIRE(field.getConcentration()[0] == dbl_approx(3.1));
     REQUIRE(field.getConcentration()[1] == dbl_approx(9.9));
@@ -132,6 +146,16 @@ SCENARIO("Geometry: Compartments and Fields",
     REQUIRE(a[20] == dbl_approx(3.1));
     REQUIRE(a[15] == dbl_approx(9.9));
     REQUIRE(a[14] == dbl_approx(9.9));
+
+    // true -> inverted y-axis & zero outside of compartment
+    a2 = field.getConcentrationImageArray(true);
+    REQUIRE(a2.size() == static_cast<std::size_t>(img.width() * img.height()));
+    REQUIRE(a2.front() == dbl_approx(0.0));
+    REQUIRE(a2[20] == dbl_approx(0.0));
+    REQUIRE(a2[21] == dbl_approx(3.1)); // (3,3)
+    REQUIRE(a2[27] == dbl_approx(9.9)); // (3,4)
+    REQUIRE(a2[26] == dbl_approx(0.0));
+    REQUIRE(a2.back() == dbl_approx(0.0));
 
     // conc array size must match image size
     REQUIRE_THROWS(field.importConcentration({1.0, 2.0}));

--- a/src/core/model/src/model_species.cpp
+++ b/src/core/model/src/model_species.cpp
@@ -483,6 +483,18 @@ double ModelSpecies::getDiffusionConstant(const QString &id) const {
   return fields[static_cast<std::size_t>(i)].getDiffusionConstant();
 }
 
+ConcentrationType
+ModelSpecies::getInitialConcentrationType(const QString &id) const {
+  if (const auto *field{getField(id)};
+      field != nullptr && field->getIsUniformConcentration()) {
+    return ConcentrationType::Uniform;
+  }
+  if (!getSampledFieldInitialAssignment(id).isEmpty()) {
+    return ConcentrationType::Image;
+  }
+  return ConcentrationType::Analytic;
+}
+
 void ModelSpecies::setInitialConcentration(const QString &id,
                                            double concentration) {
   hasUnsavedChanges = true;
@@ -631,9 +643,11 @@ void ModelSpecies::setSampledFieldConcentration(
 }
 
 std::vector<double>
-ModelSpecies::getSampledFieldConcentration(const QString &id) const {
+ModelSpecies::getSampledFieldConcentration(const QString &id,
+                                           bool maskAndInvertY) const {
   auto i = ids.indexOf(id);
-  return fields[static_cast<std::size_t>(i)].getConcentrationImageArray();
+  return fields[static_cast<std::size_t>(i)].getConcentrationImageArray(
+      maskAndInvertY);
 }
 
 QImage ModelSpecies::getConcentrationImage(const QString &id) const {

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -132,17 +132,16 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
   ui->lblInitialConcentrationUnits->setText("");
   lblGeometry->setImage(
       model.getSpecies().getConcentrationImage(currentSpeciesId));
-  if (field->getIsUniformConcentration()) {
+  auto concentrationType{
+      model.getSpecies().getInitialConcentrationType(currentSpeciesId)};
+  if (concentrationType == sme::model::ConcentrationType::Uniform) {
     // scalar
     ui->txtInitialConcentration->setText(QString::number(
         model.getSpecies().getInitialConcentration(currentSpeciesId)));
     ui->lblInitialConcentrationUnits->setText(
         model.getUnits().getConcentration());
     ui->radInitialConcentrationUniform->setChecked(true);
-  } else if (!model.getSpecies()
-                  .getSampledFieldInitialAssignment(currentSpeciesId)
-                  .isEmpty()) {
-    // image
+  } else if (concentrationType == sme::model::ConcentrationType::Image) {
     ui->radInitialConcentrationImage->setChecked(true);
   } else {
     // analytic


### PR DESCRIPTION
- add ConcentrationType enum
  - Uniform
  - Analytic
  - Image
- Model::ModelSpecies: add getInitialConcentrationType()
- add properties to sme.Species
  - concentration_type (read-only sme.ConcentrationType)
  - uniform_concentration (float)
  - analytic_concentration (str)
  - concentration_image (np.ndarray)
- assigning to the above also sets the concentration type accordingly
- add examples of use to getting started notebook
- Field::getConcentrationImageArray() add maskAndInvertY option
  - returns concentration image as 1d array suitable (after shaping) for imshow()
- resolves #644
