### PR TITLE
refactor common::Symbolic

### DIFF
--- a/src/core/common/inc/simple_symbolic.hpp
+++ b/src/core/common/inc/simple_symbolic.hpp
@@ -1,0 +1,24 @@
+// SimpleSymbolic
+//  - basic symbolic algebra functionality
+//  - lightweight alternative to Symbolic
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sme::common {
+
+class SimpleSymbolic {
+public:
+  static std::string divide(const std::string &expr, const std::string &var);
+  static std::string multiply(const std::string &expr, const std::string &var);
+  static std::string
+  substitute(const std::string &expr,
+             const std::vector<std::pair<std::string, double>> &constants);
+  static bool contains(const std::string &expr, const std::string &var);
+};
+
+} // namespace sme::common

--- a/src/core/common/inc/symbolic.hpp
+++ b/src/core/common/inc/symbolic.hpp
@@ -1,14 +1,16 @@
-// Symbolic algebra routines (simple wrapper around SymEngine)
-//  - takes a vector of math expressions as strings
-//     - with list of variables
-//     - with list of constants and their numeric values
-//  - parses expressions
-//  - returns simplified expressions with constants inlined as string
+// Symbolic
+//  - takes a vector of math expressions as strings with
+//     - variables (to remain variables after compilation)
+//     - constants and their numeric values (to be inlined during compilation)
+//     - functions with args & definition (to be inlined during compilation)
+//  - parses & validates expressions
+//  - returns simplified expressions with constants/functions inlined as string
 //  - returns differential of any expression wrt any variable as string
-//  - evaluates expressions (with LLVM compilation)
+//  - compiles expressions using LLVM for fast repeated evaluation
 
 #pragma once
 
+#include "symbolic_function.hpp"
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -17,34 +19,13 @@
 
 namespace sme::common {
 
-// divide given expression by a variable
-std::string symbolicDivide(const std::string &expr, const std::string &var);
-
-// multiply given expression by a variable
-std::string symbolicMultiply(const std::string &expr, const std::string &var);
-
-// substitute the constants in the given expression with their numerical values
-std::string symbolicSubstitute(
-    const std::string &expr,
-    const std::vector<std::pair<std::string, double>> &constants);
-
-// check if an expression contains a variable
-bool symbolicContains(const std::string &expr, const std::string &var);
-
-const char *getLLVMVersion();
-
-struct Function {
-  std::string id;
-  std::string name;
-  std::vector<std::string> args;
-  std::string body;
-};
-
 class Symbolic {
 private:
-  struct SymEngineImpl;
   struct SymEngineFunc;
-  std::unique_ptr<SymEngineImpl> pSymEngineImpl;
+  struct SymEngineWrapper;
+  std::unique_ptr<SymEngineWrapper> se;
+  bool valid{false};
+  bool compiled{false};
 
 public:
   Symbolic();
@@ -52,22 +33,20 @@ public:
       const std::vector<std::string> &expressions,
       const std::vector<std::string> &variables = {},
       const std::vector<std::pair<std::string, double>> &constants = {},
-      const std::vector<Function> &functions = {}, bool compile = true,
-      bool doCSE = true, unsigned optLevel = 3);
+      const std::vector<SymbolicFunction> &functions = {});
   explicit Symbolic(
       const std::string &expression,
       const std::vector<std::string> &variables = {},
       const std::vector<std::pair<std::string, double>> &constants = {},
-      const std::vector<Function> &functions = {}, bool compile = true,
-      bool doCSE = true, unsigned optLevel = 3)
+      const std::vector<SymbolicFunction> &functions = {})
       : Symbolic(std::vector<std::string>{expression}, variables, constants,
-                 functions, compile, doCSE, optLevel) {}
+                 functions) {}
   Symbolic(Symbolic &&) noexcept;
   Symbolic(const Symbolic &) = delete;
   Symbolic &operator=(Symbolic &&) noexcept;
   Symbolic &operator=(const Symbolic &) = delete;
   ~Symbolic();
-
+  static const char *getLLVMVersion();
   void compile(bool doCSE = true, unsigned optLevel = 3);
   [[nodiscard]] std::string expr(std::size_t i = 0) const;
   [[nodiscard]] std::string inlinedExpr(std::size_t i = 0) const;

--- a/src/core/common/inc/symbolic_function.hpp
+++ b/src/core/common/inc/symbolic_function.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace sme::common {
+
+struct SymbolicFunction {
+  std::string id;
+  std::string name;
+  std::vector<std::string> args;
+  std::string body;
+};
+} // namespace sme::common

--- a/src/core/common/src/CMakeLists.txt
+++ b/src/core/common/src/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
   core
   PRIVATE logger.cpp
           serialization.cpp
+          simple_symbolic.cpp
           symbolic.cpp
           tiff.cpp
           utils.cpp
@@ -13,6 +14,7 @@ if(BUILD_TESTING)
     core_tests
     PUBLIC logger_t.cpp
            serialization_t.cpp
+           simple_symbolic_t.cpp
            symbolic_t.cpp
            tiff_t.cpp
            utils_t.cpp)

--- a/src/core/common/src/simple_symbolic.cpp
+++ b/src/core/common/src/simple_symbolic.cpp
@@ -1,0 +1,48 @@
+#include "simple_symbolic.hpp"
+#include "logger.hpp"
+#include <symengine/basic.h>
+#include <symengine/parser.h>
+#include <symengine/parser/sbml/sbml_parser.h>
+#include <symengine/printers/strprinter.h>
+
+namespace sme::common {
+
+using namespace SymEngine;
+
+static RCP<const Basic> safeParse(const std::string &expr) {
+  // hack until https://github.com/symengine/symengine/issues/1566 is resolved:
+  // (SymEngine parser relies on strtod and assumes C locale)
+  std::locale userLocale{std::locale::global(std::locale::classic())};
+  auto e{parse_sbml(expr)};
+  std::locale::global(userLocale);
+  return e;
+}
+
+std::string SimpleSymbolic::divide(const std::string &expr,
+                                   const std::string &var) {
+  return sbml(*div(safeParse(expr), safeParse(var)));
+}
+
+std::string SimpleSymbolic::multiply(const std::string &expr,
+                                     const std::string &var) {
+  return sbml(*mul(safeParse(expr), safeParse(var)));
+}
+
+std::string SimpleSymbolic::substitute(
+    const std::string &expr,
+    const std::vector<std::pair<std::string, double>> &constants) {
+  map_basic_basic d;
+  for (const auto &[name, value] : constants) {
+    SPDLOG_DEBUG("  - constant {} = {}", name, value);
+    d[symbol(name)] = real_double(value);
+  }
+  return sbml(*safeParse(expr)->subs(d));
+}
+
+bool SimpleSymbolic::contains(const std::string &expr, const std::string &var) {
+  auto v{symbol(var)};
+  auto fs{free_symbols(*safeParse(expr))};
+  return fs.find(v) != fs.cend();
+}
+
+} // namespace sme::common

