### PR TITLE
initially use a minimum of 4 points for automatic boundary line approximations

### DIFF
--- a/src/core/mesh/src/boundary_t.cpp
+++ b/src/core/mesh/src/boundary_t.cpp
@@ -72,14 +72,14 @@ SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][core][boundary]") {
     REQUIRE(boundary.getMaxPoints() == 999);
     REQUIRE(boundary.getPoints() == points);
     // use 3 points for boundary
-    boundary.setMaxPoints(4);
-    REQUIRE(boundary.getMaxPoints() == 4);
-    REQUIRE(boundary.getPoints() == p4);
+    boundary.setMaxPoints(3);
+    REQUIRE(boundary.getMaxPoints() == 3);
+    REQUIRE(boundary.getPoints() == p3);
     // automatically determine number of points
     auto nPoints = boundary.setMaxPoints();
     REQUIRE(boundary.getMaxPoints() == nPoints);
-    REQUIRE(nPoints == 3);
-    REQUIRE(boundary.getPoints() == p3);
+    REQUIRE(nPoints == 4);
+    REQUIRE(boundary.getPoints() == p4);
   }
 }
 

--- a/src/core/mesh/src/line_simplifier.cpp
+++ b/src/core/mesh/src/line_simplifier.cpp
@@ -221,7 +221,8 @@ void LineSimplifier::getSimplifiedLine(std::vector<QPoint> &line,
                                        const LineError &allowedError) const {
   SPDLOG_DEBUG("Allowed error: total = {}, average = {}", allowedError.total,
                allowedError.average);
-  for (std::size_t n = minNumPoints; n <= maxPoints(); ++n) {
+  std::size_t n0{std::clamp(std::size_t{4}, minNumPoints, maxPoints())};
+  for (std::size_t n = n0; n <= maxPoints(); ++n) {
     getSimplifiedLine(line, n);
     auto error = getLineError(line);
     SPDLOG_DEBUG("  - n = {} : total = {}, average = {}", n, error.total,

--- a/src/core/mesh/src/line_simplifier_t.cpp
+++ b/src/core/mesh/src/line_simplifier_t.cpp
@@ -115,8 +115,8 @@ SCENARIO("Simplify Lines",
       // allow infinite deviation -> minimum number of points
       ls.getSimplifiedLine(line, {std::numeric_limits<double>::max(),
                                   std::numeric_limits<double>::max()});
-      REQUIRE(line.size() == 3);
-      REQUIRE(line == l3);
+      REQUIRE(line.size() == 4);
+      REQUIRE(line == l4);
 
       // allow total deviation of 0.5 pixels
       ls.getSimplifiedLine(line, {0.5, 0});
@@ -132,7 +132,7 @@ SCENARIO("Simplify Lines",
 
       // allow average deviation of 1 pixel
       ls.getSimplifiedLine(line, {0, 1.0});
-      REQUIRE(line.size() == 3);
+      REQUIRE(line.size() == 4);
     }
   }
   GIVEN("Non-loop") {
@@ -214,8 +214,8 @@ SCENARIO("Simplify Lines",
       // allow infinite deviation -> minimum number of points
       ls.getSimplifiedLine(line, {std::numeric_limits<double>::max(),
                                   std::numeric_limits<double>::max()});
-      REQUIRE(line.size() == 2);
-      REQUIRE(line == l2);
+      REQUIRE(line.size() == 4);
+      REQUIRE(line == l4);
 
       // allow total deviation of 0.5 pixels
       ls.getSimplifiedLine(line, {0.5, 0});
@@ -231,15 +231,15 @@ SCENARIO("Simplify Lines",
 
       // allow average deviation of 0.25 pixel
       ls.getSimplifiedLine(line, {0, 0.25});
-      REQUIRE(line.size() == 3);
+      REQUIRE(line.size() == 4);
 
       // allow total deviation of 3 pixels
       ls.getSimplifiedLine(line, {3.0, 0});
-      REQUIRE(line.size() == 3);
+      REQUIRE(line.size() == 4);
 
       // allow average deviation of 1 pixel
       ls.getSimplifiedLine(line, {0, 1.0});
-      REQUIRE(line.size() == 2);
+      REQUIRE(line.size() == 4);
     }
   }
 }

--- a/src/core/mesh/src/mesh_t.cpp
+++ b/src/core/mesh/src/mesh_t.cpp
@@ -194,9 +194,12 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][core][mesh]") {
     std::size_t maxTriangleArea{999};
     mesh::Mesh mesh(img, {}, {maxTriangleArea}, 1.0, QPointF(0, 0),
                     std::vector<QRgb>{col});
+    REQUIRE(mesh.isValid() == true);
     // use 3 point boundary around 3x1 pixel rectangle:
     // interior point is outside this boundary
     mesh.setBoundaryMaxPoints(0, 3);
+    // re-generate mesh
+    mesh.setCompartmentMaxTriangleArea(0, maxTriangleArea);
     REQUIRE(mesh.isValid() == false);
     REQUIRE(mesh.getErrorMessage() ==
             "Triangle is outside of the boundary lines");


### PR DESCRIPTION
- more likely to successfully mesh single pixel compartments / features
- user can then still choose to use less points if they want to
- resolves #658
