### PR TITLE
allow ctrl+c to cancel sme simulation

### DIFF
--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -379,7 +379,13 @@ Model::simulateString(const std::string &lengths, const std::string &intervals,
   if (const auto &e = sim->errorMessage(); !e.empty()) {
     throw SmeRuntimeError(fmt::format("Error in simulation setup: {}", e));
   }
-  sim->doMultipleTimesteps(times.value(), timeoutMillisecs);
+  sim->doMultipleTimesteps(times.value(), timeoutMillisecs, []() {
+    if (PyErr_CheckSignals() != 0) {
+      throw pybind11::error_already_set();
+      return true;
+    }
+    return false;
+  });
   if (const auto &e = sim->errorMessage(); throwOnTimeout && !e.empty()) {
     throw SmeRuntimeError(fmt::format("Error during simulation: {}", e));
   }

--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -10,6 +10,7 @@
 #include <QSize>
 #include <atomic>
 #include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <memory>
@@ -68,7 +69,8 @@ public:
                           double timeout_ms = -1.0);
   std::size_t doMultipleTimesteps(
       const std::vector<std::pair<std::size_t, double>> &timesteps,
-      double timeout_ms = -1.0);
+      double timeout_ms = -1.0,
+      const std::function<bool()> &stopRunningCallback = {});
   [[nodiscard]] const std::string &errorMessage() const;
   [[nodiscard]] const QImage &errorImage() const;
   [[nodiscard]] const std::vector<std::string> &getCompartmentIds() const;

--- a/src/core/simulate/src/CMakeLists.txt
+++ b/src/core/simulate/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if(BUILD_TESTING)
            duneini_t.cpp
            dunesim_t.cpp
            pde_t.cpp
+           pixelsim_t.cpp
            simulate_data_t.cpp
            simulate_options_t.cpp
            simulate_t.cpp)

