### PR TITLE
fix dangling pointer to simulation data bug

### DIFF
--- a/src/core/model/inc/model_compartments.hpp
+++ b/src/core/model/inc/model_compartments.hpp
@@ -46,11 +46,11 @@ private:
 public:
   ModelCompartments();
   ModelCompartments(libsbml::Model *model, ModelMembranes *membranes,
-
                     const ModelUnits *units, simulate::SimulationData *data);
   void setGeometryPtr(ModelGeometry *geometry);
   void setSpeciesPtr(ModelSpecies *species);
   void setReactionsPtr(ModelReactions *reactions);
+  void setSimulationDataPtr(simulate::SimulationData *data);
   [[nodiscard]] const QStringList &getIds() const;
   [[nodiscard]] const QStringList &getNames() const;
   [[nodiscard]] const QVector<QRgb> &getColours() const;

--- a/src/core/model/inc/model_species.hpp
+++ b/src/core/model/inc/model_species.hpp
@@ -52,6 +52,7 @@ public:
                const ModelGeometry *geometry, const ModelParameters *parameters,
                simulate::SimulationData *data, Settings *annotation);
   void setReactionsPtr(ModelReactions *reactions);
+  void setSimulationDataPtr(simulate::SimulationData *data);
   QString add(const QString &name, const QString &compartmentId);
   void remove(const QString &id);
   QString setName(const QString &id, const QString &name);

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -147,6 +147,9 @@ void Model::importFile(const std::string &filename) {
   if (importedSmeFileContents != nullptr) {
     smeFileContents->simulationData =
         std::move(importedSmeFileContents->simulationData);
+    modelCompartments->setSimulationDataPtr(
+        smeFileContents->simulationData.get());
+    modelSpecies->setSimulationDataPtr(smeFileContents->simulationData.get());
   }
   setHasUnsavedChanges(false);
 }

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -72,7 +72,6 @@ ModelCompartments::ModelCompartments() = default;
 
 ModelCompartments::ModelCompartments(libsbml::Model *model,
                                      ModelMembranes *membranes,
-
                                      const ModelUnits *units,
                                      simulate::SimulationData *data)
     : ids{importIds(model)}, names{importNamesAndMakeUnique(model, ids)},
@@ -98,6 +97,10 @@ void ModelCompartments::setSpeciesPtr(ModelSpecies *species) {
 
 void ModelCompartments::setReactionsPtr(ModelReactions *reactions) {
   modelReactions = reactions;
+}
+
+void ModelCompartments::setSimulationDataPtr(simulate::SimulationData *data) {
+  simulationData = data;
 }
 
 const QStringList &ModelCompartments::getIds() const { return ids; }

--- a/src/core/model/src/model_species.cpp
+++ b/src/core/model/src/model_species.cpp
@@ -271,6 +271,10 @@ void ModelSpecies::setReactionsPtr(ModelReactions *reactions) {
   modelReactions = reactions;
 }
 
+void ModelSpecies::setSimulationDataPtr(simulate::SimulationData *data) {
+  simulationData = data;
+}
+
 QString ModelSpecies::add(const QString &name, const QString &compartmentId) {
   hasUnsavedChanges = true;
   SPDLOG_INFO("Clearing simulation data");

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -904,10 +904,16 @@ SCENARIO("SBML: load .xml model, simulate, save as .sme, load .sme",
   s2.importFile("test.sme");
   REQUIRE(s2.getCompartments().getIds() == s.getCompartments().getIds());
   REQUIRE(s.getXml() == s2.getXml());
-  REQUIRE(s.getSimulationData().timePoints.size() == 3);
-  REQUIRE(s.getSimulationData().timePoints[2] == dbl_approx(0.2));
-  REQUIRE(s.getSimulationData().concPadding.size() == 3);
-  REQUIRE(s.getSimulationData().concPadding[2] == dbl_approx(0));
+  REQUIRE(s2.getSimulationData().timePoints.size() == 3);
+  REQUIRE(s2.getSimulationData().timePoints[2] == dbl_approx(0.2));
+  REQUIRE(s2.getSimulationData().concPadding.size() == 3);
+  REQUIRE(s2.getSimulationData().concPadding[2] == dbl_approx(0));
+  model::Model s3;
+  s3.importFile("test.sme");
+  // do something that causes ModelCompartments to clear the simulation results
+  // https://github.com/spatial-model-editor/spatial-model-editor/issues/666
+  s3.getGeometry().setPixelWidth(1.2, true);
+  REQUIRE(s3.getSimulationData().timePoints.size() == 0);
 }
 
 SCENARIO("SBML: import multi-compartment SBML doc without spatial geometry",


### PR DESCRIPTION
- add `setSimulationDataPtr()` to `ModelCompartments`, `ModelSpecies`
- use it to update data pointer after loading simulation data in `Model::importFile()`
- resolves #666
