### PR TITLE
add topology-preserving boundary simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## latest
+### Added
+- topology-preserving line simplification option [#328](https://github.com/spatial-model-editor/spatial-model-editor/issues/328)
+
 ### Changed
 - model reactions with invalid locations can now be seen and removed or relocated [#615](https://github.com/spatial-model-editor/spatial-model-editor/issues/615)
 

--- a/src/core/mesh/inc/mesh.hpp
+++ b/src/core/mesh/inc/mesh.hpp
@@ -38,11 +38,11 @@ private:
   QImage img;
   QPointF origin;
   double pixel{};
-  std::vector<std::vector<QPointF>> compartmentInteriorPoints;
   std::vector<std::size_t> boundaryMaxPoints;
   std::vector<std::size_t> compartmentMaxTriangleArea;
   // generated data
   std::unique_ptr<Boundaries> boundaries;
+  std::vector<std::vector<QPointF>> compartmentInteriorPoints;
   std::vector<QPointF> vertices;
   std::size_t nTriangles{};
   std::vector<std::vector<QTriangleF>> triangles;
@@ -71,7 +71,8 @@ public:
                 std::vector<std::size_t> maxTriangleArea = {},
                 double pixelWidth = 1.0,
                 const QPointF &originPoint = QPointF(0, 0),
-                const std::vector<QRgb> &compartmentColours = {});
+                const std::vector<QRgb> &compartmentColours = {},
+                std::size_t boundarySimplificationType = 0);
   ~Mesh();
   /**
    * @brief Returns true if the mesh is valid
@@ -86,7 +87,24 @@ public:
    */
   [[nodiscard]] std::size_t getNumBoundaries() const;
   /**
-   * @brief Set the maximum number of allowed points for a given boundary
+   * @brief Get the type of boundary simplification
+   */
+  [[nodiscard]] std::size_t getBoundarySimplificationType() const;
+  /**
+   * @brief Set the type of boundary simplification
+   */
+  void setBoundarySimplificationType(std::size_t boundarySimplificationType);
+  /**
+   * @brief Set the maximum number of allowed points
+   *
+   * If the boundary simplification type is one where each boundary line can be
+   * independently simplified, maxPoints applies only to the specified boundary
+   * line, and only this boundary line is potentially altered by this method.
+   *
+   * If the boundary simplification type is a topology-preserving type that
+   * simplifies all boundaries simultaneously, maxPoints is the total number of
+   * allowed points summed over all boundaries, and all boundary lines can
+   * potentially be altered by this method.
    *
    * @param[in] boundaryIndex the index of the boundary
    * @param[in] maxPoints the maximum number of points allowed

--- a/src/core/mesh/src/CMakeLists.txt
+++ b/src/core/mesh/src/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
           mesh.cpp
           mesh_utils.cpp
           pixel_corner_iterator.cpp
+          polyline_simplifier.cpp
           triangulate.cpp
           triangulate_common.cpp)
 if(BUILD_TESTING)
@@ -26,6 +27,8 @@ if(BUILD_TESTING)
            mesh_t.cpp
            mesh_utils.cpp
            mesh_utils_t.cpp
+           polyline_simplifier.cpp
+           polyline_simplifier_t.cpp
            pixel_corner_iterator.cpp
            pixel_corner_iterator_t.cpp
            triangulate.cpp

--- a/src/core/mesh/src/boundaries.hpp
+++ b/src/core/mesh/src/boundaries.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "boundary.hpp"
+#include "polyline_simplifier.hpp"
 #include <QImage>
 #include <QPoint>
 #include <QPointF>
@@ -20,6 +21,8 @@ namespace sme::mesh {
 class Boundaries {
 private:
   std::vector<Boundary> boundaries{};
+  std::size_t simplifierType{0};
+  PolylineSimplifier polylineSimplifier;
 
 public:
   /**
@@ -29,10 +32,22 @@ public:
    * @param[in] compartmentColours the colours that correspond to compartments
    */
   explicit Boundaries(const QImage &compartmentImage,
-                      const std::vector<QRgb> &compartmentColours);
+                      const std::vector<QRgb> &compartmentColours,
+                      std::size_t simplifierType);
   Boundaries() = default;