--- a/src/core/simulate/src/basesim.hpp
+++ b/src/core/simulate/src/basesim.hpp
@@ -11,7 +11,8 @@ namespace sme::simulate {
 class BaseSim {
 public:
   virtual ~BaseSim() = default;
-  virtual std::size_t run(double time, double timeout_ms = -1.0) = 0;
+  virtual std::size_t run(double time, double timeout_ms,
+                          const std::function<bool()> &stopRunningCallback) = 0;
   [[nodiscard]] virtual const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const = 0;
   [[nodiscard]] virtual std::size_t getConcentrationPadding() const = 0;

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -233,7 +233,8 @@ DuneSim::DuneSim(
 
 DuneSim::~DuneSim() = default;
 
-std::size_t DuneSim::run(double time, double timeout_ms) {
+std::size_t DuneSim::run(double time, double timeout_ms,
+                         const std::function<bool()> &stopRunningCallback) {
   if (pDuneImpl == nullptr) {
     return 0;
   }
@@ -246,6 +247,10 @@ std::size_t DuneSim::run(double time, double timeout_ms) {
   } catch (const Dune::Exception &e) {
     currentErrorMessage = e.what();
     SPDLOG_ERROR("{}", currentErrorMessage);
+  }
+  if (stopRunningCallback && stopRunningCallback()) {
+    SPDLOG_DEBUG("Simulation cancelled: requesting stop");
+    currentErrorMessage = "Simulation cancelled";
   }
   if (timeout_ms >= 0.0 && static_cast<double>(timer.elapsed()) >= timeout_ms) {
     SPDLOG_DEBUG("Simulation timeout: requesting stop");

--- a/src/core/simulate/src/dunesim.hpp
+++ b/src/core/simulate/src/dunesim.hpp
@@ -71,7 +71,8 @@ public:
       const std::vector<std::string> &compartmentIds,
       const std::map<std::string, double, std::less<>> &substitutions = {});
   ~DuneSim() override;
-  std::size_t run(double time, double timeout_ms) override;
+  std::size_t run(double time, double timeout_ms,
+                  const std::function<bool()> &stopRunningCallback) override;
   [[nodiscard]] const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
   [[nodiscard]] std::size_t getConcentrationPadding() const override;

--- a/src/core/simulate/src/dunesim_t.cpp
+++ b/src/core/simulate/src/dunesim_t.cpp
@@ -6,9 +6,8 @@
 using namespace sme;
 using namespace sme::test;
 
-SCENARIO("DuneSim: empty compartments",
-         "[core/simulate/dunesim][core/"
-         "simulate][core][simulate][dunesim][dune]") {
+SCENARIO("DuneSim", "[core/simulate/dunesim][core/"
+                    "simulate][core][simulate][dunesim][dune]") {
   WHEN("Model has no species") {
     auto m{getExampleModel(Mod::ABtoC)};
     for (const auto &speciesId : m.getSpecies().getIds("comp")) {
@@ -40,7 +39,7 @@ SCENARIO("DuneSim: empty compartments",
     REQUIRE(maxAreas.size() == 3);
     simulate::DuneSim duneSim(m, comps);
     for (std::size_t i = 0; i < 2; ++i) {
-      duneSim.run(0.05, 100e3);
+      duneSim.run(0.05, 100e3, {});
     }
     simulate::SimulationData data0{m.getSimulationData()};
     REQUIRE(duneSim.getConcentrations(0).size() == 5441);
@@ -62,7 +61,7 @@ SCENARIO("DuneSim: empty compartments",
     comps.pop_back();
     simulate::DuneSim newDuneSim(m, comps);
     for (std::size_t i = 0; i < 2; ++i) {
-      newDuneSim.run(0.05, 100e3);
+      newDuneSim.run(0.05, 100e3, {});
     }
     REQUIRE(newDuneSim.getConcentrations(0).size() == 5441);
     REQUIRE(newDuneSim.getConcentrations(1).size() == 8068);
@@ -80,5 +79,13 @@ SCENARIO("DuneSim: empty compartments",
       CAPTURE(diff);
       REQUIRE(diff / sum < 1e-10);
     }
+  }
+  WHEN("Callback is provided and used to stop simulation") {
+    auto m{getExampleModel(Mod::ABtoC)};
+    std::vector<std::string> comps{"comp"};
+    simulate::DuneSim duneSim(m, comps);
+    REQUIRE(duneSim.errorMessage().empty());
+    duneSim.run(1, -1, []() { return true; });
+    REQUIRE(duneSim.errorMessage() == "Simulation cancelled");
   }
 }

--- a/src/core/simulate/src/pixelsim.cpp
+++ b/src/core/simulate/src/pixelsim.cpp
@@ -332,7 +332,8 @@ PixelSim::PixelSim(
 
 PixelSim::~PixelSim() = default;
 
-std::size_t PixelSim::run(double time, double timeout_ms) {
+std::size_t PixelSim::run(double time, double timeout_ms,
+                          const std::function<bool()> &stopRunningCallback) {
   SPDLOG_TRACE("  - max rel local err {}", errMax.rel);
   SPDLOG_TRACE("  - max abs local err {}", errMax.abs);
   SPDLOG_TRACE("  - max stepsize {}", maxTimestep);
@@ -365,6 +366,10 @@ std::size_t PixelSim::run(double time, double timeout_ms) {
         static_cast<double>(timer.elapsed()) >= timeout_ms) {
       SPDLOG_DEBUG("Simulation timeout: requesting stop");
       setStopRequested(true);
+    }
+    if (stopRunningCallback && stopRunningCallback()) {
+      setStopRequested(true);
+      SPDLOG_DEBUG("Simulation cancelled: requesting stop");
     }
     if (stopRequested.load()) {
       currentErrorMessage = "Simulation stopped early";

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -58,7 +58,8 @@ public:
       const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
       const std::map<std::string, double, std::less<>> &substitutions = {});
   ~PixelSim() override;
-  std::size_t run(double time, double timeout_ms) override;
+  std::size_t run(double time, double timeout_ms,
+                  const std::function<bool()> &stopRunningCallback) override;
   [[nodiscard]] const std::vector<double> &
   getConcentrations(std::size_t compartmentIndex) const override;
   [[nodiscard]] std::size_t getConcentrationPadding() const override;

--- a/src/core/simulate/src/pixelsim_t.cpp
+++ b/src/core/simulate/src/pixelsim_t.cpp
@@ -1,0 +1,20 @@
+#include "catch_wrapper.hpp"
+#include "model.hpp"
+#include "model_test_utils.hpp"
+#include "pixelsim.hpp"
+
+using namespace sme;
+using namespace sme::test;
+
+SCENARIO("PixelSim", "[core/simulate/pixelsim][core/"
+                     "simulate][core][simulate][pixel]") {
+  WHEN("Callback is provided and used to stop simulation") {
+    auto m{getExampleModel(Mod::ABtoC)};
+    std::vector<std::string> comps{"comp"};
+    std::vector<std::vector<std::string>> specs{{"A", "B", "C"}};
+    simulate::PixelSim pixelSim(m, comps, specs);
+    REQUIRE(pixelSim.errorMessage().empty());
+    pixelSim.run(1, -1, []() { return true; });
+    REQUIRE(pixelSim.errorMessage() == "Simulation stopped early");
+  }
+}

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -269,9 +269,9 @@ void TabSimulate::btnSimulate_clicked() {
 
   this->setCursor(Qt::WaitCursor);
   // start simulation in a new thread
-  simSteps = std::async(std::launch::async,
-                        &sme::simulate::Simulation::doMultipleTimesteps,
-                        sim.get(), simulationTimes.value(), -1.0);
+  simSteps = std::async(
+      std::launch::async, &sme::simulate::Simulation::doMultipleTimesteps,
+      sim.get(), simulationTimes.value(), -1.0, std::function<bool()>{});
   // start timer to periodically update simulation results
   plotRefreshTimer.start();
 }


### PR DESCRIPTION
- add optional stopRunningCallback to simulate
- whenever simulation checks for timeout, it also calls this if it exists
- if it returns true, simulation behaves in same way as if timeout occurs
- in sme: callback checks if python signal has been raised, e.g. ctrl+c from user, and if so throws
- resolves #665