--- a/src/core/common/src/simple_symbolic_t.cpp
+++ b/src/core/common/src/simple_symbolic_t.cpp
@@ -1,0 +1,71 @@
+#include "catch_wrapper.hpp"
+#include "math_test_utils.hpp"
+#include "simple_symbolic.hpp"
+#include <cmath>
+
+using namespace sme;
+using namespace sme::test;
+
+SCENARIO("SimpleSymbolic",
+         "[core/common/simple_symbolic][core/common][core][simple_symbolic]") {
+  GIVEN("divide expression with number") {
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x", "1.3"), "x/1.3"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("1", "2"), "2^(-1)"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("10*x", "5"), "2*x"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("(cos(x))^2+3", "3.14"),
+                  "(3 + cos(x)^2)/3.14"));
+    REQUIRE(
+        symEq(common::SimpleSymbolic::divide("2*unknown_function(a,b,c)", "2"),
+              "2*unknown_function(a, b, c)/2"));
+  }
+  GIVEN("divide expression with symbol") {
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x", "x"), "1"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("1", "x"), "x^(-1)"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("0", "x"), "0"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x^2", "x"), "x"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x+3*x", "x"), "4"));
+  }
+  GIVEN("divide expression with other symbols") {
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x+a", "x"), "(a + x)/x"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x+y", "x"), "(x + y)/x"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("y*x", "x"), "y"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("y*x*z/y", "x"), "z"));
+  }
+  GIVEN("divide expression with other symbols & functions") {
+    REQUIRE(
+        symEq(common::SimpleSymbolic::divide("sin(x+a)", "x"), "sin(a + x)/x"));
+    REQUIRE(
+        symEq(common::SimpleSymbolic::divide("x*sin(x+a)", "x"), "sin(a + x)"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("x*unknown(z)", "x"),
+                  "unknown(z)"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide(
+                      "x*(unknown1(unknown2(x)) + 2*another_unknown(q))", "x"),
+                  "2*another_unknown(q) + unknown1(unknown2(x))"));
+    REQUIRE(symEq(common::SimpleSymbolic::divide("unknown1(unknown2(z))", "x"),
+                  "unknown1(unknown2(z))/x"));
+  }
+  GIVEN("multiply expression with number") {
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("x", "1.3"), "x*1.3"));
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("1", "2"), "2"));
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("10*x", "5"), "10*5*x"));
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("4.2/x", "x"), "4.2"));
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("cos(y)/x", "x"), "cos(y)"));
+    REQUIRE(symEq(common::SimpleSymbolic::multiply("unknown(z)/x", "x"),
+                  "unknown(z)"));
+    REQUIRE(symEq(
+        common::SimpleSymbolic::multiply("x*unknown_function(a,b,c)/x/x", "x"),
+        "unknown_function(a, b, c)"));
+  }
+  GIVEN("check if expression contains symbol") {
+    REQUIRE(common::SimpleSymbolic::contains("x", "x") == true);
+    REQUIRE(common::SimpleSymbolic::contains("1", "x") == false);
+    REQUIRE(common::SimpleSymbolic::contains("y+x^2", "x") == true);
+    REQUIRE(common::SimpleSymbolic::contains("y+x^2", "y") == true);
+    REQUIRE(common::SimpleSymbolic::contains("y+x^2", "z") == false);
+    REQUIRE(common::SimpleSymbolic::contains("x*unknown(z)", "x") == true);
+    REQUIRE(common::SimpleSymbolic::contains("z*unknown(x)", "x") == true);
+    REQUIRE(common::SimpleSymbolic::contains("z*unknown(y)", "x") == false);
+    REQUIRE(common::SimpleSymbolic::contains("(cos(symbol))^2+3", "symbol") ==
+            true);
+  }
+}

--- a/src/core/common/src/symbolic.cpp
+++ b/src/core/common/src/symbolic.cpp
@@ -1,123 +1,101 @@
 #include "symbolic.hpp"
 #include "logger.hpp"
-#include <algorithm>
 #include <llvm/Config/llvm-config.h>
-#include <locale>
-#include <sstream>
+#include <map>
 #include <symengine/basic.h>
-#include <symengine/constants.h>
-#include <symengine/dict.h>
-#include <symengine/functions.h>
 #include <symengine/llvm_double.h>
-#include <symengine/mul.h>
-#include <symengine/number.h>
-#include <symengine/parser.h>
 #include <symengine/parser/sbml/sbml_parser.h>
-#include <symengine/printers/strprinter.h>
-#include <symengine/rational.h>
-#include <symengine/real_double.h>
-#include <symengine/symbol.h>
-#include <symengine/symengine_exception.h>
 #include <symengine/symengine_rcp.h>
