### PR TITLE
avoid possible dangling reference in ModelCompartments::remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - functions with zero arguments are now fully supported [#674](https://github.com/spatial-model-editor/spatial-model-editor/issues/674)
 - python interface: setting n_threads=1 for simulate takes precedence over n_threads value in model [#672](https://github.com/spatial-model-editor/spatial-model-editor/issues/672)
 - bug where membrane reactions could disappear when geometry was changed [#679](https://github.com/spatial-model-editor/spatial-model-editor/issues/679)
+- bug where removing a compartment could result in an invalid model or a crash [#685](https://github.com/spatial-model-editor/spatial-model-editor/issues/685)
 
 ## [1.2.0] - 2021-09-13
 ### Added

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -191,10 +191,13 @@ static void removeCompartmentFromSBML(libsbml::Model *model,
 }
 
 bool ModelCompartments::remove(const QString &id) {
-  SPDLOG_INFO("Removing compartment '{}'", id.toStdString());
+  // make a copy of id to use throughout this function, as it could be ref to
+  // the one in ids that we are about to remove! (see #685)
+  std::string compartmentId{id.toStdString()};
+  SPDLOG_INFO("Removing compartment '{}'", compartmentId);
   auto i = ids.indexOf(id);
   if (i < 0) {
-    SPDLOG_WARN("Compartment '{}' not found", id.toStdString());
+    SPDLOG_WARN("Compartment '{}' not found", compartmentId);
     return false;
   }
   hasUnsavedChanges = true;
@@ -205,8 +208,8 @@ bool ModelCompartments::remove(const QString &id) {
   colours.removeAt(i);
   using diffType = decltype(compartments)::difference_type;
   compartments.erase(compartments.begin() + static_cast<diffType>(i));
-  removeCompartmentFromSBML(sbmlModel, id.toStdString());
-  for (const auto &s : modelSpecies->getIds(id)) {
+  removeCompartmentFromSBML(sbmlModel, compartmentId);
+  for (const auto &s : modelSpecies->getIds(compartmentId.c_str())) {
     modelSpecies->remove(s);
   }
   modelMembranes->updateCompartments(compartments);

--- a/src/core/model/src/model_functions.cpp
+++ b/src/core/model/src/model_functions.cpp
@@ -223,7 +223,7 @@ void ModelFunctions::remove(const QString &id) {
   }
   hasUnsavedChanges = true;
   SPDLOG_INFO("  - function {} removed", rmfunc->getId());
-  auto i = ids.indexOf(id);
+  auto i{ids.indexOf(id)};
   ids.removeAt(i);
   names.removeAt(i);
 }

--- a/src/core/model/src/model_parameters.cpp
+++ b/src/core/model/src/model_parameters.cpp
@@ -268,7 +268,7 @@ QString ModelParameters::add(const QString &name) {
 
 void ModelParameters::remove(const QString &id) {
   hasUnsavedChanges = true;
-  std::string sId{id.toStdString()};
+  auto sId{id.toStdString()};
   SPDLOG_INFO("Removing parameter {}", sId);
   if (auto *asgn = sbmlModel->getAssignmentRuleByVariable(sId);
       asgn != nullptr) {

--- a/src/core/model/src/model_reactions.cpp
+++ b/src/core/model/src/model_reactions.cpp
@@ -349,8 +349,8 @@ QString ModelReactions::add(const QString &name, const QString &locationId,
 }
 
 void ModelReactions::remove(const QString &id) {
-  auto i = ids.indexOf(id);
-  std::string sId = id.toStdString();
+  auto i{ids.indexOf(id)};
+  auto sId{id.toStdString()};
   SPDLOG_INFO("Removing reaction {}", sId);
   std::unique_ptr<libsbml::Reaction> rmReac(sbmlModel->removeReaction(sId));
   if (rmReac == nullptr) {

--- a/src/core/model/src/model_species.cpp
+++ b/src/core/model/src/model_species.cpp
@@ -321,7 +321,7 @@ QString ModelSpecies::add(const QString &name, const QString &compartmentId) {
 }
 
 void ModelSpecies::remove(const QString &id) {
-  std::string sId = id.toStdString();
+  auto sId{id.toStdString()};
   SPDLOG_INFO("Removing species {}", sId);
   auto i = ids.indexOf(id);
   if (i < 0) {
@@ -341,11 +341,11 @@ void ModelSpecies::remove(const QString &id) {
   names.removeAt(i);
   sbmlAnnotation->speciesColours.erase(sId);
   compartmentIds.removeAt(i);
-  removeInitialAssignment(id);
+  removeInitialAssignment(sId.c_str());
   fields.erase(fields.begin() +
                static_cast<decltype(fields)::difference_type>(i));
-  modelReactions->removeAllInvolvingSpecies(id);
-  if (auto *param = getDiffusionConstantParameter(sbmlModel, id);
+  modelReactions->removeAllInvolvingSpecies(sId.c_str());
+  if (auto *param = getDiffusionConstantParameter(sbmlModel, sId.c_str());
       param != nullptr) {
     SPDLOG_INFO("Removing diffusion constant parameter '{}'", param->getId());
     param->removeFromParentAndDelete();


### PR DESCRIPTION
- make a copy of id before removing it from list of ids and use this copy throughout in ModelCompartments::remove()
- otherwise if user passes a const ref to the id in the list, it changes value after being removed from ids
- do the same for other ModelX::remove() where relevant
- resolves #685