-
+  ~Boundaries();
+  /**
+   * @brief The simplified boundaries
+   */
   [[nodiscard]] const std::vector<Boundary> &getBoundaries() const;
+  /**
+   * @brief Get the type of boundary simplifier used
+   */
+  [[nodiscard]] std::size_t getSimplifierType() const;
+  /**
+   * @brief Set the type of boundary simplifier used
+   */
+  void setSimplifierType(std::size_t simplifierType);
   /**
    * @brief The number of boundaries
    */
@@ -44,6 +59,12 @@ public:
    * @param[in] maxPoints the maximum number of points allowed
    */
   void setMaxPoints(std::size_t boundaryIndex, std::size_t maxPoints);
+  /**
+   * @brief Set the total maximum number of allowed points over all boundaries
+   *
+   * @param[in] maxPoints the maximum number of points allowed
+   */
+  void setMaxPoints(std::size_t maxPoints);
   /**
    * @brief Get the maximum number of allowed points for a given boundary
    *

--- a/src/core/mesh/src/boundaries_bench.cpp
+++ b/src/core/mesh/src/boundaries_bench.cpp
@@ -5,14 +5,24 @@ template <typename T> static void mesh_Boundaries(benchmark::State &state) {
   T data;
   sme::mesh::Boundaries boundaries;
   for (auto _ : state) {
-    boundaries = sme::mesh::Boundaries(data.img, data.colours);
+    boundaries = sme::mesh::Boundaries(data.img, data.colours, 0);
   }
 }
 
 template <typename T>
-static void mesh_Boundary_setMaxPoints(benchmark::State &state) {
+static void mesh_Boundary_setMaxPoints0(benchmark::State &state) {
   T data;
-  sme::mesh::Boundaries boundaries(data.img, data.colours);
+  sme::mesh::Boundaries boundaries(data.img, data.colours, 0);
+  auto nPoints{boundaries.getMaxPoints(0)};
+  for (auto _ : state) {
+    boundaries.setMaxPoints(0, nPoints + 1);
+  }
+}
+
+template <typename T>
+static void mesh_Boundary_setMaxPoints1(benchmark::State &state) {
+  T data;
+  sme::mesh::Boundaries boundaries(data.img, data.colours, 1);
   auto nPoints{boundaries.getMaxPoints(0)};
   for (auto _ : state) {
     boundaries.setMaxPoints(0, nPoints + 1);
@@ -20,4 +30,5 @@ static void mesh_Boundary_setMaxPoints(benchmark::State &state) {
 }
 
 SME_BENCHMARK(mesh_Boundaries);
-SME_BENCHMARK(mesh_Boundary_setMaxPoints);
+SME_BENCHMARK(mesh_Boundary_setMaxPoints0);
+SME_BENCHMARK(mesh_Boundary_setMaxPoints1);

--- a/src/core/mesh/src/boundary.cpp
+++ b/src/core/mesh/src/boundary.cpp
@@ -17,8 +17,8 @@ const std::vector<QPoint> &Boundary::getAllPoints() const {
 
 std::size_t Boundary::getMaxPoints() const { return maxPoints; }
 
-void Boundary::setPoints(const std::vector<QPoint> &simplifiedPoints) {
-  points = simplifiedPoints;
+void Boundary::setPoints(std::vector<QPoint> &&simplifiedPoints) {
+  points = std::move(simplifiedPoints);
 }
 
 void Boundary::setMaxPoints(std::size_t nMaxPoints) {

--- a/src/core/mesh/src/boundary.hpp
+++ b/src/core/mesh/src/boundary.hpp
@@ -49,7 +49,7 @@ public:
   /**
    * @brief Set the simplified line points explicitly
    */