-#include <symengine/visitor.h>
 
 namespace sme::common {
 
-static std::string toString(const SymEngine::RCP<const SymEngine::Basic> &e) {
-  return SymEngine::sbml(*e);
-}
+using namespace SymEngine;
 
 struct Symbolic::SymEngineFunc {
-  std::string name;
-  SymEngine::vec_basic args;
-  SymEngine::RCP<const SymEngine::Basic> body;
+  std::string name{};
+  vec_basic args{};
+  RCP<const Basic> body{};
+  SymEngineFunc() = default;
+  explicit SymEngineFunc(const SymbolicFunction &symbolicFunction);
 };
 
-struct Symbolic::SymEngineImpl {
-  SymEngine::vec_basic exprInlined{};
-  SymEngine::vec_basic exprOriginal{};
-  SymEngine::vec_basic varVec{};
-  SymEngine::LLVMDoubleVisitor lambdaLLVM{};
-  std::map<std::string, SymEngine::RCP<const SymEngine::Symbol>> symbols{};
-  bool valid{false};
-  bool compiled{false};
+Symbolic::SymEngineFunc::SymEngineFunc(const SymbolicFunction &symbolicFunction)
+    : name{symbolicFunction.name} {
+  SbmlParser parser;
+  for (const auto &arg : symbolicFunction.args) {
+    args.push_back(parser.parse(arg));
+  }
+  body = parser.parse(symbolicFunction.body);
+}
+
+struct Symbolic::SymEngineWrapper {
+  LLVMDoubleVisitor lambdaLLVM{};
+  vec_basic exprInlined{};
+  vec_basic exprOriginal{};
+  vec_basic varVec{};
+  std::map<std::string, RCP<const Symbol>, std::less<>> symbols{};
   std::string errorMessage{};
-  void init(const std::vector<std::string> &expressions,
-            const std::vector<std::string> &variables,
-            const std::vector<std::pair<std::string, double>> &constants,
-            const std::vector<Function> &functions);
-  void compile(bool doCSE, unsigned optLevel);
-  void relabel(const std::vector<std::string> &newVariables);
-  void rescale(double factor, const std::vector<std::string> &exclusions = {});
 };
 
-void Symbolic::SymEngineImpl::init(
-    const std::vector<std::string> &expressions,
-    const std::vector<std::string> &variables,
-    const std::vector<std::pair<std::string, double>> &constants,
-    const std::vector<Function> &functions) {
+Symbolic::Symbolic() = default;
+
+Symbolic::Symbolic(const std::vector<std::string> &expressions,
+                   const std::vector<std::string> &variables,
+                   const std::vector<std::pair<std::string, double>> &constants,
+                   const std::vector<SymbolicFunction> &functions)
+    : se{std::make_unique<SymEngineWrapper>()} {
   SPDLOG_DEBUG("parsing {} expressions", expressions.size());
-  valid = true;
-  compiled = false;
   for (const auto &v : variables) {
     SPDLOG_DEBUG("  - variable {}", v);
-    symbols[v] = SymEngine::symbol(v);
-    varVec.push_back(symbols[v]);
+    se->symbols[v] = symbol(v);
+    se->varVec.push_back(se->symbols[v]);
   }
-  SymEngine::map_basic_basic d;
+  map_basic_basic d;
   for (const auto &[name, value] : constants) {
     SPDLOG_DEBUG("  - constant {} = {}", name, value);
-    d[SymEngine::symbol(name)] = SymEngine::real_double(value);
+    d[symbol(name)] = real_double(value);
   }
   // hack until https://github.com/symengine/symengine/issues/1566 is resolved:
   // (SymEngine parser relies on strtod and assumes C locale)
-  std::locale userLocale = std::locale::global(std::locale::classic());
-  SymEngine::SbmlParser parser;
+  std::locale userLocale{std::locale::global(std::locale::classic())};
+  SbmlParser parser;
   // map from function id to symengine expressions
-  std::map<std::string, Symbolic::SymEngineFunc> symEngineFuncs;
+  std::map<std::string, SymEngineFunc, std::less<>> symEngineFuncs;
   for (const auto &function : functions) {
     SPDLOG_DEBUG("  - function '{}: {}'", function.id, function.body);
-    auto &symEngineFunc = symEngineFuncs[function.id];
-    symEngineFunc.name = function.name;
-    for (const auto &arg : function.args) {
-      symEngineFunc.args.push_back(parser.parse(arg));
-    }
-    symEngineFunc.body = parser.parse(function.body);
+    symEngineFuncs[function.id] = SymEngineFunc(function);
   }
   for (const auto &expression : expressions) {
-    SymEngine::map_basic_basic fns;
+    map_basic_basic fns;
     SPDLOG_DEBUG("expr {}", expression);
     // parse expression & substitute all supplied functions & numeric constants
     // todo: clean this up - see
     // https://github.com/symengine/symengine/issues/1689
     try {
       int remainingAllowedReplaceLoops{1024};
-      auto e = parser.parse(expression);
-      SymEngine::RCP<const SymEngine::Basic> ePrevious{SymEngine::zero};
-      exprOriginal.push_back(e);
-      auto remainingSymbols = SymEngine::function_symbols(*e);
+      auto e{parser.parse(expression)};
+      RCP<const Basic> ePrevious{zero};
+      se->exprOriginal.push_back(e);
+      auto remainingSymbols{function_symbols(*e)};
       while (!remainingSymbols.empty() && !eq(*e, *ePrevious) &&
              --remainingAllowedReplaceLoops > 0) {
         ePrevious = e;
         for (const auto &funcSymbol : remainingSymbols) {
           auto name =
-              SymEngine::rcp_dynamic_cast<const SymEngine::FunctionSymbol>(
-                  funcSymbol)
-                  ->get_name();
-          if (auto iter = symEngineFuncs.find(name);
+              rcp_dynamic_cast<const FunctionSymbol>(funcSymbol)->get_name();
+          if (auto iter{symEngineFuncs.find(name)};
               iter != symEngineFuncs.cend()) {
             const auto &f = iter->second;
             const auto &args = funcSymbol->get_args();
             if (args.size() != f.args.size()) {
-              valid = false;
-              errorMessage =
+              se->errorMessage =
                   fmt::format("Function '{}' requires {} argument(s), found {}",
                               f.name, f.args.size(), args.size());
-              SPDLOG_WARN("{}", errorMessage);
+              SPDLOG_WARN("{}", se->errorMessage);
               std::locale::global(userLocale);
               return;
             }
-            SymEngine::map_basic_basic arg_map;
+            map_basic_basic arg_map;
             for (std::size_t i = 0; i < args.size(); ++i) {
               arg_map[f.args[i]] = args[i];
             }
@@ -130,194 +108,46 @@ void Symbolic::SymEngineImpl::init(
           eReplaced = e->xreplace(fns);
         }
         e = eReplaced;
-        remainingSymbols = SymEngine::function_symbols(*e);
+        remainingSymbols = function_symbols(*e);
       }
       if (remainingAllowedReplaceLoops <= 0) {
-        valid = false;
-        errorMessage = "Recursive function calls not supported";
-        SPDLOG_WARN("{}", errorMessage);
+        se->errorMessage = "Recursive function calls not supported";
+        SPDLOG_WARN("{}", se->errorMessage);
         std::locale::global(userLocale);
         return;
       }
-      exprInlined.push_back(e->subs(d));
-    } catch (const SymEngine::SymEngineException &e) {
+      se->exprInlined.push_back(e->subs(d));
+    } catch (const SymEngineException &e) {
       // if SymEngine failed to parse, capture error message
       SPDLOG_WARN("{}", e.what());
-      valid = false;
-      errorMessage = e.what();
+      se->errorMessage = e.what();
       std::locale::global(userLocale);
       return;
     }
-    SPDLOG_DEBUG("  --> {}", toString(exprInlined.back()));
+    SPDLOG_DEBUG("  --> {}", sbml(*se->exprInlined.back()));
     // check that all remaining symbols are in the variables vector
-    auto fs = SymEngine::free_symbols(*exprInlined.back());
+    auto fs = free_symbols(*se->exprInlined.back());
     if (auto iter = find_if(fs.cbegin(), fs.cend(),
                             [&v = variables](const auto &s) {
                               return std::find(v.cbegin(), v.cend(),
-                                               toString(s)) == v.cend();
+                                               sbml(*s)) == v.cend();
                             });
         iter != fs.cend()) {
-      valid = false;
-      errorMessage = "Unknown symbol: " + toString(*iter);
-      SPDLOG_WARN("{}", errorMessage);
+      se->errorMessage = "Unknown symbol: " + sbml(*(*iter));
+      SPDLOG_WARN("{}", se->errorMessage);
       std::locale::global(userLocale);
       return;
     }
-    auto fn = SymEngine::function_symbols(*exprInlined.back());
+    auto fn{function_symbols(*se->exprInlined.back())};
     if (!fn.empty()) {
-      valid = false;
-      errorMessage = "Unknown function: " + toString(*fn.begin());
-      SPDLOG_WARN("{}", errorMessage);
+      se->errorMessage = "Unknown function: " + sbml(*(*fn.begin()));
+      SPDLOG_WARN("{}", se->errorMessage);
       std::locale::global(userLocale);
       return;
     }
   }
+  valid = true;
   std::locale::global(userLocale);
-}
-
-void Symbolic::SymEngineImpl::compile(bool doCSE, unsigned optLevel) {
-  SPDLOG_DEBUG("compiling expression:");
-#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  if (varVec.size() == exprInlined.size()) {
-    for (std::size_t i = 0; i < varVec.size(); ++i) {
-      SPDLOG_TRACE("  [{}] <- {}", toString(varVec[i]),
-                   toString(exprInlined[i]));
-    }
-  }
-#endif
-  try {
-    lambdaLLVM.init(varVec, exprInlined, doCSE, optLevel);
-  } catch (const std::exception &e) {
-    // if SymEngine failed to compile, capture error message
-    SPDLOG_WARN("{}", e.what());
-    valid = false;
-    compiled = false;
-    errorMessage = "Failed to compile expression: ";
-    errorMessage.append(e.what());
-    return;
-  }
-  compiled = true;
-}
-
-void Symbolic::SymEngineImpl::relabel(
-    const std::vector<std::string> &newVariables) {
-  if (varVec.size() != newVariables.size()) {
-    SPDLOG_WARN("cannot relabel variables: newVariables size {} "
-                "does not match number of existing variables {}",
-                newVariables.size(), varVec.size());
-    return;
-  }
-  decltype(varVec) newVarVec;
-  decltype(symbols) newSymbols;
-  SymEngine::map_basic_basic d;
-  for (std::size_t i = 0; i < newVariables.size(); ++i) {
-    const auto &v = newVariables[i];
-    newSymbols[v] = SymEngine::symbol(v);
-    newVarVec.push_back(newSymbols[v]);
-    d[varVec[i]] = newVarVec[i];
-    SPDLOG_DEBUG("relabeling {} -> {}", toString(varVec[i]),
-                 toString(newVarVec[i]));
-  }
-  // substitute new variables into all expressions
-  for (auto &e : exprInlined) {
-    SPDLOG_DEBUG("exprInlined '{}'", toString(e));
-    e = e->subs(d);
-    SPDLOG_DEBUG("  -> '{}'", toString(e));
-  }
-  for (auto &e : exprOriginal) {
-    SPDLOG_DEBUG("exprOriginal '{}'", toString(e));
-    e = e->subs(d);
-    SPDLOG_DEBUG("  -> '{}'", toString(e));
-  }
-  // replace old variables with new variables in vector & map
-  std::swap(varVec, newVarVec);
-  std::swap(symbols, newSymbols);
-  if (compiled) {
-    compile(true, 3);
-  }
-}
-
-void Symbolic::SymEngineImpl::rescale(
-    double factor, const std::vector<std::string> &exclusions) {
-  SymEngine::map_basic_basic d;
-  auto f = SymEngine::number(factor);
-  for (const auto &v : varVec) {
-    if (std::find(exclusions.cbegin(), exclusions.cend(), toString(v)) !=
-        exclusions.cend()) {
-      d[v] = v;
-    } else {
-      d[v] = SymEngine::mul(v, f);
-    }
-  }
-  for (auto &e : exprInlined) {
-    SPDLOG_DEBUG("exprInlined '{}'", toString(e));
-    e = e->subs(d);
-    SPDLOG_DEBUG("  -> '{}'", toString(e));
-  }
-  for (auto &e : exprOriginal) {
-    SPDLOG_DEBUG("exprOriginal '{}'", toString(e));
-    e = e->subs(d);
-    SPDLOG_DEBUG("  -> '{}'", toString(e));
-  }
-  if (compiled) {
-    compile(true, 3);
-  }
-}
-
-std::string symbolicDivide(const std::string &expr, const std::string &var) {
-  std::locale userLocale = std::locale::global(std::locale::classic());
-  std::string result = toString(
-      SymEngine::div(SymEngine::parse_sbml(expr), SymEngine::symbol(var)));
-  std::locale::global(userLocale);
-  return result;
-}
-
-std::string symbolicMultiply(const std::string &expr, const std::string &var) {
-  std::locale userLocale = std::locale::global(std::locale::classic());
-  std::string result = toString(
-      SymEngine::mul(SymEngine::parse_sbml(expr), SymEngine::symbol(var)));
-  std::locale::global(userLocale);
-  return result;
-}
-
-std::string symbolicSubstitute(
-    const std::string &expr,
-    const std::vector<std::pair<std::string, double>> &constants) {
-  std::locale userLocale = std::locale::global(std::locale::classic());
-  SymEngine::map_basic_basic d;
-  for (const auto &[name, value] : constants) {
-    SPDLOG_DEBUG("  - constant {} = {}", name, value);
-    d[SymEngine::symbol(name)] = SymEngine::real_double(value);
-  }
-  auto e{SymEngine::parse_sbml(expr)};
-  std::string result = toString(e->subs(d));
-  std::locale::global(userLocale);
-  return result;
-}
-
-bool symbolicContains(const std::string &expr, const std::string &var) {
-  std::locale userLocale = std::locale::global(std::locale::classic());
-  auto e{SymEngine::parse_sbml(expr)};
-  auto v{SymEngine::symbol(var)};
-  auto fs = SymEngine::free_symbols(*e);
-  std::locale::global(userLocale);
-  return fs.find(v) != fs.cend();
-}
-
-const char *getLLVMVersion() { return LLVM_VERSION_STRING; }
-
-Symbolic::Symbolic() = default;
-
-Symbolic::Symbolic(const std::vector<std::string> &expressions,
-                   const std::vector<std::string> &variables,
-                   const std::vector<std::pair<std::string, double>> &constants,
-                   const std::vector<Function> &functions, bool compile,
-                   bool doCSE, unsigned optLevel)
-    : pSymEngineImpl{std::make_unique<SymEngineImpl>()} {
-  pSymEngineImpl->init(expressions, variables, constants, functions);
-  if (compile && pSymEngineImpl->valid) {
-    pSymEngineImpl->compile(doCSE, optLevel);
-  }
 }
 
 Symbolic::~Symbolic() = default;
@@ -326,48 +156,126 @@ Symbolic::Symbolic(Symbolic &&) noexcept = default;
 
 Symbolic &Symbolic::operator=(Symbolic &&) noexcept = default;
 
+const char *Symbolic::getLLVMVersion() { return LLVM_VERSION_STRING; }
+
 void Symbolic::compile(bool doCSE, unsigned optLevel) {
-  pSymEngineImpl->compile(doCSE, optLevel);
+  if (!valid) {
+    return;
+  }
+  SPDLOG_DEBUG("compiling expression:");
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
+  if (se->varVec.size() == se->exprInlined.size()) {
+    for (std::size_t i = 0; i < se->varVec.size(); ++i) {
+      SPDLOG_TRACE("  [{}] <- {}", sbml(*se->varVec[i]),
+                   sbml(*se->exprInlined[i]));
+    }
+  }
+#endif
+  try {
+    se->lambdaLLVM.init(se->varVec, se->exprInlined, doCSE, optLevel);
+  } catch (const std::exception &e) {
+    // if SymEngine failed to compile, capture error message
+    SPDLOG_WARN("{}", e.what());
+    valid = false;
+    compiled = false;
+    se->errorMessage = "Failed to compile expression: ";
+    se->errorMessage.append(e.what());
+    return;
+  }
+  compiled = true;
 }
 
 std::string Symbolic::expr(std::size_t i) const {
-  return toString(pSymEngineImpl->exprOriginal[i]);
+  return sbml(*se->exprOriginal[i]);
 }
 
 std::string Symbolic::inlinedExpr(std::size_t i) const {
-  return toString(pSymEngineImpl->exprInlined[i]);
+  return sbml(*se->exprInlined[i]);
 }
 
 std::string Symbolic::diff(const std::string &var, std::size_t i) const {
-  auto dexpr_dvar =
-      pSymEngineImpl->exprInlined[i]->diff(pSymEngineImpl->symbols[var]);
-  return toString(dexpr_dvar);
+  return sbml(*se->exprInlined[i]->diff(se->symbols.at(var)));
 }
 
 void Symbolic::relabel(const std::vector<std::string> &newVariables) {
-  pSymEngineImpl->relabel(newVariables);
+  if (se->varVec.size() != newVariables.size()) {
+    SPDLOG_WARN("cannot relabel variables: newVariables size {} "
+                "does not match number of existing variables {}",
+                newVariables.size(), se->varVec.size());
+    return;
+  }
+  decltype(se->varVec) newVarVec;
+  decltype(se->symbols) newSymbols;
+  map_basic_basic d;
+  for (std::size_t i = 0; i < newVariables.size(); ++i) {
+    const auto &v = newVariables[i];
+    newSymbols[v] = symbol(v);
+    newVarVec.push_back(newSymbols[v]);
+    d[se->varVec[i]] = newVarVec[i];
+    SPDLOG_DEBUG("relabeling {} -> {}", sbml(*se->varVec[i]),
+                 sbml(*newVarVec[i]));
+  }
+  // substitute new variables into all expressions
+  for (auto &e : se->exprInlined) {
+    SPDLOG_DEBUG("exprInlined '{}'", sbml(*e));
+    e = e->subs(d);
+    SPDLOG_DEBUG("  -> '{}'", sbml(*e));
+  }
+  for (auto &e : se->exprOriginal) {
+    SPDLOG_DEBUG("exprOriginal '{}'", sbml(*e));
+    e = e->subs(d);
+    SPDLOG_DEBUG("  -> '{}'", sbml(*e));
+  }
+  // replace old variables with new variables in vector & map
+  std::swap(se->varVec, newVarVec);
+  std::swap(se->symbols, newSymbols);
+  if (compiled) {
+    compile(true, 3);
+  }
 }
 
 void Symbolic::rescale(double factor,
                        const std::vector<std::string> &exclusions) {
-  pSymEngineImpl->rescale(factor, exclusions);
+  map_basic_basic d;
+  auto f = number(factor);
+  for (const auto &v : se->varVec) {
+    if (std::find(exclusions.cbegin(), exclusions.cend(), sbml(*v)) !=
+        exclusions.cend()) {
+      d[v] = v;
+    } else {
+      d[v] = mul(v, f);
+    }
+  }
+  for (auto &e : se->exprInlined) {
+    SPDLOG_DEBUG("exprInlined '{}'", sbml(*e));
+    e = e->subs(d);
+    SPDLOG_DEBUG("  -> '{}'", sbml(*e));
+  }
+  for (auto &e : se->exprOriginal) {
+    SPDLOG_DEBUG("exprOriginal '{}'", sbml(*e));
+    e = e->subs(d);
+    SPDLOG_DEBUG("  -> '{}'", sbml(*e));
+  }
+  if (compiled) {
+    compile(true, 3);
+  }
 }
 
 void Symbolic::eval(std::vector<double> &results,
                     const std::vector<double> &vars) const {
-  pSymEngineImpl->lambdaLLVM.call(results.data(), vars.data());
+  se->lambdaLLVM.call(results.data(), vars.data());
 }
 
 void Symbolic::eval(double *results, const double *vars) const {
-  pSymEngineImpl->lambdaLLVM.call(results, vars);
+  se->lambdaLLVM.call(results, vars);
 }
 
-bool Symbolic::isValid() const { return pSymEngineImpl->valid; }
+bool Symbolic::isValid() const { return valid; }
 
-bool Symbolic::isCompiled() const { return pSymEngineImpl->compiled; }
+bool Symbolic::isCompiled() const { return compiled; }
 
 const std::string &Symbolic::getErrorMessage() const {
-  return pSymEngineImpl->errorMessage;
+  return se->errorMessage;
 }
 
 } // namespace sme::common

--- a/src/core/common/src/symbolic_t.cpp
+++ b/src/core/common/src/symbolic_t.cpp
@@ -13,6 +13,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     CAPTURE(expr);
     REQUIRE(sym.expr() == "10");
     REQUIRE(sym.inlinedExpr() == "10");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     sym.eval(res);
     REQUIRE(res[0] == dbl_approx(10));
@@ -21,8 +26,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(res[0] == dbl_approx(10));
   }
   GIVEN("3*x + 7*x: one var, no constants") {
-    std::string expr = "3*x + 7 * x";
-    auto sym = common::Symbolic(expr);
+    std::string expr{"3*x + 7 * x"};
+    common::Symbolic sym(expr);
     REQUIRE(!sym.isValid());
     REQUIRE(sym.getErrorMessage() == "Unknown symbol: x");
     sym = common::Symbolic(expr, {"x"});
@@ -30,6 +35,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(sym.expr() == "10*x");
     REQUIRE(sym.inlinedExpr() == "10*x");
     REQUIRE(sym.diff("x") == "10");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     sym.eval(res, {0.2});
     REQUIRE(res[0] == dbl_approx(2));
@@ -44,12 +54,17 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   }
   GIVEN("3*x + 7*x, 4*x - 3: two expressions, one var, no constants") {
     std::vector<std::string> expr{"3*x + 7 * x", "4*x - 3"};
-    common::Symbolic sym(expr, {"x"}, {});
+    common::Symbolic sym(expr, {"x"});
     CAPTURE(expr);
     REQUIRE(sym.inlinedExpr(0) == "10*x");
     REQUIRE(symEq(sym.inlinedExpr(1), "4*x - 3"));
     REQUIRE(sym.diff("x", 0) == "10");
     REQUIRE(sym.diff("x", 1) == "4");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(2, 0);
     sym.eval(res, {0.2});
     REQUIRE(res[0] == dbl_approx(2));
@@ -71,31 +86,51 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(res[1] == dbl_approx(-3));
   }
   GIVEN("1.324*x + 2*3: one var, no constants") {
-    std::string expr = "1.324 * x + 2*3";
+    std::string expr{"1.324 * x + 2*3"};
     common::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(symEq(sym.inlinedExpr(), "6 + 1.324*x"));
     REQUIRE(sym.diff("x") == "1.324");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.rescale(2.00); // multiply all vars by 2
+    REQUIRE(symEq(sym.inlinedExpr(), "6 + 2.648*x"));
+    REQUIRE(sym.diff("x") == "2.648");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
-    sym.eval(res, {0.1});
+    sym.eval(res, {0.05});
     REQUIRE(res[0] == dbl_approx(6.1324));
   }
   GIVEN("0.324*x + 2*3: one var, no constants") {
-    std::string expr = "0.324 * x + 2*3";
+    std::string expr{"0.324 * x + 2*3"};
     common::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(symEq(sym.inlinedExpr(), "6 + 0.324*x"));
     REQUIRE(sym.diff("x") == "0.324");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     sym.eval(res, {0.1});
     REQUIRE(res[0] == dbl_approx(6.0324));
   }
   GIVEN("3*x + 4/x - 1.0*x + 0.2*x*x - 0.1: one var, no constants") {
-    std::string expr = "3*x + 4/x - 1.0*x + 0.2*x*x - 0.1";
+    std::string expr{"3*x + 4/x - 1.0*x + 0.2*x*x - 0.1"};
     common::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(symEq(sym.inlinedExpr(), "-0.1 + 2.0*x + 4*x^(-1) + 0.2*x^2"));
     REQUIRE(symEq(sym.diff("x"), "2.0 + 0.4*x - 4*x^(-2)"));
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     for (auto x : std::vector<double>{-0.1, 0, 0.9, 23e-17, 4.88e11, 7e32}) {
       sym.eval(res, {x});
@@ -104,7 +139,7 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     }
   }
   GIVEN("3*x + 4/y - 1.0*x + 0.2*x*y - 0.1: two vars, no constants") {
-    std::string expr = "3*x + 4/y - 1.0*x + 0.2*x*y - 0.1";
+    std::string expr{"3*x + 4/y - 1.0*x + 0.2*x*y - 0.1"};
     REQUIRE(common::Symbolic(expr, {"x"}, {}).getErrorMessage() ==
             "Unknown symbol: y");
     REQUIRE(common::Symbolic(expr, {"y"}, {}).getErrorMessage() ==
@@ -115,6 +150,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(symEq(sym.diff("x"), "2.0 + 0.2*y"));
     REQUIRE(symEq(sym.diff("y"), "0.2*x - 4*y^(-2)"));
     REQUIRE(sym.diff("z") == "0");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     for (auto x : std::vector<double>{-0.1, 0, 0.9, 23e-17, 4.88e11, 7e32}) {
       for (auto y : std::vector<double>{-0.1, 3, 0.9, 23e-17, 4.88e11, 7e32}) {
@@ -125,8 +165,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     }
   }
   GIVEN("two expressions, three vars, no constants") {
-    std::vector<std::string> expr = {"3*x + 4/y - 1.0*x + 0.2*x*y - 0.1",
-                                     "z - cos(x)*sin(y) - x*y"};
+    std::vector<std::string> expr{"3*x + 4/y - 1.0*x + 0.2*x*y - 0.1",
+                                  "z - cos(x)*sin(y) - x*y"};
     REQUIRE(common::Symbolic(expr, {"z", "x"}, {}).getErrorMessage() ==
             "Unknown symbol: y");
     REQUIRE(common::Symbolic(expr, {"x", "y"}, {}).getErrorMessage() ==
@@ -143,6 +183,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(symEq(sym.diff("x", 1), "-y + sin(y)*sin(x)"));
     REQUIRE(symEq(sym.diff("y", 1), "-x - cos(y)*cos(x)"));
     REQUIRE(sym.diff("z", 1) == "1");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(2, 0);
     for (auto x : std::vector<double>{-0.1, 0, 0.69, 23e-7, 4.188e5}) {
       for (auto y : std::vector<double>{-0.11, 34, 0.9, 29e-7, 4.88e5}) {
@@ -156,13 +201,18 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     }
   }
   GIVEN("exponentiale^(4*x): print exponential function") {
-    std::string expr = "exponentiale^(4*x)";
+    std::string expr{"exponentiale^(4*x)"};
     REQUIRE(common::Symbolic(expr, {}, {}).getErrorMessage() ==
             "Unknown symbol: x");
     common::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(sym.inlinedExpr() == "exp(4*x)");
     REQUIRE(sym.diff("x") == "4*exp(4*x)");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     for (auto x : std::vector<double>{-0.1, 0, 0.9, 23e-17, 4.88e11, 7e32}) {
       sym.eval(res, {x});
@@ -170,11 +220,16 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     }
   }
   GIVEN("x^(3/2): print square-root function") {
-    std::string expr = "x^(3/2)";
+    std::string expr{"x^(3/2)"};
     common::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(sym.inlinedExpr() == "x^(3/2)");
     REQUIRE(sym.diff("x") == "(3/2)*sqrt(x)");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     for (auto x : std::vector<double>{0.1, 0, 0.9, 23e-17, 4.88e11, 7e32}) {
       sym.eval(res, {x});
@@ -183,11 +238,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   }
   GIVEN("3*x + alpha*x - a*n/x: one var, constants") {
     std::vector<std::pair<std::string, double>> constants;
-    constants.push_back({"alpha", 0.5});
-    constants.push_back({"a", 0.8 + 1e-11});
-    constants.push_back({"n", -23});
-    constants.push_back({"Unused", -99});
-    std::string expr = "3*x + alpha*x - a*n*x";
+    constants.emplace_back("alpha", 0.5);
+    constants.emplace_back("a", 0.8 + 1e-11);
+    constants.emplace_back("n", -23);
+    constants.emplace_back("Unused", -99);
+    std::string expr{"3*x + alpha*x - a*n*x"};
     REQUIRE(common::Symbolic(expr, {}, constants).getErrorMessage() ==
             "Unknown symbol: x");
     REQUIRE(
@@ -199,6 +254,11 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(sym.inlinedExpr() == "21.90000000023*x");
     REQUIRE(sym.diff("x") == "21.90000000023");
     REQUIRE(sym.diff("y") == "0");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
     std::vector<double> res(1, 0);
     for (auto x : std::vector<double>{-0.1, 0, 0.9, 23e-17, 4.88e11, 7e32}) {
       sym.eval(res, {x, 2356.546});
@@ -206,22 +266,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
               dbl_approx(3 * x + 0.5 * x - (0.8 + 1e-11) * (-23) * x));
     }
   }
-  GIVEN("expression: parse without compiling, then compile") {
-    std::string expr = "1.324 * x + 2*3";
-    common::Symbolic sym(expr, {"x"}, {}, {}, false);
-    CAPTURE(expr);
-    REQUIRE(sym.inlinedExpr() == "6 + 1.324*x");
-    REQUIRE(sym.diff("x") == "1.324");
-    std::vector<double> res(1, 0.0);
-    sym.compile();
-    sym.eval(res, {0.1});
-    REQUIRE(res[0] == dbl_approx(6.1324));
-    sym.compile();
-    sym.eval(res, {0.1});
-    REQUIRE(res[0] == dbl_approx(6.1324));
-  }
   GIVEN("relabel one expression with two vars") {
-    std::string expr = "3*x + 12*sin(y)";
+    std::string expr{"3*x + 12*sin(y)"};
     common::Symbolic sym(expr, {"x", "y"});
     CAPTURE(expr);
     REQUIRE(sym.diff("x") == "3");
@@ -230,12 +276,30 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(sym.inlinedExpr() == "3*newX + 12*sin(newY)");
     REQUIRE(sym.diff("newX") == "3");
     REQUIRE(sym.diff("newY") == "12*cos(newY)");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+  }
+  GIVEN("relabel one compiled expression with two vars") {
+    std::string expr{"3*x + 12*sin(y)"};
+    common::Symbolic sym(expr, {"x", "y"});
+    sym.compile();
+    CAPTURE(expr);
+    REQUIRE(sym.diff("x") == "3");
+    REQUIRE(sym.diff("y") == "12*cos(y)");
+    sym.relabel({"newX", "newY"});
+    REQUIRE(sym.inlinedExpr() == "3*newX + 12*sin(newY)");
+    REQUIRE(sym.diff("newX") == "3");
+    REQUIRE(sym.diff("newY") == "12*cos(newY)");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
   }
   GIVEN("invalid variable relabeling is a no-op") {
-    std::string expr = "3*x + 12*sin(y)";
+    std::string expr{"3*x + 12*sin(y)"};
     common::Symbolic sym(expr, {"x", "y"});
     CAPTURE(expr);
     REQUIRE(sym.inlinedExpr() == expr);
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
     REQUIRE(sym.diff("x") == "3");
     REQUIRE(sym.diff("y") == "12*cos(y)");
     sym.relabel({"a"});
@@ -244,43 +308,55 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     REQUIRE(sym.inlinedExpr() == expr);
   }
   GIVEN("unknown function") {
-    std::string expr = "abcd(y)";
+    std::string expr{"abcd(y)"};
     common::Symbolic sym(expr, {"y"});
-    REQUIRE(!sym.isValid());
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     REQUIRE(sym.getErrorMessage() == "Unknown function: abcd(y)");
+    sym.compile();
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(expr);
   }
   GIVEN("unknown functions") {
-    std::string expr = "abcd(y) + unknown_function(y)";
+    std::string expr{"abcd(y) + unknown_function(y)"};
     common::Symbolic sym(expr, {"y"});
-    REQUIRE(!sym.isValid());
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     REQUIRE(sym.getErrorMessage() == "Unknown function: abcd(y)");
+    sym.compile();
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(expr);
   }
   GIVEN("functions calling unknown functions") {
-    std::string expr = "pow(2*y + cos(abcd(y)), 2)";
+    std::string expr{"pow(2*y + cos(abcd(y)), 2)"};
     common::Symbolic sym(expr, {"y"});
-    REQUIRE(!sym.isValid());
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     REQUIRE(sym.getErrorMessage() == "Unknown function: abcd(y)");
+    sym.compile();
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(expr);
   }
   GIVEN("some user-defined functions") {
-    common::Function f0;
+    common::SymbolicFunction f0;
     f0.id = "f0";
     f0.name = "zero_arg_func";
     f0.args = {};
     f0.body = "6";
-    common::Function f1;
+    common::SymbolicFunction f1;
     f1.id = "f1";
     f1.name = "my func";
     f1.args = {"x"};
     f1.body = "2*x";
-    common::Function f2;
+    common::SymbolicFunction f2;
     f2.id = "f2";
     f2.name = "func2";
     f2.args = {"x", "y"};
     f2.body = "2*x*y";
-    common::Function g2;
+    common::SymbolicFunction g2;
     g2.id = "g2";
     g2.name = "g2";
     g2.args = {"a", "b"};
@@ -297,10 +373,14 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     WHEN("1-arg func") {
       std::string expr{"2*f1(z)"};
       common::Symbolic sym(expr, {"z"}, {}, {f1});
-      REQUIRE(sym.isValid());
       REQUIRE(sym.getErrorMessage().empty());
       REQUIRE(sym.expr() == "2*f1(z)");
       REQUIRE(sym.inlinedExpr() == "4*z");
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == false);
+      sym.compile();
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == true);
       CAPTURE(expr);
     }
     WHEN("0-arg func called with one argument") {
@@ -314,7 +394,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     WHEN("1-arg func called with two arguments") {
       std::string expr{"2*f1(x, y)"};
       common::Symbolic sym(expr, {"x", "y"}, {}, {f1});
-      REQUIRE(!sym.isValid());
+      REQUIRE(sym.isValid() == false);
+      REQUIRE(sym.isCompiled() == false);
       REQUIRE(sym.getErrorMessage() ==
               "Function 'my func' requires 1 argument(s), found 2");
       CAPTURE(expr);
@@ -322,7 +403,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     WHEN("2-arg func called with one argument") {
       std::string expr{"2*f2(a)"};
       common::Symbolic sym(expr, {"a"}, {}, {f2});
-      REQUIRE(!sym.isValid());
+      REQUIRE(sym.isValid() == false);
+      REQUIRE(sym.isCompiled() == false);
       REQUIRE(sym.getErrorMessage() ==
               "Function 'func2' requires 2 argument(s), found 1");
       CAPTURE(expr);
@@ -331,18 +413,26 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
       std::string expr = "f1(2+f1(f1(2*f1(z))))";
       common::Symbolic sym(expr, {"z"}, {}, {f1});
       CAPTURE(sym.getErrorMessage());
-      REQUIRE(sym.isValid());
       REQUIRE(sym.getErrorMessage().empty());
       REQUIRE(symEq(sym.inlinedExpr(), "2*(2 + 16*z)"));
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == false);
+      sym.compile();
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == true);
       CAPTURE(expr);
     }
     WHEN("1-arg func calls 2-arg func") {
       std::string expr = "f1(1+f2(alpha, beta))";
       common::Symbolic sym(expr, {"alpha", "beta"}, {}, {f1, f2});
       CAPTURE(sym.getErrorMessage());
-      REQUIRE(sym.isValid());
       REQUIRE(sym.getErrorMessage().empty());
       REQUIRE(symEq(sym.inlinedExpr(), "2*(1+2*alpha*beta)"));
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == false);
+      sym.compile();
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == true);
       CAPTURE(expr);
     }
     WHEN("2-arg func calls 2-arg func") {
@@ -350,14 +440,18 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
           "f2(x, alpha)*f2(beta, y)*g2(f2(x, y), f2(alpha, beta))";
       common::Symbolic sym(expr, {"alpha", "beta", "x", "y"}, {}, {f1, f2, g2});
       CAPTURE(sym.getErrorMessage());
-      REQUIRE(sym.isValid());
       REQUIRE(sym.getErrorMessage().empty());
       REQUIRE(symEq(sym.inlinedExpr(), "1"));
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == false);
+      sym.compile();
+      REQUIRE(sym.isValid() == true);
+      REQUIRE(sym.isCompiled() == true);
       CAPTURE(expr);
     }
   }
   GIVEN("single recursive function call") {
-    common::Function f1;
+    common::SymbolicFunction f1;
     f1.id = "f1";
     f1.name = "my func";
     f1.args = {"x"};
@@ -365,65 +459,10 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     std::string expr{"f1(a)"};
     common::Symbolic sym(expr, {"a"}, {}, {f1});
     CAPTURE(sym.getErrorMessage());
-    REQUIRE(!sym.isValid());
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     REQUIRE(sym.getErrorMessage() == "Recursive function calls not supported");
     CAPTURE(expr);
-  }
-  GIVEN("symbolicDivide expression with number") {
-    REQUIRE(common::symbolicDivide("x", "1.3") == "x/1.3");
-    REQUIRE(common::symbolicDivide("1", "2") == "2^(-1)");
-    REQUIRE(common::symbolicDivide("10*x", "5") == "10*x/5");
-    REQUIRE(common::symbolicDivide("(cos(x))^2+3", "3.14") ==
-            "(3 + cos(x)^2)/3.14");
-    REQUIRE(common::symbolicDivide("2*unknown_function(a,b,c)", "2") ==
-            "2*unknown_function(a, b, c)/2");
-  }
-  GIVEN("symbolicDivide expression with symbol") {
-    REQUIRE(common::symbolicDivide("x", "x") == "1");
-    REQUIRE(common::symbolicDivide("1", "x") == "x^(-1)");
-    REQUIRE(common::symbolicDivide("0", "x") == "0");
-    REQUIRE(common::symbolicDivide("x^2", "x") == "x");
-    REQUIRE(common::symbolicDivide("x+3*x", "x") == "4");
-  }
-  GIVEN("symbolicDivide expression with other symbols") {
-    REQUIRE(common::symbolicDivide("x+a", "x") == "(a + x)/x");
-    REQUIRE(common::symbolicDivide("x+y", "x") == "(x + y)/x");
-    REQUIRE(common::symbolicDivide("y*x", "x") == "y");
-    REQUIRE(common::symbolicDivide("y*x*z/y", "x") == "z");
-  }
-  GIVEN("symbolicDivide expression with other symbols & functions") {
-    REQUIRE(common::symbolicDivide("f()", "2") == "f()/2");
-    REQUIRE(common::symbolicDivide("sin(x+a)", "x") == "sin(a + x)/x");
-    REQUIRE(common::symbolicDivide("x*sin(x+a)", "x") == "sin(a + x)");
-    REQUIRE(common::symbolicDivide("x*unknown(z)", "x") == "unknown(z)");
-    REQUIRE(common::symbolicDivide(
-                "x*(unknown1(unknown2(x)) + 2*another_unknown(q))", "x") ==
-            "2*another_unknown(q) + unknown1(unknown2(x))");
-    REQUIRE(common::symbolicDivide("unknown1(unknown2(z))", "x") ==
-            "unknown1(unknown2(z))/x");
-  }
-  GIVEN("symbolicMultiply expression with number") {
-    REQUIRE(common::symbolicMultiply("x", "1.3") == "x*1.3");
-    REQUIRE(common::symbolicMultiply("1", "2") == "2");
-    REQUIRE(common::symbolicMultiply("10*x", "5") == "10*5*x");
-    REQUIRE(common::symbolicMultiply("4.2/x", "x") == "4.2");
-    REQUIRE(common::symbolicMultiply("cos(y)/x", "x") == "cos(y)");
-    REQUIRE(common::symbolicMultiply("unknown(z)/x", "x") == "unknown(z)");
-    REQUIRE(common::symbolicMultiply("x*unknown_function(a,b,c)/x/x", "x") ==
-            "unknown_function(a, b, c)");
-  }
-  GIVEN("check if expression contains symbol") {
-    REQUIRE(common::symbolicContains("x", "x") == true);
-    REQUIRE(common::symbolicContains("1", "x") == false);
-    REQUIRE(common::symbolicContains("y+x^2", "x") == true);
-    REQUIRE(common::symbolicContains("y+x^2", "y") == true);
-    REQUIRE(common::symbolicContains("y+x^2", "z") == false);
-    REQUIRE(common::symbolicContains("f()", "z") == false);
-    REQUIRE(common::symbolicContains("z + f()", "z") == true);
-    REQUIRE(common::symbolicContains("x*unknown(z)", "x") == true);
-    REQUIRE(common::symbolicContains("z*unknown(x)", "x") == true);
-    REQUIRE(common::symbolicContains("z*unknown(y)", "x") == false);
-    REQUIRE(common::symbolicContains("(cos(symbol))^2+3", "symbol") == true);
   }
   GIVEN("expressions with relative difference < 1e-13 test equal") {
     REQUIRE(symEq(QString("0.9999999999"), QString("1")) == false);
@@ -438,26 +477,40 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
                   QString("9.999999999999999e-4*x + 1.0000000000000001*y")) ==
             true);
   }
