### PR TITLE
add ODE import help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 ## latest
 ### Added
+- non-spatial model guided import [#607](https://github.com/spatial-model-editor/spatial-model-editor/issues/607)
 - python interface: optional multithreading (via OpenMP) for Pixel simulations on linux [#662](https://github.com/spatial-model-editor/spatial-model-editor/issues/662)
 
 ### Fixed
 - bug where loading a model with simulation data and changing model units could cause a crash [#666](https://github.com/spatial-model-editor/spatial-model-editor/issues/666)
 - show warning message before dune simulation of model with non-spatial species [#664](https://github.com/spatial-model-editor/spatial-model-editor/issues/664)
-- minimum supported version of macos now 10.14 instead of 10.15 [#669](https://github.com/spatial-model-editor/spatial-model-editor/issues/669)
+- minimum supported version of MacOS is now 10.14 instead of 10.15 [#669](https://github.com/spatial-model-editor/spatial-model-editor/issues/669)
 
 ## [1.1.5] - 2021-09-01
 ### Added

--- a/src/core/common/inc/symbolic.hpp
+++ b/src/core/common/inc/symbolic.hpp
@@ -23,6 +23,11 @@ std::string symbolicDivide(const std::string &expr, const std::string &var);
 // multiply given expression by a variable
 std::string symbolicMultiply(const std::string &expr, const std::string &var);
 
+// substitute the constants in the given expression with their numerical values
+std::string symbolicSubstitute(
+    const std::string &expr,
+    const std::vector<std::pair<std::string, double>> &constants);
+
 // check if an expression contains a variable
 bool symbolicContains(const std::string &expr, const std::string &var);
 

--- a/src/core/common/src/symbolic.cpp
+++ b/src/core/common/src/symbolic.cpp
@@ -280,6 +280,21 @@ std::string symbolicMultiply(const std::string &expr, const std::string &var) {
   return result;
 }
 
+std::string symbolicSubstitute(
+    const std::string &expr,
+    const std::vector<std::pair<std::string, double>> &constants) {
+  std::locale userLocale = std::locale::global(std::locale::classic());
+  SymEngine::map_basic_basic d;
+  for (const auto &[name, value] : constants) {
+    SPDLOG_DEBUG("  - constant {} = {}", name, value);
+    d[SymEngine::symbol(name)] = SymEngine::real_double(value);
+  }
+  auto e{SymEngine::parse_sbml(expr)};
+  std::string result = toString(e->subs(d));
+  std::locale::global(userLocale);
+  return result;
+}
+
 bool symbolicContains(const std::string &expr, const std::string &var) {
   std::locale userLocale = std::locale::global(std::locale::classic());
   auto e{SymEngine::parse_sbml(expr)};

--- a/src/core/model/inc/model.hpp
+++ b/src/core/model/inc/model.hpp
@@ -26,19 +26,9 @@
 #include <memory>
 #include <optional>
 
-// SBML forward declarations
 namespace libsbml {
 class SBMLDocument;
-class Model;
-class Compartment;
-class SpatialModelPlugin;
-class Geometry;
-class SampledFieldGeometry;
-class ParametricGeometry;
-class ParametricObject;
-class Reaction;
-class UnitDefinition;
-} // namespace libsbml
+}
 
 namespace sme::mesh {
 class Mesh;
@@ -74,7 +64,7 @@ private:
   std::unique_ptr<ModelUnits> modelUnits;
   std::unique_ptr<ModelMath> modelMath;
 
-  void initModelData();
+  void initModelData(bool emptySpatialModel = false);
   void setHasUnsavedChanges(bool unsavedChanges);
   void updateSBMLDoc();
 

--- a/src/core/model/inc/model_compartments.hpp
+++ b/src/core/model/inc/model_compartments.hpp
@@ -2,14 +2,14 @@
 
 #pragma once
 
+#include "geometry.hpp"
 #include <QPointF>
 #include <QRgb>
 #include <QStringList>
 #include <QVector>
+#include <map>
 #include <memory>
 #include <optional>
-
-#include "geometry.hpp"
 
 namespace libsbml {
 class Model;
@@ -42,6 +42,7 @@ private:
   const ModelUnits *modelUnits{nullptr};
   simulate::SimulationData *simulationData = nullptr;
   bool hasUnsavedChanges{false};
+  std::map<std::string, double, std::less<>> initialCompartmentSizes{};
 
 public:
   ModelCompartments();
@@ -70,6 +71,8 @@ public:
   [[nodiscard]] const geometry::Compartment *
   getCompartment(const QString &id) const;
   [[nodiscard]] double getSize(const QString &id) const;
+  [[nodiscard]] const std::map<std::string, double, std::less<>> &
+  getInitialCompartmentSizes() const;
   void clear();
   [[nodiscard]] bool getHasUnsavedChanges() const;
   void setHasUnsavedChanges(bool unsavedChanges);

--- a/src/core/model/inc/model_reactions.hpp
+++ b/src/core/model/inc/model_reactions.hpp
@@ -17,6 +17,14 @@ namespace sme::model {
 
 class ModelMembranes;
 
+struct ReactionRescaling {
+  std::string id{};
+  QString reactionName{};
+  QString reactionLocation{};
+  QString originalExpression{};
+  QString rescaledExpression{};
+};
+
 class ModelReactions {
 private:
   QStringList ids;
@@ -25,12 +33,19 @@ private:
   libsbml::Model *sbmlModel{};
   const ModelMembranes *modelMembranes{};
   bool hasUnsavedChanges{false};
+  bool isIncompleteODEImport{false};
 
 public:
   ModelReactions();
   explicit ModelReactions(libsbml::Model *model,
-                          const ModelMembranes *membranes);
-  void makeReactionsSpatial(bool haveValidGeometry);
+                          const ModelMembranes *membranes,
+                          bool isNonSpatialModel);
+  void makeReactionLocationsValid();
+  void applySpatialReactionRescalings(
+      const std::vector<ReactionRescaling> &reactionRescalings);
+  [[nodiscard]] std::vector<ReactionRescaling>
+  getSpatialReactionRescalings() const;
+  [[nodiscard]] bool getIsIncompleteODEImport() const;
   [[nodiscard]] QStringList getIds(const QString &locationId) const;
   QString add(const QString &name, const QString &locationId,
               const QString &rateExpression = "1");

--- a/src/core/model/src/model_compartments_t.cpp
+++ b/src/core/model/src/model_compartments_t.cpp
@@ -313,6 +313,11 @@ SCENARIO("SBML compartments",
     REQUIRE(compartments.getIds()[1] == "c2");
     REQUIRE(compartments.getIds()[2] == "c3");
     REQUIRE(compartments.getHasUnsavedChanges() == false);
+    // check initial sizes
+    const auto &initialSizes{compartments.getInitialCompartmentSizes()};
+    REQUIRE(initialSizes.at("c1") == dbl_approx(5441000.0));
+    REQUIRE(initialSizes.at("c2") == dbl_approx(4034000.0));
+    REQUIRE(initialSizes.at("c3") == dbl_approx(525000.0));
     QRgb c1{qRgb(0, 2, 0)};
     QRgb c2{qRgb(144, 97, 193)};
     QRgb c3{qRgb(197, 133, 96)};
@@ -338,8 +343,11 @@ SCENARIO("SBML compartments",
     compartments.setColour("c1", c3);
     REQUIRE(compartments.getHasUnsavedChanges() == true);
     REQUIRE(compartments.getColour("c1") == c3);
+    REQUIRE(compartments.getSize("c1") == dbl_approx(initialSizes.at("c3")));
     REQUIRE(compartments.getColour("c2") == c2);
+    REQUIRE(compartments.getSize("c2") == dbl_approx(initialSizes.at("c2")));
     REQUIRE(compartments.getColour("c3") == 0);
+    REQUIRE(compartments.getSize("c3") == dbl_approx(0));
     // valid id, invalid colour
     compartments.setHasUnsavedChanges(false);
     compartments.setColour("c3", cInvalid);

--- a/src/core/model/src/model_geometry_t.cpp
+++ b/src/core/model/src/model_geometry_t.cpp
@@ -30,7 +30,7 @@ SCENARIO("Model geometry",
     model::ModelMembranes mMembranes(doc->getModel());
     model::ModelGeometry mGeometry;
     model::ModelSpecies mSpecies;
-    model::ModelReactions mReactions(doc->getModel(), &mMembranes);
+    model::ModelReactions mReactions(doc->getModel(), &mMembranes, false);
     simulate::SimulationData simulationData{};
     mCompartments = model::ModelCompartments(doc->getModel(), &mMembranes,
                                              &mUnits, &simulationData);

--- a/src/core/model/src/validation.cpp
+++ b/src/core/model/src/validation.cpp
@@ -48,11 +48,12 @@ std::string countAndPrintSBMLDocErrors(const libsbml::SBMLDocument *doc) {
   return errors;
 }
 
-std::string validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc) {
-  auto errors{countAndPrintSBMLDocErrors(doc)};
-  if (!errors.empty()) {
+ValidateAndUpgradeResult validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc) {
+  ValidateAndUpgradeResult result;
+  result.errors = countAndPrintSBMLDocErrors(doc);
+  if (!result.errors.empty()) {
     SPDLOG_ERROR("Errors while reading SBML file, aborting.");
-    return errors;
+    return result;
   }
   SPDLOG_INFO("Successfully imported SBML Level {}, Version {} model",
               doc->getLevel(), doc->getVersion());
@@ -69,8 +70,9 @@ std::string validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc) {
       countAndPrintSBMLDocErrors(doc);
     }
   }
-  // enable spatial extension
+  // enable spatial extension if not already done
   if (!doc->isPackageEnabled("spatial")) {
+    result.spatial = false;
     doc->enablePackage(libsbml::SpatialExtension::getXmlnsL3V1V1(), "spatial",
                        true);
     doc->setPackageRequired("spatial", true);
@@ -78,7 +80,7 @@ std::string validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc) {
   }
   doc->checkConsistency();
   printSBMLDocWarnings(doc);
-  return {};
+  return result;
 }
 
 } // namespace sme::model

--- a/src/core/model/src/validation.hpp
+++ b/src/core/model/src/validation.hpp
@@ -10,8 +10,13 @@ class SBMLDocument;
 
 namespace sme::model {
 
+struct ValidateAndUpgradeResult {
+  std::string errors{};
+  bool spatial{true};
+};
+
 void printSBMLDocWarnings(const libsbml::SBMLDocument *doc);
 std::string countAndPrintSBMLDocErrors(const libsbml::SBMLDocument *doc);
-std::string validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc);
+ValidateAndUpgradeResult validateAndUpgradeSBMLDoc(libsbml::SBMLDocument *doc);
 
 } // namespace sme::model

--- a/src/core/resources/models/very-simple-model.xml
+++ b/src/core/resources/models/very-simple-model.xml
@@ -126,13 +126,13 @@
       </unitDefinition>
     </listOfUnitDefinitions>
     <listOfCompartments>
-      <compartment id="c1" name="Outside" spatialDimensions="3" size="5441" units="area" constant="true">
+      <compartment id="c1" name="Outside" spatialDimensions="3" size="5441000" constant="true">
         <spatial:compartmentMapping spatial:id="c1_compartmentMapping" spatial:domainType="c1_domainType" spatial:unitSize="1"/>
       </compartment>
-      <compartment id="c2" name="Cell" spatialDimensions="3" size="4034" units="area" constant="true">
+      <compartment id="c2" name="Cell" spatialDimensions="3" size="4034000" constant="true">
         <spatial:compartmentMapping spatial:id="c2_compartmentMapping" spatial:domainType="c2_domainType" spatial:unitSize="1"/>
       </compartment>
-      <compartment id="c3" name="Nucleus" spatialDimensions="3" size="525" units="area" constant="true">
+      <compartment id="c3" name="Nucleus" spatialDimensions="3" size="525000" constant="true">
         <spatial:compartmentMapping spatial:id="c3_compartmentMapping" spatial:domainType="c3_domainType" spatial:unitSize="1"/>
       </compartment>
       <compartment id="c1_c2_membrane" name="Outside &lt;-&gt; Cell" spatialDimensions="2" size="338" constant="true">
@@ -316,17 +316,17 @@
       <spatial:listOfDomains>
         <spatial:domain spatial:id="c1_domain" spatial:domainType="c1_domainType">
           <spatial:listOfInteriorPoints>
-            <spatial:interiorPoint spatial:coord1="68.5" spatial:coord2="83.5" spatial:coord3="0"/>
+            <spatial:interiorPoint spatial:coord1="68.5" spatial:coord2="83.5" spatial:coord3="0.5"/>
           </spatial:listOfInteriorPoints>
         </spatial:domain>
         <spatial:domain spatial:id="c2_domain" spatial:domainType="c2_domainType">
           <spatial:listOfInteriorPoints>
-            <spatial:interiorPoint spatial:coord1="59.5" spatial:coord2="28.5" spatial:coord3="0"/>
+            <spatial:interiorPoint spatial:coord1="59.5" spatial:coord2="28.5" spatial:coord3="0.5"/>
           </spatial:listOfInteriorPoints>
         </spatial:domain>
         <spatial:domain spatial:id="c3_domain" spatial:domainType="c3_domainType">
           <spatial:listOfInteriorPoints>
-            <spatial:interiorPoint spatial:coord1="39.5" spatial:coord2="49.5" spatial:coord3="0"/>
+            <spatial:interiorPoint spatial:coord1="39.5" spatial:coord2="49.5" spatial:coord3="0.5"/>
           </spatial:listOfInteriorPoints>
         </spatial:domain>
         <spatial:domain spatial:id="c1_c2_membrane_domain" spatial:domainType="c1_c2_membrane_domainType"/>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 add_subdirectory(widgets)
 add_subdirectory(dialogs)
 add_subdirectory(tabs)
+add_subdirectory(wizards)
 
 target_link_libraries(gui PUBLIC Qt::Widgets sme::core)
 set_property(TARGET gui PROPERTY CXX_STANDARD 17)

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "model.hpp"
+#include <QLabel>
 #include <QMainWindow>
 #include <memory>
 
-class QLabel;
 class TabFunctions;
 class TabGeometry;
 class TabEvents;
@@ -69,6 +69,7 @@ private:
   void actionSet_model_units_triggered();
   void actionEdit_geometry_image_triggered();
   void actionSet_spatial_coordinates_triggered();
+  void actionFinalize_non_spatial_import_triggered();
 
   // View menu actions
   void actionGeometry_grid_triggered(bool checked);

--- a/src/gui/wizards/CMakeLists.txt
+++ b/src/gui/wizards/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(gui PRIVATE ode_import_wizard.cpp)
+target_include_directories(gui PUBLIC .)
+
+if(BUILD_TESTING)
+  target_sources(gui_tests PUBLIC ode_import_wizard_t.cpp)
+endif()

--- a/src/gui/wizards/ode_import_wizard.cpp
+++ b/src/gui/wizards/ode_import_wizard.cpp
@@ -1,0 +1,128 @@
+#include "ode_import_wizard.hpp"
+#include "ui_ode_import_wizard.h"
+
+static QString toQStringApprox(double x) { return QString::number(x, 'g', 5); }
+
+static QString toQStringAccurate(double x) {
+  return QString::number(x, 'g', 13);
+}
+
+static QString makeDepthTableRow(const QString &compartment, double odeVolume,
+                                 double pdeVolume) {
+  double ratio{pdeVolume / odeVolume};
+  QString hexColor{"#00aa00"};
+  if (ratio > 1.1 || ratio < 0.9) {
+    hexColor = "#aa0000";
+  }
+  return QString(
+             "<tr><td><p>%1</p></td><td><p>%2</p></td><td><p>%3</p></"
+             "td><td><p style=\"font-weight:600; color:%4;\">%5</p></td></tr>")
+      .arg(compartment.toHtmlEscaped())
+      .arg(toQStringApprox(odeVolume))
+      .arg(toQStringApprox(pdeVolume))
+      .arg(hexColor)
+      .arg(toQStringApprox(ratio));
+}
+
+static QString makeTableHeader() {
+  return R"(<html><head/><body>
+             <table border="1"
+                    style="font-size:large; margin-top:10px; margin-bottom:2px; margin-left:2px; margin-right:2px;"
+                    align="center"
+                    cellspacing="0"
+                    cellpadding="10">)";
+}
+
+static QString makeDepthTable(const sme::model::Model &model) {
+  const auto &compartments{model.getCompartments()};
+  auto table{makeTableHeader()};
+  table.push_back(
+      "<tr><th><p>Compartment</p></th><th><p>ODE Volume</p></th><th><p>PDE "
+      "Volume</p></th><th><p>Ratio</p></th></tr>");
+  const auto &odeVolumes{compartments.getInitialCompartmentSizes()};
+  for (const auto &id : compartments.getIds()) {
+    double oldSize{1.0};
+    if (auto old{odeVolumes.find(id.toStdString())}; old != odeVolumes.end()) {
+      oldSize = old->second;
+    }
+    table.append(makeDepthTableRow(compartments.getName(id), oldSize,
+                                   compartments.getSize(id)));
+  }
+  table.append("</table></body></html>");
+  return table;
+}
+
+void setBestDepth(sme::model::Model &model) {
+  auto oldSizes{model.getCompartments().getInitialCompartmentSizes()};
+  const auto &compartments{model.getCompartments()};
+  auto &geometry{model.getGeometry()};
+  auto initialDepth{geometry.getPixelDepth()};
+  // set depth to match first compartment volume for which we have an ode volume
+  for (const auto &compartmentId : compartments.getIds()) {
+    if (auto iter{oldSizes.find(compartmentId.toStdString())};
+        iter != oldSizes.cend()) {
+      auto odeVol{iter->second};
+      auto pdeVol{compartments.getSize(compartmentId)};
+      auto newDepth{initialDepth * odeVol / pdeVol};
+      geometry.setPixelDepth(newDepth);
+      return;
+    }
+  }
+}
+
+OdeImportWizard::OdeImportWizard(sme::model::Model &smeModel, QWidget *parent)
+    : QWizard(parent), ui{std::make_unique<Ui::OdeImportWizard>()},
+      model{smeModel}, initialDepth{model.getGeometry().getPixelDepth()} {
+  ui->setupUi(this);
+  setBestDepth(model);
+  ui->lblDepthUnits->setText(model.getUnits().getLength().name);
+  ui->txtDepthValue->setText(
+      toQStringAccurate(model.getGeometry().getPixelDepth()));
+  updateDepth(ui->txtDepthValue->text());
+  connect(ui->txtDepthValue, &QLineEdit::textEdited, this,
+          &OdeImportWizard::updateDepth);
+}
+
+double OdeImportWizard::getInitialPixelDepth() const { return initialDepth; }
+
+const std::vector<sme::model::ReactionRescaling> &
+OdeImportWizard::getReactionRescalings() const {
+  return reactionRescalings;
+}
+
+static QString makeRescalingsTable(
+    const std::vector<sme::model::ReactionRescaling> &reactionRescalings) {
+  auto table{makeTableHeader()};
+  table.push_back("<tr><th><p>Reaction</p></th><th><p>Location</p></th><th "
+                  "colspan=2><p>Rate</p></th></tr>");
+  for (const auto &reactionRescaling : reactionRescalings) {
+    table.push_back(
+        QString("<tr><td align=center valign=middle rowspan=2><p>%1</p></td>")
+            .arg(reactionRescaling.reactionName.toHtmlEscaped()));
+    table.push_back(
+        QString("<td align=center valign=middle rowspan=2><p>%1</p></td>")
+            .arg(reactionRescaling.reactionLocation.toHtmlEscaped()));
+    table.push_back(
+        QString("<td align=right><p>Original:</p></td><td><p>%1</p></tr>")
+            .arg(reactionRescaling.originalExpression.toHtmlEscaped()));
+    table.push_back(
+        QString(
+            "<tr><td align=right><p>Rescaled:</p></td><td><p>%1</p></td></tr>")
+            .arg(reactionRescaling.rescaledExpression.toHtmlEscaped()));
+  }
+  return table;
+}
+
+void OdeImportWizard::updateDepth(const QString &text) {
+  bool validDouble{false};
+  double depth{text.toDouble(&validDouble)};
+  if (validDouble) {
+    model.getGeometry().setPixelDepth(depth);
+    ui->htmlDepthVolumes->setHtml(makeDepthTable(model));
+    reactionRescalings = model.getReactions().getSpatialReactionRescalings();
+    ui->htmlReactionsRescalings->setHtml(
+        makeRescalingsTable(reactionRescalings));
+  }
+}
+
+OdeImportWizard::~OdeImportWizard() = default;

--- a/src/gui/wizards/ode_import_wizard.hpp
+++ b/src/gui/wizards/ode_import_wizard.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "model.hpp"
+#include <QWizard>
+#include <memory>
+
+namespace Ui {
+class OdeImportWizard;
+}
+
+class OdeImportWizard : public QWizard {
+  Q_OBJECT
+
+public:
+  explicit OdeImportWizard(sme::model::Model &smeModel,
+                           QWidget *parent = nullptr);
+  ~OdeImportWizard() override;
+  [[nodiscard]] double getInitialPixelDepth() const;
+  [[nodiscard]] const std::vector<sme::model::ReactionRescaling> &
+  getReactionRescalings() const;
+
+private:
+  std::unique_ptr<Ui::OdeImportWizard> ui;
+  sme::model::Model &model;
+  double initialDepth{1.0};
+  std::vector<sme::model::ReactionRescaling> reactionRescalings{};
+  void updateDepth(const QString &text);
+};

--- a/src/gui/wizards/ode_import_wizard.ui
+++ b/src/gui/wizards/ode_import_wizard.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OdeImportWizard</class>
+ <widget class="QWizard" name="OdeImportWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>987</width>
+    <height>655</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ODE Import Wizard</string>
+  </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ClassicStyle</enum>
+  </property>
+  <widget class="QWizardPage" name="wizPrerequisites">
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QLabel" name="lblPrerequisites">
+      <property name="text">
+       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ODE import finalization&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The goal of this tool is to construct a PDE model that initially behaves similarly to the original ODE model. It does this by rescaling the reaction rates and the depth of the geometry image.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The resulting simulation results should be the same assuming:&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; no initial spatial variation of species concentrations&lt;/li&gt;
+&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; infinitely fast diffusion&lt;/li&gt;
+&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; compartment volumes unchanged&lt;/li&gt;&lt;/ul&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Prerequisites&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Before continuing, check that:&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600; color:#00aa00;&quot;&gt;Geometry image width and height are correct&lt;/span&gt;&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; font-weight:600;&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; color:#00aa00;&quot;&gt;All reaction locations are correct&lt;/span&gt;&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; font-weight:600; color:#00aa00;&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Model units are correct&lt;/li&gt;&lt;/ul&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;If any of the above need to be changed, press &amp;quot;Cancel&amp;quot; and make these changes before finalizing the model, as they will affect the rescaling.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::RichText</enum>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizDepth">
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <item>
+     <layout class="QGridLayout" name="gridDepth">
+      <item row="1" column="2">
+       <widget class="QLabel" name="lblDepthUnits">
+        <property name="text">
+         <string>units</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lblDepthLabel">
+        <property name="text">
+         <string>Depth:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="txtDepthValue"/>
+      </item>
+      <item row="0" column="0" colspan="3">
+       <widget class="QLabel" name="lblDepthIntro">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Geometry Depth&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The depth doesn't affect the spatial model, as it is a 2d simulation assumed to have no variation in the z direction.&lt;/p&gt;&lt;p&gt;However, it does affect how we import a non-spatial model, as it changes the volume of the compartments in the spatial model.&lt;/p&gt;&lt;p&gt;To try to make these volumes as consistent as possible with the original ODE model, we can rescale the depth (z-direction) of the geometry image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::RichText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QTextEdit" name="htmlDepthVolumes">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizReactions">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="lblReactionsIntro">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Reaction rates&lt;/span&gt;&lt;/p&gt;&lt;p&gt;In the ODE model, these were in units of &lt;span style=&quot; font-weight:600;&quot;&gt;amount&lt;/span&gt; per time.&lt;/p&gt;&lt;p&gt;In the PDE model:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Compartment reactions: &lt;span style=&quot; font-weight:600;&quot;&gt;concentration&lt;/span&gt; per time&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Membrane reactions: &lt;span style=&quot; font-weight:600;&quot;&gt;amount &lt;/span&gt;per &lt;span style=&quot; font-weight:600;&quot;&gt;unit membrane area&lt;/span&gt; per time&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;The rates below have been automatically symbolically divided by appropriate compartment volume or membrane area terms to get the units right.&lt;/p&gt;&lt;p&gt;Any remaining compartment volume or membrane area terms left in the reaction rate expression after this are then substituted for their numerical values to give a local reaction rate expression with the correct units.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QTextEdit" name="htmlReactionsRescalings">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/wizards/ode_import_wizard_t.cpp
+++ b/src/gui/wizards/ode_import_wizard_t.cpp
@@ -1,0 +1,38 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "ode_import_wizard.hpp"
+#include <QLabel>
+#include <QLineEdit>
+#include <QTextEdit>
+#include <QWizardPage>
+
+using namespace sme;
+using namespace sme::test;
+
+TEST_CASE("OdeImportWizard",
+          "[gui/wizards/ode_import_wizard][gui/wizards][gui]") {
+  auto m{getExampleModel(Mod::VerySimpleModel)};
+  OdeImportWizard wiz(m);
+  // first page
+  auto *wizPrerequisites{wiz.findChild<QWizardPage *>("wizPrerequisites")};
+  REQUIRE(wizPrerequisites != nullptr);
+  auto *lblPrerequisites{
+      wizPrerequisites->findChild<QLabel *>("lblPrerequisites")};
+  REQUIRE(lblPrerequisites != nullptr);
+  REQUIRE(lblPrerequisites->text().size() > 100);
+  // second page
+  auto *wizDepth{wiz.findChild<QWizardPage *>("wizDepth")};
+  REQUIRE(wizDepth != nullptr);
+  auto *txtDepthValue{wizDepth->findChild<QLineEdit *>("txtDepthValue")};
+  REQUIRE(txtDepthValue != nullptr);
+  auto *lblDepthUnits{wizDepth->findChild<QLabel *>("lblDepthUnits")};
+  REQUIRE(lblDepthUnits != nullptr);
+  auto *htmlDepthVolumes{wizDepth->findChild<QTextEdit *>("htmlDepthVolumes")};
+  REQUIRE(htmlDepthVolumes != nullptr);
+  // last page
+  auto *wizReactions{wiz.findChild<QWizardPage *>("wizReactions")};
+  REQUIRE(wizReactions != nullptr);
+  auto *htmlReactionsRescalings{
+      wizReactions->findChild<QTextEdit *>("htmlReactionsRescalings")};
+  REQUIRE(htmlReactionsRescalings != nullptr);
+}


### PR DESCRIPTION
- MainWindow
  - on ODE model import, status bar contains instructions/clickable link for next step
- OdeImportWizard
  - finalize ode import & explain what is being done
  - suggests depth value based on matching ODE and PDE compartment volumes
    - displays ratio of these volumes, coloured red if significantly different
  - calls makeReactionsSpatial() to rescale reaction rates
- ModelReactions
  - no longer automatically rescales reaction rates on import or when location is changed
  - constructor takes `isNonSpatialModel` bool
  - makeReactionsSpatial(): now rescales reaction rates ODE -> PDE
  - added makeLocationsValid(): sets each location to best guess, called when all compartments assigned valid geometry
  - add getIsIncompleteODEImport(): true if ode model imported, until makeReactionsSpatial is called
- ModelCompartments
  - store intial compartment Size values on load
- validateAndUpgradeSBMLDoc
  - checks if initial model is spatial
  - returns a struct instead of a string