-  void setPoints(const std::vector<QPoint> &simplifiedPoints);
+  void setPoints(std::vector<QPoint> &&simplifiedPoints);
   /**
    * @brief Set the maximum number of points to use in the approximate line
    */

--- a/src/core/mesh/src/line_simplifier_bench.cpp
+++ b/src/core/mesh/src/line_simplifier_bench.cpp
@@ -4,7 +4,7 @@
 
 template <typename T> static void mesh_LineSimplifier(benchmark::State &state) {
   T data;
-  sme::mesh::Boundaries boundaries(data.img, data.colours);
+  sme::mesh::Boundaries boundaries(data.img, data.colours, 0);
   for (auto _ : state) {
     for (const auto &boundary : boundaries.getBoundaries()) {
       auto l{sme::mesh::LineSimplifier(boundary.getAllPoints(),

--- a/src/core/mesh/src/polyline_simplifier.cpp
+++ b/src/core/mesh/src/polyline_simplifier.cpp
@@ -1,0 +1,74 @@
+#include "polyline_simplifier.hpp"
+#include "boundary.hpp"
+#include "logger.hpp"
+#include <algorithm>
+
+namespace sme::mesh {
+
+PolylineSimplifier::PolylineSimplifier(
+    const std::vector<Boundary> &boundaries) {
+  setBoundaries(boundaries);
+}
+
+void PolylineSimplifier::setBoundaries(
+    const std::vector<Boundary> &boundaries) {
+  ct.clear();
+  constraintIds.clear();
+  for (auto &boundary : boundaries) {
+    std::vector<CGALCt::Point> v;
+    auto n{boundary.getAllPoints().size()};
+    v.reserve(n);
+    for (const auto &p : boundary.getAllPoints()) {
+      v.emplace_back(p.x(), p.y());
+    }
+    constraintIds.push_back(
+        ct.insert_constraint(v.begin(), v.end(), boundary.isLoop()));
+  }
+}
+
+std::size_t PolylineSimplifier::getMaxPoints() const {
+  return ct.number_of_vertices();
+}
+
+static void
+updatePoints(const CGALCt &ct,
+             const std::vector<CGALCt::Constraint_id> &constraintIds,
+             std::vector<Boundary> &boundaries) {
+  for (std::size_t i = 0; i < boundaries.size(); ++i) {
+    std::vector<QPoint> points;
+    auto vertices{ct.vertices_in_constraint(constraintIds[i])};
+    points.reserve(vertices.size());
+    for (auto vertex : vertices) {
+      points.emplace_back(static_cast<int>(vertex->point().x()),
+                          static_cast<int>(vertex->point().y()));
+    }
+    if (boundaries[i].isLoop()) {
+      points.pop_back();
+    }
+    boundaries[i].setPoints(std::move(points));
+  }
+}
+
+void PolylineSimplifier::setMaxPoints(std::vector<Boundary> &boundaries,
+                                      std::size_t maxPoints) {
+  namespace PS = CGAL::Polyline_simplification_2;
+  if (boundaries.empty()) {
+    return;
+  }
+  bool canReuseCt{boundaries.size() == constraintIds.size() && maxPoints != 0 &&
+                  maxPoints <= ct.number_of_vertices()};
+  if (!canReuseCt) {
+    setBoundaries(boundaries);
+  }
+  if (maxPoints == 0) {
+    constexpr double maxAllowedCost{5.0};
+    PS::simplify(ct, PS::Squared_distance_cost(),
+                 PS::Stop_above_cost_threshold(maxAllowedCost), false);
+  } else {
+    PS::simplify(ct, PS::Squared_distance_cost(),
+                 PS::Stop_below_count_threshold(maxPoints), false);
+  }
+  updatePoints(ct, constraintIds, boundaries);
+}
+
+} // namespace sme::mesh

--- a/src/core/mesh/src/polyline_simplifier.hpp
+++ b/src/core/mesh/src/polyline_simplifier.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "boundary.hpp"
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Constrained_triangulation_plus_2.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polyline_simplification_2/simplify.h>
+#include <QImage>
+#include <QPoint>
+#include <QPointF>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace sme::mesh {
+
+using CGALKernel = CGAL::Exact_predicates_inexact_constructions_kernel;
+using CGALVb = CGAL::Polyline_simplification_2::Vertex_base_2<CGALKernel>;
+using CGALFb = CGAL::Constrained_triangulation_face_base_2<CGALKernel>;
+using CGALTds = CGAL::Triangulation_data_structure_2<CGALVb, CGALFb>;
+using CGALCdt =
+    CGAL::Constrained_Delaunay_triangulation_2<CGALKernel, CGALTds,
+                                               CGAL::Exact_predicates_tag>;
+using CGALCt = CGAL::Constrained_triangulation_plus_2<CGALCdt>;
+
+/**
+ * @brief Simplify a set of boundary lines
+ *
+ * Simplify a set of lines by removing vertices without causing any new
+ * intersections: topology-preserving polyline simplification.
+ * https://doc.cgal.org/latest/Polyline_simplification_2
+ */
+class PolylineSimplifier {
+private:
+  std::vector<CGALCt::Constraint_id> constraintIds;
+  CGALCt ct;
+  void initCt(const std::vector<Boundary> &boundaries);
+
+public:
+  explicit PolylineSimplifier(const std::vector<Boundary> &boundaries);
+  explicit PolylineSimplifier() = default;
+  PolylineSimplifier(const PolylineSimplifier &) = default;
+  PolylineSimplifier &operator=(const PolylineSimplifier &) = default;
+  // delete move constructors to avoid CGAL::Constrained_triangulation_plus_2
+  // move-constructor, which leaks memory
+  PolylineSimplifier(PolylineSimplifier &&) = delete;
+  PolylineSimplifier &operator=(PolylineSimplifier &&) = delete;
+  ~PolylineSimplifier() = default;
+  void setBoundaries(const std::vector<Boundary> &boundaries);
+  [[nodiscard]] std::size_t getMaxPoints() const;
+  void setMaxPoints(std::vector<Boundary> &boundaries, std::size_t maxPoints);
+};
+
+} // namespace sme::mesh

--- a/src/core/mesh/src/polyline_simplifier_t.cpp
+++ b/src/core/mesh/src/polyline_simplifier_t.cpp
@@ -1,0 +1,94 @@
+#include "boundaries.hpp"
+#include "catch_wrapper.hpp"
+#include "polyline_simplifier.hpp"
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+using namespace sme;
+
+static std::size_t
+countVertices(const std::vector<mesh::Boundary> &boundaries) {
+  return std::accumulate(
+      boundaries.cbegin(), boundaries.cend(), std::size_t{0},
+      [](std::size_t n, const auto &b) { return n + b.getPoints().size(); });
+}
+
+TEST_CASE(
+    "PolylineSimplifier",
+    "[core/mesh/polyline_simplifier][core/mesh][core][polyline_simplifier]") {
+  SECTION("Invalid inputs are no-ops") {
+    std::vector<mesh::Boundary> b{
+        mesh::Boundary({QPoint(1, 1), QPoint(1, 3), QPoint(3, 1)}, true)};
+    mesh::PolylineSimplifier polylineSimplifier(b);
+    REQUIRE(b.front().getAllPoints().size() == 3);
+    REQUIRE(b.front().isLoop() == true);
+    b.clear();
+    REQUIRE(b.empty());
+    polylineSimplifier.setMaxPoints(b, 123);
+    REQUIRE(b.empty());
+  }
+  SECTION("Concave loops") {
+    QImage img(":/geometry/concave-cell-nucleus-100x100.png");
+    QRgb col0 = img.pixel(0, 0);
+    QRgb col1 = img.pixel(35, 20);
+    QRgb col2 = img.pixel(40, 50);
+    std::vector<mesh::Boundary> boundaries{
+        mesh::Boundaries(img, {col0, col1, col2}, 0).getBoundaries()};
+    mesh::PolylineSimplifier polylineSimplifier(boundaries);
+    polylineSimplifier.setMaxPoints(boundaries, 20);
+    // for concave loops: max points equal to number of vertices
+    REQUIRE(polylineSimplifier.getMaxPoints() == 20);
+    REQUIRE(countVertices(boundaries) == 20);
+    polylineSimplifier.setMaxPoints(boundaries, 24);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 24);
+    REQUIRE(countVertices(boundaries) == 24);
+    polylineSimplifier.setMaxPoints(boundaries, 15);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 15);
+    REQUIRE(countVertices(boundaries) == 15);
+    // automatic choice of max points:
+    polylineSimplifier.setMaxPoints(boundaries, 0);
+    REQUIRE(polylineSimplifier.getMaxPoints() > 0);
+    REQUIRE(countVertices(boundaries) > 0);
+    // setting maxPoints below minimium possible value sets it to minimum
+    polylineSimplifier.setMaxPoints(boundaries, 3);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 11);
+    REQUIRE(countVertices(boundaries) == 11);
+  }
+  SECTION("Mix of loops and lines") {
+    QImage img(":/geometry/liver-cells-200x100.png");
+    QRgb col0 = img.pixel(24, 50);
+    QRgb col1 = img.pixel(76, 14);
+    QRgb col2 = img.pixel(20, 15);
+    std::vector<mesh::Boundary> boundaries{
+        mesh::Boundaries(img, {col0, col1, col2}, 0).getBoundaries()};
+    mesh::PolylineSimplifier polylineSimplifier(boundaries);
+    // set max points too small
+    polylineSimplifier.setMaxPoints(boundaries, 12);
+    REQUIRE(polylineSimplifier.getMaxPoints() == Catch::Approx(61).margin(2));
+    // more vertices than points, as some vertices present in multiple boundary
+    // lines
+    REQUIRE(countVertices(boundaries) == Catch::Approx(97).margin(2));
+    // set max points too large
+    polylineSimplifier.setMaxPoints(boundaries, 999999);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 626);
+    REQUIRE(countVertices(boundaries) == 662);
+    polylineSimplifier.setMaxPoints(boundaries, 88);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 88);
+    REQUIRE(countVertices(boundaries) == 124);
+    polylineSimplifier.setMaxPoints(boundaries, 150);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 150);
+    REQUIRE(countVertices(boundaries) == 186);
+    // setting maxPoints to current value is a no-op
+    polylineSimplifier.setMaxPoints(boundaries, 150);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 150);
+    REQUIRE(countVertices(boundaries) == 186);
+    polylineSimplifier.setMaxPoints(boundaries, 144);
+    REQUIRE(polylineSimplifier.getMaxPoints() == 144);
+    REQUIRE(countVertices(boundaries) == 180);
+    // automatic choice of max points:
+    polylineSimplifier.setMaxPoints(boundaries, 0);
+    REQUIRE(polylineSimplifier.getMaxPoints() > 0);
+    REQUIRE(countVertices(boundaries) > 0);
+  }
+}