-  GIVEN("expression with 1/0") {
+  GIVEN("expression with 1/0: parses but doesn't compile") {
+    common::Symbolic sym("1/0");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
     // 1/0 evaluates to complex infinity in symengine
-    common::Symbolic sym("1/0", {}, {}, {});
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(sym.getErrorMessage());
-    REQUIRE(!sym.isValid());
     REQUIRE(sym.getErrorMessage() == "Failed to compile expression: LLVMDouble "
                                      "can only represent real valued infinity");
   }
-  GIVEN("expression with inf") {
+  GIVEN("expression with inf: parses and compiles") {
     // real infinity is ok both for parsing & for llvm compilation
     common::Symbolic sym("inf", {}, {}, {});
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(sym.getErrorMessage());
-    REQUIRE(sym.isValid());
+    REQUIRE(sym.getErrorMessage().empty());
+    sym.compile();
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == true);
+    CAPTURE(sym.getErrorMessage());
     REQUIRE(sym.getErrorMessage().empty());
   }
-  GIVEN("expression with nan") {
+  GIVEN("expression with nan: parses but doesn't compile") {
     // nan parses ok but not supported by llvm compilation
-    common::Symbolic sym("nan", {}, {}, {});
+    common::Symbolic sym("nan");
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    sym.compile();
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
     CAPTURE(sym.getErrorMessage());
-    REQUIRE(!sym.isValid());
     REQUIRE(sym.getErrorMessage().substr(0, 30) ==
             "Failed to compile expression: ");
   }

--- a/src/core/model/inc/model_functions.hpp
+++ b/src/core/model/inc/model_functions.hpp
@@ -38,7 +38,8 @@ public:
   void removeArgument(const QString &functionId, const QString &argumentId);
   QString add(const QString &name);
   void remove(const QString &id);
-  [[nodiscard]] std::vector<common::Function> getSymbolicFunctions() const;
+  [[nodiscard]] std::vector<common::SymbolicFunction>
+  getSymbolicFunctions() const;
   [[nodiscard]] bool getHasUnsavedChanges() const;
   void setHasUnsavedChanges(bool unsavedChanges);
 };

--- a/src/core/model/src/model_functions.cpp
+++ b/src/core/model/src/model_functions.cpp
@@ -228,8 +228,9 @@ void ModelFunctions::remove(const QString &id) {
   names.removeAt(i);
 }
 
-std::vector<common::Function> ModelFunctions::getSymbolicFunctions() const {
-  std::vector<common::Function> fns;
+std::vector<common::SymbolicFunction>
+ModelFunctions::getSymbolicFunctions() const {
+  std::vector<common::SymbolicFunction> fns;
   fns.reserve(static_cast<std::size_t>(ids.size()));
   for (const auto &id : ids) {
     auto &fn = fns.emplace_back();

--- a/src/core/model/src/model_reactions.cpp
+++ b/src/core/model/src/model_reactions.cpp
@@ -4,7 +4,7 @@
 #include "logger.hpp"
 #include "model_membranes.hpp"
 #include "sbml_math.hpp"
-#include "symbolic.hpp"
+#include "simple_symbolic.hpp"
 #include <QString>
 #include <algorithm>
 #include <memory>
@@ -132,9 +132,9 @@ static ReactionRescaling getReactionRescaling(
   auto expr{mathASTtoString(kineticLaw->getMath())};
   reactionRescaling.originalExpression = expr.c_str();
   SPDLOG_INFO("  - {}", expr);
-  expr = common::symbolicDivide(expr, divisor);
+  expr = common::SimpleSymbolic::divide(expr, divisor);
   SPDLOG_INFO("  --> {}", expr);
-  expr = common::symbolicSubstitute(expr, constants);
+  expr = common::SimpleSymbolic::substitute(expr, constants);
   SPDLOG_INFO("  --> {}", expr);
   reactionRescaling.rescaledExpression = expr.c_str();
   return reactionRescaling;
@@ -672,7 +672,7 @@ bool ModelReactions::dependOnVariable(const QString &variableId) const {
   auto v{variableId.toStdString()};
   return std::any_of(ids.begin(), ids.end(), [&v, this](const auto &id) {
     auto e{getRateExpression(id).toStdString()};
-    return common::symbolicContains(e, v);
+    return common::SimpleSymbolic::contains(e, v);
   });
 }
 

--- a/src/core/simulate/src/pde.cpp
+++ b/src/core/simulate/src/pde.cpp
@@ -74,8 +74,7 @@ Pde::Pde(const model::Model *doc_ptr,
       }
       // parse and inline constants & function calls
       common::Symbolic sym(expr.toStdString(), vars, constants,
-                           doc_ptr->getFunctions().getSymbolicFunctions(),
-                           false);
+                           doc_ptr->getFunctions().getSymbolicFunctions());
       if (!sym.isValid()) {
         throw PdeError(sym.getErrorMessage());
       }
@@ -85,7 +84,7 @@ Pde::Pde(const model::Model *doc_ptr,
     // reparse full rhs to simplify
     SPDLOG_DEBUG("Species {} Reparsing all reaction terms", speciesIDs.at(i));
     // parse expression with symengine to simplify
-    common::Symbolic sym(r.toStdString(), vars, {}, {}, false);
+    common::Symbolic sym(r.toStdString(), vars);
     if (!sym.isValid()) {
       throw PdeError(sym.getErrorMessage());
     }

--- a/src/core/simulate/src/pixelsim_impl.cpp
+++ b/src/core/simulate/src/pixelsim_impl.cpp
@@ -53,8 +53,11 @@ ReacEval::ReacEval(
     rhs.push_back("0"); // dy/dt = 0
   }
   // compile all expressions with symengine
-  sym = common::Symbolic(rhs, sIds, {}, {}, true, doCSE, optLevel);
-  if (!sym.isValid()) {
+  sym = common::Symbolic(rhs, sIds);
+  if (sym.isValid()) {
+    sym.compile(doCSE, optLevel);
+  }
+  if (!sym.isCompiled()) {
     std::string msg{sym.getErrorMessage()};
     msg.append("\nExpression: \"");
     msg.append(sym.expr());

--- a/src/gui/dialogs/dialogabout.cpp
+++ b/src/gui/dialogs/dialogabout.cpp
@@ -71,8 +71,8 @@ DialogAbout::DialogAbout(QWidget *parent)
                        FMT_VERSION % 100));
   libraries.append(dep("SymEngine", "https://github.com/symengine/symengine",
                        SYMENGINE_VERSION));
-  libraries.append(
-      dep("LLVM core", "https://llvm.org", sme::common::getLLVMVersion()));
+  libraries.append(dep("LLVM core", "https://llvm.org",
+                       sme::common::Symbolic::getLLVMVersion()));
   libraries.append(dep("GMP", "https://gmplib.org", __GNU_MP_VERSION,
                        __GNU_MP_VERSION_MINOR, __GNU_MP_VERSION_PATCHLEVEL));
   libraries.append(dep("MPFR", "https://www.mpfr.org/", MPFR_VERSION_MAJOR,

--- a/src/gui/widgets/plotwrapper.cpp
+++ b/src/gui/widgets/plotwrapper.cpp
@@ -69,7 +69,9 @@ void PlotWrapper::addObservableLine(
   vars.push_back("t");
   sme::common::Symbolic sym(plotWrapperObservable.expression.toStdString(),
                             vars);
-  if (!sym.isValid()) {
+  if (sym.isValid()) {
+    sym.compile();
+  } else {
     SPDLOG_WARN("Skipping invalid expression: '{}'",
                 plotWrapperObservable.expression.toStdString());
     return;

--- a/src/gui/widgets/qplaintextmathedit.cpp
+++ b/src/gui/widgets/qplaintextmathedit.cpp
@@ -154,7 +154,8 @@ void QPlainTextMathEdit::reset() {
   qPlainTextEdit_textChanged();
 }
 
-void QPlainTextMathEdit::addFunction(const sme::common::Function &function) {
+void QPlainTextMathEdit::addFunction(
+    const sme::common::SymbolicFunction &function) {
   SPDLOG_TRACE("adding function: {}", function.id);
   functions.push_back(function);
   SPDLOG_TRACE("  -> display name {}", function.name);
@@ -349,7 +350,7 @@ void QPlainTextMathEdit::qPlainTextEdit_textChanged() {
   if (currentErrorMessage.isEmpty()) {
     // parse (but don't compile) symbolic expression
     SPDLOG_DEBUG("parsing '{}' with SymEngine backend", newExpr);
-    sym = sme::common::Symbolic(newExpr, vars, consts, functions, false);
+    sym = sme::common::Symbolic(newExpr, vars, consts, functions);
     if (sym.isValid()) {
       expressionIsValid = true;
       currentErrorMessage = "";

--- a/src/gui/widgets/qplaintextmathedit.hpp
+++ b/src/gui/widgets/qplaintextmathedit.hpp
@@ -33,7 +33,7 @@ public:
                    const std::string &displayName = {});
   void removeVariable(const std::string &variable);
   void reset();
-  void addFunction(const sme::common::Function &function);
+  void addFunction(const sme::common::SymbolicFunction &function);
   void removeFunction(const std::string &functionId);
   void setConstants(const std::vector<sme::model::IdNameValue> &constants = {});
   void updateCompleter();
@@ -51,7 +51,7 @@ private:
   const QColor colourValid{QColor(200, 255, 200)};
   const QColor colourInvalid{QColor(255, 150, 150)};
   std::vector<std::string> vars;
-  std::vector<sme::common::Function> functions;
+  std::vector<sme::common::SymbolicFunction> functions;
   std::vector<std::pair<std::string, double>> consts{};
   StringStringMap mapVarsToDisplayNames;
   StringStringMap mapDisplayNamesToVars;

--- a/src/gui/widgets/qplaintextmathedit_t.cpp
+++ b/src/gui/widgets/qplaintextmathedit_t.cpp
@@ -229,7 +229,7 @@ SCENARIO("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
       REQUIRE(mathEdit.getVariableMath().empty() == true);
       REQUIRE(mathEdit.getErrorMessage() == "function 'cse' not found");
       REQUIRE(mathEdit.mathIsValid() == false);
-      sme::common::Function f;
+      sme::common::SymbolicFunction f;
       f.id = "cse";
       f.name = "cse";
       f.args = {"z"};


### PR DESCRIPTION
- separate construction (i.e. parsing) from compilation
- move standalone symbolic utility functions into `SimpleSymbolic` class
