### PR TITLE
export reaction ModifierSpecies to SBML

### DIFF
--- a/src/core/common/inc/simple_symbolic.hpp
+++ b/src/core/common/inc/simple_symbolic.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,6 +20,7 @@ public:
   substitute(const std::string &expr,
              const std::vector<std::pair<std::string, double>> &constants);
   static bool contains(const std::string &expr, const std::string &var);
+  static std::set<std::string, std::less<>> symbols(const std::string &expr);
 };
 
 } // namespace sme::common

--- a/src/core/common/src/simple_symbolic.cpp
+++ b/src/core/common/src/simple_symbolic.cpp
@@ -40,9 +40,17 @@ std::string SimpleSymbolic::substitute(
 }
 
 bool SimpleSymbolic::contains(const std::string &expr, const std::string &var) {
-  auto v{symbol(var)};
+  return symbols(expr).count(var) != 0;
+}
+
+std::set<std::string, std::less<>>
+SimpleSymbolic::symbols(const std::string &expr) {
+  std::set<std::string, std::less<>> result;
   auto fs{free_symbols(*safeParse(expr))};
-  return fs.find(v) != fs.cend();
+  for (const auto &s : fs) {
+    result.insert(rcp_dynamic_cast<const Symbol>(s)->get_name());
+  }
+  return result;
 }
 
 } // namespace sme::common


### PR DESCRIPTION
- species referenced in reaction rate expression but are not reactants or products in sbml are "modifiers"
- we now export this, but don't import it as we allow any valid species to be referenced in a rate expression
- resolves #133