--- a/src/core/mesh/src/triangulate_bench.cpp
+++ b/src/core/mesh/src/triangulate_bench.cpp
@@ -7,7 +7,7 @@ template <typename T>
 static void mesh_TriangulateBoundaries(benchmark::State &state) {
   T data;
   auto interiorPoints{sme::mesh::getInteriorPoints(data.img, data.colours)};
-  sme::mesh::Boundaries boundaries(data.img, data.colours);
+  sme::mesh::Boundaries boundaries(data.img, data.colours, 0);
   for (auto _ : state) {
     auto t{sme::mesh::Triangulate(boundaries.getBoundaries(), interiorPoints,
                                   data.maxTriangleArea)};

--- a/src/core/model/inc/model.hpp
+++ b/src/core/model/inc/model.hpp
@@ -101,6 +101,8 @@ public:
   [[nodiscard]] const simulate::SimulationData &getSimulationData() const;
   SimulationSettings &getSimulationSettings();
   [[nodiscard]] const SimulationSettings &getSimulationSettings() const;
+  MeshParameters &getMeshParameters();
+  [[nodiscard]] const MeshParameters &getMeshParameters() const;
 
   explicit Model();
   Model(Model &&) noexcept = default;

--- a/src/core/model/inc/model_settings.hpp
+++ b/src/core/model/inc/model_settings.hpp
@@ -14,11 +14,14 @@ namespace sme::model {
 struct MeshParameters {
   std::vector<std::size_t> maxPoints{};
   std::vector<std::size_t> maxAreas{};
-
+  std::size_t boundarySimplifierType{0};
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
     if (version == 0) {
       ar(CEREAL_NVP(maxPoints), CEREAL_NVP(maxAreas));
+    } else if (version == 1) {
+      ar(CEREAL_NVP(maxPoints), CEREAL_NVP(maxAreas),
+         CEREAL_NVP(boundarySimplifierType));
     }
   }
 };
@@ -80,7 +83,7 @@ struct Settings {
 
 } // namespace sme::model
 
-CEREAL_CLASS_VERSION(sme::model::MeshParameters, 0);
+CEREAL_CLASS_VERSION(sme::model::MeshParameters, 1);
 CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 1);
 CEREAL_CLASS_VERSION(sme::model::SimulationSettings, 1);
 CEREAL_CLASS_VERSION(sme::model::Settings, 0);

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -256,6 +256,12 @@ const SimulationSettings &Model::getSimulationSettings() const {
   return settings->simulationSettings;
 }
 
+MeshParameters &Model::getMeshParameters() { return settings->meshParameters; }
+
+const MeshParameters &Model::getMeshParameters() const {
+  return settings->meshParameters;
+}
+
 void Model::clear() {
   doc.reset();
   isValid = false;

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -293,9 +293,10 @@ void ModelGeometry::updateMesh() {
   const auto &colours{modelCompartments->getColours()};
   const auto &ids{modelCompartments->getIds()};
   const auto &meshParams{sbmlAnnotation->meshParameters};
-  mesh = std::make_unique<mesh::Mesh>(
-      image, meshParams.maxPoints, meshParams.maxAreas, pixelWidth,
-      physicalOrigin, common::toStdVec(colours));
+  mesh = std::make_unique<mesh::Mesh>(image, meshParams.maxPoints,
+                                      meshParams.maxAreas, pixelWidth,
+                                      physicalOrigin, common::toStdVec(colours),
+                                      meshParams.boundarySimplifierType);
   for (int i = 0; i < ids.size(); ++i) {
     modelCompartments->setInteriorPoints(
         ids[i],
@@ -441,7 +442,8 @@ bool ModelGeometry::getHasImage() const { return hasImage; }
 void ModelGeometry::writeGeometryToSBML() const {
   if (mesh != nullptr && mesh->isValid()) {
     sbmlAnnotation->meshParameters = {mesh->getBoundaryMaxPoints(),
-                                      mesh->getCompartmentMaxTriangleArea()};
+                                      mesh->getCompartmentMaxTriangleArea(),
+                                      mesh->getBoundarySimplificationType()};
   }
 }
 

--- a/src/core/model/src/xml_annotation_t.cpp
+++ b/src/core/model/src/xml_annotation_t.cpp
@@ -27,6 +27,8 @@ TEST_CASE("XML Annotations",
     simulationSettings.times.push_back({5, 0.25});
     simulationSettings.options.pixel.maxThreads = 4;
     simulationSettings.options.dune.dt = 0.0123;
+    auto &meshParameters{settings.meshParameters};
+    meshParameters.boundarySimplifierType = 1;
     model::setSbmlAnnotation(model, settings);
 
     // load them from sbml
@@ -42,6 +44,8 @@ TEST_CASE("XML Annotations",
     REQUIRE(newSimulationSettings.times.size() == 2);
     REQUIRE(newSimulationSettings.options.pixel.maxThreads == 4);
     REQUIRE(newSimulationSettings.options.dune.dt == dbl_approx(0.0123));
+    auto &newMeshParameters{settings.meshParameters};
+    REQUIRE(newMeshParameters.boundarySimplifierType == 1);
 
     // change options, save & write to file
     newSimulationSettings.times.push_back({7, 0.33});

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
           dialoggeometryimage.cpp
           dialogimage.cpp
           dialogimageslice.cpp
+          dialogmeshingoptions.cpp
           dialogsimulationoptions.cpp
           dialogunits.cpp)
 target_include_directories(gui PUBLIC .)
@@ -27,6 +28,7 @@ if(BUILD_TESTING)
            dialoggeometryimage_t.cpp
            dialogimage_t.cpp
            dialogimageslice_t.cpp
+           dialogmeshingoptions_t.cpp
            dialogsimulationoptions_t.cpp
            dialogunits_t.cpp)
 endif()

--- a/src/gui/dialogs/dialogmeshingoptions.cpp
+++ b/src/gui/dialogs/dialogmeshingoptions.cpp
@@ -1,0 +1,21 @@
+#include "dialogmeshingoptions.hpp"
+#include "ui_dialogmeshingoptions.h"
+
+DialogMeshingOptions::DialogMeshingOptions(
+    std::size_t boundarySimplificationType, QWidget *parent)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogMeshingOptions>()} {
+  ui->setupUi(this);
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+          &DialogMeshingOptions::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &DialogMeshingOptions::reject);
+  ui->cmbBoundarySimplificationType->setCurrentIndex(
+      static_cast<int>(boundarySimplificationType));
+}
+
+DialogMeshingOptions::~DialogMeshingOptions() = default;
+
+std::size_t DialogMeshingOptions::getBoundarySimplificationType() const {
+  return static_cast<std::size_t>(
+      ui->cmbBoundarySimplificationType->currentIndex());
+}

--- a/src/gui/dialogs/dialogmeshingoptions.hpp
+++ b/src/gui/dialogs/dialogmeshingoptions.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <QDialog>
+#include <memory>
+
+namespace Ui {
+class DialogMeshingOptions;
+}
+
+class DialogMeshingOptions : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit DialogMeshingOptions(std::size_t boundarySimplificationType,
+                                QWidget *parent = nullptr);
+  ~DialogMeshingOptions() override;
+  std::size_t getBoundarySimplificationType() const;
+
+private:
+  std::unique_ptr<Ui::DialogMeshingOptions> ui;
+};

--- a/src/gui/dialogs/dialogmeshingoptions.ui
+++ b/src/gui/dialogs/dialogmeshingoptions.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogMeshingOptions</class>
+ <widget class="QDialog" name="DialogMeshingOptions">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>469</width>
+    <height>92</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Meshing Options</string>
+  </property>
+  <property name="whatsThis">
+   <string/>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblBoundarySimplificationType">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Boundary Simplification Type:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="cmbBoundarySimplificationType">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Visvalingam-Whyatt</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Topology preserving</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/dialogs/dialogmeshingoptions_t.cpp
+++ b/src/gui/dialogs/dialogmeshingoptions_t.cpp
@@ -1,0 +1,23 @@
+#include "catch_wrapper.hpp"
+#include "dialogmeshingoptions.hpp"
+#include "qt_test_utils.hpp"
+
+using namespace sme::test;
+
+TEST_CASE("DialogMeshingOptions", "[gui/dialogs/meshingoptions][gui/"
+                                  "dialogs][gui][meshingoptions]") {
+  DialogMeshingOptions dia(1);
+  ModalWidgetTimer mwt;
+  SECTION("user does nothing: unchanged") {
+    mwt.addUserAction();
+    mwt.start();
+    dia.exec();
+    REQUIRE(dia.getBoundarySimplificationType() == 1);
+  }
+  SECTION("user changes value") {
+    mwt.addUserAction({"Up"});
+    mwt.start();
+    dia.exec();
+    REQUIRE(dia.getBoundarySimplificationType() == 0);
+  }
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2,6 +2,7 @@
 #include "dialogabout.hpp"
 #include "dialogcoordinates.hpp"
 #include "dialoggeometryimage.hpp"
+#include "dialogmeshingoptions.hpp"
 #include "dialogsimulationoptions.hpp"
 #include "dialogunits.hpp"
 #include "duneconverter.hpp"
@@ -189,6 +190,9 @@ void MainWindow::setupConnections() {
 
   connect(ui->actionSimulation_options, &QAction::triggered, this,
           &MainWindow::actionSimulation_options_triggered);
+
+  connect(ui->action_Meshing_options, &QAction::triggered, this,
+          &MainWindow::action_Meshing_options_triggered);
 
   connect(ui->action_What_s_this, &QAction::triggered, this,
           []() { QWhatsThis::enterWhatsThisMode(); });
@@ -606,6 +610,18 @@ void MainWindow::actionSimulation_options_triggered() {
   DialogSimulationOptions dialog(model.getSimulationSettings().options);
   if (dialog.exec() == QDialog::Accepted) {
     tabSimulate->setOptions(dialog.getOptions());
+    tabMain_currentChanged(ui->tabMain->currentIndex());
+  }
+}
+
+void MainWindow::action_Meshing_options_triggered() {
+  DialogMeshingOptions dialog(model.getMeshParameters().boundarySimplifierType);
+  if (auto &boundarySimplifierType{
+          model.getMeshParameters().boundarySimplifierType};
+      dialog.exec() == QDialog::Accepted &&
+      boundarySimplifierType != dialog.getBoundarySimplificationType()) {
+    boundarySimplifierType = dialog.getBoundarySimplificationType();
+    model.getGeometry().updateMesh();
     tabMain_currentChanged(ui->tabMain->currentIndex());
   }
 }

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -78,6 +78,7 @@ private:
 
   // Advanced menu actions
   void actionSimulation_options_triggered();
+  void action_Meshing_options_triggered();
 
   void lblGeometry_mouseOver(QPoint point);
   void spinGeometryZoom_valueChanged(int value);

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -286,6 +286,7 @@
      <string>&amp;Advanced</string>
     </property>
     <addaction name="actionSimulation_options"/>
+    <addaction name="action_Meshing_options"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -543,6 +544,11 @@
    </property>
    <property name="text">
     <string>Invert &amp;y-axis</string>
+   </property>
+  </action>
+  <action name="action_Meshing_options">
+   <property name="text">
+    <string>&amp;Meshing options...</string>
    </property>
   </action>
   <actiongroup name="actionGroupSimType">

--- a/src/gui/mainwindow_t.cpp
+++ b/src/gui/mainwindow_t.cpp
@@ -297,6 +297,13 @@ TEST_CASE("MainWindow: advanced menu", tags) {
     sendKeyEvents(menu_Advanced, {"S"});
     REQUIRE(mwt.getResult() == "Simulation Options");
   }
+  SECTION("menu: Advanced->Meshing options... ") {
+    mwt.addUserAction({"Down", "Enter"});
+    mwt.start();
+    sendKeyEvents(&w, {"Alt+A"});
+    sendKeyEvents(menu_Advanced, {"M"});
+    REQUIRE(mwt.getResult() == "Meshing Options");
+  }
 }
 
 TEST_CASE("MainWindow: geometry", tags) {


### PR DESCRIPTION
- add GUI option to choose boundary line simplification type
  - Advanced -> Mesh Options
- add DialogMeshingOptions
  - choice of default or topology-preserving boundary simplification type
- add lineSimplificationType option in various places
- add PolylineSimplifier
  - uses CGAL 2D Polyline Simplification to simplify without causing new intersections
