### PR TITLE
add n_threads option to sme simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## latest
+### Added
+- python interface: optional multithreading (via OpenMP) for Pixel simulations on linux [#662](https://github.com/spatial-model-editor/spatial-model-editor/pull/662)
 
 ## [1.1.5] - 2021-09-01
 ### Added

--- a/ci/linux-wheels.sh
+++ b/ci/linux-wheels.sh
@@ -15,12 +15,13 @@ cmake .. \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/opt/smelibs \
   -DBUILD_BENCHMARKS=off \
-  -DBUILD_GUI=OFF \
+  -DBUILD_GUI=off \
   -DBUILD_CLI=off \
   -DBUILD_TESTING=off \
   -DBUILD_PYTHON_LIBRARY=off \
   -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
-  -DSME_EXTERNAL_SMECORE=off
+  -DSME_EXTERNAL_SMECORE=off \
+  -DSME_WITH_OPENMP=on
 make -j2 core
 make install
 cd ..

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ class CMakeBuild(build_ext):
             "SME_EXTRA_EXE_LIBS",
             "SME_EXTERNAL_SMECORE",
             "SME_QT_DISABLE_UNICODE",
+            "SME_WITH_OPENMP",
             "PYTHON_LIBRARY",
             "CMAKE_CXX_COMPILER_LAUNCHER",
             "SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM",

--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -39,11 +39,13 @@ public:
   simulateString(const std::string &lengths, const std::string &intervals,
                  int timeoutSeconds, bool throwOnTimeout,
                  simulate::SimulatorType simulatorType,
-                 bool continueExistingSimulation, bool returnResults);
+                 bool continueExistingSimulation, bool returnResults,
+                 int nThreads);
   std::vector<SimulationResult>
   simulateFloat(double simulationTime, double imageInterval, int timeoutSeconds,
                 bool throwOnTimeout, simulate::SimulatorType simulatorType,
-                bool continueExistingSimulation, bool returnResults);
+                bool continueExistingSimulation, bool returnResults,
+                int nThreads);
   std::vector<SimulationResult> getSimulationResults();
   [[nodiscard]] std::string getStr() const;
 };

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -108,7 +108,7 @@ class TestModel(unittest.TestCase):
             self.assertEqual(len(sim_results), len(sim_results2))
 
             # previous sim results are cleared by default
-            sim_results = m.simulate(0.002, 0.001, simulator_type=sim_type)
+            sim_results = m.simulate(0.002, 0.001, simulator_type=sim_type, n_threads=2)
             self.assertEqual(len(sim_results), 3)
 
             sim_results2 = m.simulation_results()


### PR DESCRIPTION
- enable openMP in linux wheels
- n_threads=1 by default so existing behaviour unchanged
- resolves #662
