### PR TITLE
add initial optimization functionality

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,7 +18,7 @@ env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  SONAR_SCANNER_VERSION: '4.6.2.2472'
+  SONAR_SCANNER_VERSION: '4.7.0.2747'
   CC: clang
   CXX: clang++
 
@@ -32,7 +32,7 @@ jobs:
         script: [codecov, sonar, asan, ubsan, tsan]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           path: ~/.sonarcache
           key: sonar-${{ github.job }}-${{ matrix.script }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: sonar-${{ github.job }}-${{ matrix.script }}-${{ runner.os }}-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Get static libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Set "latest" version number unless commit is version tagged
@@ -31,7 +31,7 @@ jobs:
         path: ~/.cache/ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.9
     - name: Get static libs
@@ -51,7 +51,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - name: Set "latest" version number unless commit is version tagged
@@ -63,7 +63,7 @@ jobs:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Get static libs
@@ -81,7 +81,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,13 +25,13 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.02.09
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.02.09
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.02.28
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.02.28
       CIBW_SKIP: '*-manylinux_i686 *-musllinux*'
       CIBW_ENVIRONMENT: 'SME_BUILD_CORE=off'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Set "latest" version number unless commit is version tagged
@@ -43,7 +43,7 @@ jobs:
         path: ${{ github.workspace }}/ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: '3.9'
     - name: Install cibuildwheel
@@ -64,7 +64,7 @@ jobs:
       CIBW_ENVIRONMENT: 'BLAS=None LAPACK=None ATLAS=None'
       CIBW_TEST_SKIP: 'pp3*-macosx_x86_64'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - name: Set "latest" version number unless commit is version tagged
@@ -76,7 +76,7 @@ jobs:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Download static libraries
@@ -98,7 +98,7 @@ jobs:
       SME_EXTRA_CORE_DEFS: '_hypot=hypot;MS_WIN64'
       CIBW_TEST_SKIP: "pp3*-win_amd64"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="left" width="64" height="64" src="https://raw.githubusercontent.com/spatial-model-editor/spatial-model-editor/main/src/core/resources/icon.iconset/icon_32x32@2x.png" alt="icon">
+<img align="left" width="64" height="64" src="https://raw.githubusercontent.com/spatial-model-editor/spatial-model-editor/main/core/resources/icon.iconset/icon_32x32@2x.png" alt="icon">
 
 # Spatial Model Editor
 

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2022.02.03.tbb"
+SME_DEPS_VERSION="2022.02.28"
 OS=$1
 
 set -e -x

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -1,0 +1,163 @@
+#pragma once
+#include "sme/model.hpp"
+#include "sme/simulate.hpp"
+#include <pagmo/algorithm.hpp>
+#include <pagmo/population.hpp>
+#include <pagmo/problem.hpp>
+
+namespace sme::simulate {
+
+/**
+ * @brief Types of model parameters that can be used in optimization
+ */
+enum class OptParamType { ModelParameter, ReactionParameter };
+
+/**
+ * @brief Defines a parameter to be used in optimization
+ */
+struct OptParam {
+  /**
+   * @brief The type of parameter
+   */
+  OptParamType optParamType;
+  /**
+   * @brief The id of the parameter in the model
+   */
+  QString id;
+  /**
+   * @brief The id of the parent of the parameter in the model (optional)
+   */
+  QString parentId;
+  /**
+   * @brief The lower bound on the allowed values of the parameter
+   */
+  double lowerBound;
+  /**
+   * @brief The upper bound on the allowed values of the parameter
+   */
+  double upperBound;
+};
+
+/**
+ * @brief Types of costs that can be used in optimization
+ */
+enum class OptCostType { Concentration, ConcentrationDcdt };
+
+/**
+ * @brief Types of differences that can be used in costs
+ */
+enum class OptCostDiffType { Absolute, Relative };
+
+/**
+ * @brief Defines a cost function to be minimzed
+ */
+struct OptCost {
+  /**
+   * @brief The type of cost function
+   */
+  OptCostType optCostType;
+  /**
+   * @brief The type of difference (e.g. absolute, relative) used in the cost
+   * function
+   */
+  OptCostDiffType optCostDiffType;
+  /**
+   * @brief The scale factor to multiply the cost by
+   *
+   * This assigns a relative weight to this cost when the optimization involves
+   * the sum of multiple cost functions.
+   */
+  double scaleFactor{1.0};
+  /**
+   * @brief The index of the compartment containing the species
+   */
+  std::size_t compartmentIndex;
+  /**
+   * @brief The index of the species
+   */
+  std::size_t speciesIndex;
+  /**
+   * @brief The target values to compare with the species concentration
+   *
+   * Should contain a desired value for each pixel in the compartment.
+   * If empty, the target values are assumed to be zero.
+   */
+  std::vector<double> targetValues;
+  /**
+   * @brief A small number to avoid dividing by zero in relative differences
+   *
+   * A small value to be added to the denominator of relative differences to
+   * avoid instabilities caused by dividing by zero.
+   */
+  double epsilon{1e-15};
+};
+
+/**
+ * @brief Optimization options
+ */
+struct OptimizeOptions {
+  /**
+   * @brief The population size to evolve
+   */
+  std::size_t nParticles{1};
+  /**
+   * @brief The time for which the model should be simulated
+   */
+  double simulationTime{1};
+  /**
+   * @brief The parameters to optimize
+   */
+  std::vector<OptParam> optParams;
+  /**
+   * @brief The costs to minimize
+   */
+  std::vector<OptCost> optCosts;
+};
+
+/**
+ * @brief Optimize model parameters
+ *
+ * Optimizes the supplied model parameters to minimize the supplied cost
+ * functions.
+ */
+class Optimization {
+private:
+  pagmo::problem prob;
+  pagmo::algorithm algo;
+  pagmo::population pop;
+  OptimizeOptions options;
+  std::size_t niter{0};
+
+public:
+  /**
+   * @brief Constructs an Optimization object from the supplied model and
+   * optimization options
+   *
+   * @param[in] model the model to optimize
+   * @param[in] optimizeOptions the optimization options
+   */
+  explicit Optimization(sme::model::Model &model,
+                        OptimizeOptions optimizeOptions);
+  /**
+   * @brief Do a single evolution of parameter optimization
+   */
+  void evolve();
+  /**
+   * @brief Apply the current best parameter values to the supplied model
+   */
+  void applyParametersToModel(sme::model::Model *model) const;
+  /**
+   * @brief The current best set of parameters
+   */
+  std::vector<double> params() const;
+  /**
+   * @brief The fitness of the current best set of parameters
+   */
+  std::vector<double> fitness() const;
+  /**
+   * @brief The number of completed evolve iterations
+   */
+  std::size_t iterations() const;
+};
+
+} // namespace sme::simulate

--- a/core/simulate/src/CMakeLists.txt
+++ b/core/simulate/src/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(
           dunesim_impl.cpp
           dunesim_impl_coupled.cpp
           dunesim_impl_independent.cpp
+          optimize.cpp
+          optimize_impl.cpp
           pde.cpp
           pixelsim.cpp
           pixelsim_impl.cpp
@@ -26,6 +28,8 @@ if(BUILD_TESTING)
            dunegrid_t.cpp
            duneini_t.cpp
            dunesim_t.cpp
+           optimize_t.cpp
+           optimize_impl_t.cpp
            pde_t.cpp
            pixelsim_t.cpp
            simulate_data_t.cpp

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -1,0 +1,36 @@
+#include "sme/optimize.hpp"
+#include "optimize_impl.hpp"
+#include "sme/logger.hpp"
+#include "sme/model.hpp"
+#include <iostream>
+#include <pagmo/algorithms/pso.hpp>
+#include <utility>
+
+namespace sme::simulate {
+
+Optimization::Optimization(sme::model::Model &model,
+                           OptimizeOptions optimizeOptions)
+    : options{std::move(optimizeOptions)} {
+  PagmoUDP udp{};
+  udp.init(model.getXml().toStdString(), options);
+  prob = pagmo::problem{std::move(udp)};
+  algo = pagmo::algorithm{pagmo::pso()};
+  pop = pagmo::population{prob, options.nParticles};
+}
+
+void Optimization::evolve() {
+  pop = algo.evolve(pop);
+  ++niter;
+}
+
+void Optimization::applyParametersToModel(sme::model::Model *model) const {
+  applyParameters(params(), options.optParams, model);
+}
+
+std::vector<double> Optimization::params() const { return pop.champion_x(); }
+
+std::vector<double> Optimization::fitness() const { return pop.champion_f(); }
+
+std::size_t Optimization::iterations() const { return niter; };
+
+} // namespace sme::simulate

--- a/core/simulate/src/optimize_impl.cpp
+++ b/core/simulate/src/optimize_impl.cpp
@@ -1,0 +1,122 @@
+#include "optimize_impl.hpp"
+
+namespace sme::simulate {
+
+void applyParameters(const pagmo::vector_double &values,
+                     const std::vector<OptParam> &optParams,
+                     sme::model::Model *model) {
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    const auto &param{optParams[i]};
+    double value{values[i]};
+    switch (param.optParamType) {
+    case OptParamType::ModelParameter:
+      SPDLOG_INFO("Setting parameter '{}' to {}", param.id.toStdString(),
+                  value);
+      model->getParameters().setExpression(param.id,
+                                           common::dblToQStr(value, 17));
+      break;
+    case OptParamType::ReactionParameter:
+      SPDLOG_INFO("Setting reaction parameter '{}' of reaction '{}' to {}",
+                  param.id.toStdString(), param.parentId.toStdString(), value);
+      model->getReactions().setParameterValue(param.parentId, param.id, value);
+      break;
+    default:
+      throw std::invalid_argument("Optimization: Invalid OptParamType");
+    }
+  }
+}
+
+double calculateCosts(const std::vector<OptCost> &optCosts,
+                      const sme::simulate::Simulation &sim) {
+  double cost{0};
+  for (const auto &optCost : optCosts) {
+    std::vector<double> values;
+    auto compIndex{optCost.compartmentIndex};
+    auto specIndex{optCost.speciesIndex};
+    switch (optCost.optCostType) {
+    case OptCostType::Concentration:
+      values =
+          sim.getConc(sim.getTimePoints().size() - 1, compIndex, specIndex);
+      break;
+    case OptCostType::ConcentrationDcdt:
+      values = sim.getDcdt(compIndex, specIndex);
+      break;
+    default:
+      throw std::invalid_argument("Optimization: Invalid OptCostType");
+    }
+    if (optCost.targetValues.empty()) {
+      // default target is zero if not specified
+      for (auto &value : values) {
+        value = std::abs(value);
+      }
+    } else {
+      if (values.size() != optCost.targetValues.size()) {
+        SPDLOG_ERROR(
+            "Mismatch between size of values ({}) and target values ({})",
+            values.size(), optCost.targetValues.size());
+        throw std::invalid_argument(
+            "Optimization: Target values size mismatch");
+      }
+      for (std::size_t i = 0; i < values.size(); ++i) {
+        double diff{values[i] - optCost.targetValues[i]};
+        if (optCost.optCostDiffType == OptCostDiffType::Relative) {
+          diff /= (std::abs(optCost.targetValues[i]) + optCost.epsilon);
+        }
+        values[i] = std::abs(diff);
+      }
+    }
+    cost += optCost.scaleFactor * sme::common::sum(values);
+  }
+  return cost;
+}
+
+PagmoUDP::PagmoUDP() = default;
+
+PagmoUDP::PagmoUDP(PagmoUDP &&) noexcept = default;
+
+PagmoUDP &PagmoUDP::operator=(PagmoUDP &&) noexcept = default;
+
+PagmoUDP::~PagmoUDP() = default;
+
+PagmoUDP &PagmoUDP::operator=(const PagmoUDP &other) {
+  if (&other != this) {
+    init(other.xmlModel, other.optimizeOptions);
+  }
+  return *this;
+}
+
+PagmoUDP::PagmoUDP(const PagmoUDP &other) {
+  init(other.xmlModel, other.optimizeOptions);
+}
+
+void PagmoUDP::init(const std::string &xml, const OptimizeOptions &options) {
+  SPDLOG_INFO("initializing model");
+  xmlModel = xml;
+  optimizeOptions = options;
+  model = std::make_unique<sme::model::Model>();
+  model->importSBMLString(xmlModel);
+}
+
+[[nodiscard]] pagmo::vector_double
+PagmoUDP::fitness(const pagmo::vector_double &dv) const {
+  model->getSimulationData().clear();
+  applyParameters(dv, optimizeOptions.optParams, model.get());
+  sme::simulate::Simulation sim(*model);
+  sim.doTimesteps(optimizeOptions.simulationTime);
+  auto cost{calculateCosts(optimizeOptions.optCosts, sim)};
+  return {cost};
+}
+
+[[nodiscard]] std::pair<pagmo::vector_double, pagmo::vector_double>
+PagmoUDP::get_bounds() const {
+  std::pair<pagmo::vector_double, pagmo::vector_double> bounds;
+  bounds.first.reserve(optimizeOptions.optParams.size());
+  bounds.second.reserve(optimizeOptions.optParams.size());
+  for (const auto &optParam : optimizeOptions.optParams) {
+    bounds.first.push_back(optParam.lowerBound);
+    bounds.second.push_back(optParam.upperBound);
+  }
+  return bounds;
+}
+
+} // namespace sme::simulate

--- a/core/simulate/src/optimize_impl.hpp
+++ b/core/simulate/src/optimize_impl.hpp
@@ -1,0 +1,51 @@
+#include "sme/logger.hpp"
+#include "sme/model.hpp"
+#include "sme/optimize.hpp"
+#include "sme/simulate.hpp"
+#include "sme/utils.hpp"
+#include <iostream>
+#include <pagmo/algorithms/pso.hpp>
+
+namespace sme::simulate {
+
+void applyParameters(const pagmo::vector_double &values,
+                     const std::vector<OptParam> &optParams,
+                     sme::model::Model *model);
+
+double calculateCosts(const std::vector<OptCost> &optCosts,
+                      const sme::simulate::Simulation &sim);
+
+/**
+ * @brief Implements a Pagmo User Defined Problem to evolve
+ *
+ * @note Needs to be copy-constructible, implement fitness() and get_bounds()
+ * functions and be thread-safe, see
+ * https://esa.github.io/pagmo2/docs/cpp/problem.html
+ *
+ * @note Pagmo also assumes a UDP is cheap to copy, in particular when using
+ * Archipelagos for parallel evolution many copies are made. Currently ours is
+ * not cheap to copy as it also makes a copy of the model (in order to be thread
+ * safe when modifying/simulating this model).
+ */
+
+class PagmoUDP {
+private:
+  std::string xmlModel;
+  std::unique_ptr<sme::model::Model> model;
+  OptimizeOptions optimizeOptions;
+
+public:
+  explicit PagmoUDP();
+  PagmoUDP(PagmoUDP &&) noexcept;
+  PagmoUDP &operator=(PagmoUDP &&) noexcept;
+  PagmoUDP &operator=(const PagmoUDP &other);
+  PagmoUDP(const PagmoUDP &other);
+  ~PagmoUDP();
+  void init(const std::string &xml, const OptimizeOptions &options);
+  [[nodiscard]] pagmo::vector_double
+  fitness(const pagmo::vector_double &dv) const;
+  [[nodiscard]] std::pair<pagmo::vector_double, pagmo::vector_double>
+  get_bounds() const;
+};
+
+} // namespace sme::simulate

--- a/core/simulate/src/optimize_impl_t.cpp
+++ b/core/simulate/src/optimize_impl_t.cpp
@@ -1,0 +1,260 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "optimize_impl.hpp"
+#include "sme/model.hpp"
+#include "sme/optimize.hpp"
+#include "sme/utils.hpp"
+#include <algorithm>
+
+using namespace sme;
+using namespace sme::test;
+
+TEST_CASE("Optimize applyParameters: parameters",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::VerySimpleModel)};
+  // optimization parameter: param parameter
+  simulate::OptParam optParam{simulate::OptParamType::ModelParameter, "param",
+                              "", 0.66, 0.99};
+  REQUIRE(model.getParameters().getExpression("param").toDouble() ==
+          dbl_approx(1));
+  simulate::applyParameters({0.123}, {optParam}, &model);
+  REQUIRE(model.getParameters().getExpression("param").toDouble() ==
+          dbl_approx(0.123));
+  simulate::applyParameters({-99}, {optParam}, &model);
+  REQUIRE(model.getParameters().getExpression("param").toDouble() ==
+          dbl_approx(-99));
+}
+
+TEST_CASE("Optimize applyParameters: reaction parameters",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  // optimization parameter: k1 parameter of reaction r1
+  simulate::OptParam optParam{simulate::OptParamType::ReactionParameter, "k1",
+                              "r1", 0.05, 0.21};
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") ==
+          dbl_approx(0.1));
+  simulate::applyParameters({0.123}, {optParam}, &model);
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") ==
+          dbl_approx(0.123));
+  simulate::applyParameters({-99}, {optParam}, &model);
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") ==
+          dbl_approx(-99));
+}
+
+TEST_CASE("Optimize calculateCosts: zero or no target values",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  simulate::Simulation sim(model);
+  auto zeroTarget{model.getSpecies().getField("A")->getConcentration()};
+  // make explicit target of zero for all pixels
+  std::fill(zeroTarget.begin(), zeroTarget.end(), 0.0);
+
+  // cost: absolute difference of concentration of species A from zero
+  simulate::OptCost optCostConc{simulate::OptCostType::Concentration,
+                                simulate::OptCostDiffType::Absolute,
+                                1.0,
+                                0,
+                                0,
+                                {}};
+  // cost: absolute difference of dcdt of species A from zero
+  simulate::OptCost optCostDcdt{simulate::OptCostType::ConcentrationDcdt,
+                                simulate::OptCostDiffType::Absolute,
+                                1.0,
+                                0,
+                                0,
+                                {}};
+
+  // costs are zero if no OptCost supplied:
+  REQUIRE(simulate::calculateCosts({}, sim) == dbl_approx(0.0));
+
+  // sum over initial concentration of A to get costConc vs 0
+  auto conc{model.getSpecies().getField("A")->getConcentration()};
+  double cost{common::sum(conc)};
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim) == dbl_approx(cost));
+  // repeat with explicit vector of zeros as target
+  optCostConc.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim) == dbl_approx(cost));
+  optCostConc.targetValues.clear();
+  // initial dcdt without simulating is zero
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim) == 0.0);
+  // repeat with explicit vector of zeros as target
+  optCostDcdt.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim) == 0.0);
+  optCostDcdt.targetValues.clear();
+  sim.doTimesteps(1.0);
+  // after simulation non-zero
+  auto c{simulate::calculateCosts({optCostDcdt}, sim)};
+  REQUIRE(c > 0.0);
+  // check equal to explicit zeros target value
+  optCostDcdt.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim) == dbl_approx(c));
+  optCostDcdt.targetValues.clear();
+
+  // if concentration A is set to constant, conc cost is just npixels * that
+  // value
+  model.getSimulationData().clear();
+  model.getSpecies().setInitialConcentration("A", 0.73);
+  model.getSpecies().setInitialConcentration("B", 1.24);
+  simulate::Simulation sim2(model);
+  auto c1{static_cast<double>(conc.size()) * 0.73};
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim2) ==
+          dbl_approx(c1).epsilon(1e-13));
+  // repeat with explicit vector of zeros as target
+  optCostConc.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim2) ==
+          dbl_approx(c1).epsilon(1e-13));
+  optCostConc.targetValues.clear();
+  // if concentration B is also constant, then initial dA/dt is approx -A B k1
+  sim2.doTimesteps(1e-8);
+  auto c2{static_cast<double>(conc.size()) * 0.73 * 1.24 * 0.1};
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim2) ==
+          dbl_approx(c2).epsilon(1e-8));
+  // repeat with explicit vector of zeros as target
+  optCostDcdt.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim2) ==
+          dbl_approx(c2).epsilon(1e-8));
+  optCostDcdt.targetValues.clear();
+
+  // if concentration A is set to zero, conc cost & dcdt cost are zero
+  model.getSimulationData().clear();
+  model.getSpecies().setInitialConcentration("A", 0.0);
+  simulate::Simulation sim3(model);
+  sim3.doTimesteps(1.0);
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim3) == dbl_approx(0.0));
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim3) == dbl_approx(0.0));
+  // repeat with explicit vector of zeros as target
+  optCostConc.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostConc}, sim3) == dbl_approx(0.0));
+  optCostConc.targetValues.clear();
+  optCostDcdt.targetValues = zeroTarget;
+  REQUIRE(simulate::calculateCosts({optCostDcdt}, sim3) == dbl_approx(0.0));
+  optCostDcdt.targetValues.clear();
+}
+
+TEST_CASE("Optimize calculateCosts: target values",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  simulate::Simulation sim(model);
+  auto target{model.getSpecies().getField("A")->getConcentration()};
+  // make explicit target of 2 for all pixels
+  constexpr double targetPixel{2.0};
+  std::fill(target.begin(), target.end(), targetPixel);
+  double targetSum{static_cast<double>(target.size()) * targetPixel};
+  constexpr double epsilon{3.4e-11};
+
+  // cost: absolute difference of concentration of species A from zero
+  simulate::OptCost optCostConcAbs{simulate::OptCostType::Concentration,
+                                   simulate::OptCostDiffType::Absolute,
+                                   1.0,
+                                   0,
+                                   0,
+                                   target};
+  // cost: absolute difference of dcdt of species A from zero
+  simulate::OptCost optCostDcdtAbs{simulate::OptCostType::ConcentrationDcdt,
+                                   simulate::OptCostDiffType::Absolute,
+                                   1.0,
+                                   0,
+                                   0,
+                                   target};
+  // cost: relative difference of concentration of species A from zero
+  simulate::OptCost optCostConcRel{simulate::OptCostType::Concentration,
+                                   simulate::OptCostDiffType::Relative,
+                                   1.0,
+                                   0,
+                                   0,
+                                   target,
+                                   epsilon};
+  // cost: relative difference of dcdt of species A from zero
+  simulate::OptCost optCostDcdtRel{simulate::OptCostType::ConcentrationDcdt,
+                                   simulate::OptCostDiffType::Relative,
+                                   1.0,
+                                   0,
+                                   0,
+                                   target,
+                                   epsilon};
+
+  // sum over initial concentration of A to get costConc vs 2
+  auto conc{model.getSpecies().getField("A")->getConcentration()};
+  double cost{targetSum - common::sum(conc)};
+  REQUIRE(simulate::calculateCosts({optCostConcAbs}, sim) == dbl_approx(cost));
+  // relative difference just a rescaling since target is uniform:
+  // diff/(targetPixel+epsilon)
+  REQUIRE(simulate::calculateCosts({optCostConcRel}, sim) ==
+          dbl_approx(cost / (targetPixel + epsilon)).epsilon(1e-13));
+
+  // initial dcdt without simulating is zero, so cost = |0 - targetSum|
+  REQUIRE(simulate::calculateCosts({optCostDcdtAbs}, sim) ==
+          dbl_approx(targetSum));
+  REQUIRE(simulate::calculateCosts({optCostDcdtRel}, sim) ==
+          dbl_approx(targetSum / (targetPixel + epsilon)).epsilon(1e-13));
+  sim.doTimesteps(1.0);
+  // after simulation dcdt is negative for A, so cost increased
+  REQUIRE(simulate::calculateCosts({optCostDcdtAbs}, sim) > targetSum);
+  // absolute & relative still related by constant factor since relative uses
+  // target value in denominator which is the same everywhere
+  REQUIRE(simulate::calculateCosts({optCostDcdtRel}, sim) ==
+          dbl_approx(simulate::calculateCosts({optCostDcdtAbs}, sim) /
+                     (targetPixel + epsilon))
+              .epsilon(1e-13));
+
+  // if concentration A is set to target, conc cost is zero
+  model.getSimulationData().clear();
+  model.getSpecies().setInitialConcentration("A", targetPixel);
+  double concB{1.254};
+  model.getSpecies().setInitialConcentration("B", concB);
+  simulate::Simulation sim2(model);
+  REQUIRE(simulate::calculateCosts({optCostConcAbs}, sim2) == dbl_approx(0));
+  REQUIRE(simulate::calculateCosts({optCostConcRel}, sim2) == dbl_approx(0));
+  // if concentration B is also uniform, then initial dA/dt = - A B k1
+  sim2.doTimesteps(1e-8);
+  double dadt{-targetSum * concB * 0.1};
+  REQUIRE(simulate::calculateCosts({optCostDcdtAbs}, sim2) ==
+          dbl_approx(targetSum - dadt).epsilon(1e-8));
+  REQUIRE(
+      simulate::calculateCosts({optCostDcdtRel}, sim2) ==
+      dbl_approx((targetSum - dadt) / (targetPixel + epsilon)).epsilon(1e-8));
+
+  // if concentration A is set to zero, conc & dcdt are zero
+  model.getSimulationData().clear();
+  model.getSpecies().setInitialConcentration("A", 0.0);
+  simulate::Simulation sim3(model);
+  sim3.doTimesteps(1.0);
+  REQUIRE(simulate::calculateCosts({optCostConcAbs}, sim3) ==
+          dbl_approx(targetSum));
+  REQUIRE(simulate::calculateCosts({optCostDcdtAbs}, sim3) ==
+          dbl_approx(targetSum));
+  REQUIRE(simulate::calculateCosts({optCostConcRel}, sim3) ==
+          dbl_approx(targetSum / (targetPixel + epsilon)).epsilon(1e-13));
+  REQUIRE(simulate::calculateCosts({optCostDcdtRel}, sim3) ==
+          dbl_approx(targetSum / (targetPixel + epsilon)).epsilon(1e-13));
+}
+
+TEST_CASE("Optimize calculateCosts: invalid target values",
+          "[core/simulate/optimize][core/simulate][core][optimize][invalid]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  auto correctSize{model.getSpecies().getField("A")->getConcentration().size()};
+  simulate::Simulation sim(model);
+  simulate::OptCost optCostInvalid{simulate::OptCostType::Concentration,
+                                   simulate::OptCostDiffType::Absolute,
+                                   1.0,
+                                   0,
+                                   0,
+                                   {}};
+  // correct size
+  optCostInvalid.targetValues = std::vector<double>(correctSize, 1.5);
+  REQUIRE_NOTHROW(simulate::calculateCosts({optCostInvalid}, sim));
+  // too small
+  optCostInvalid.targetValues = {{1.0, 2.0}};
+  REQUIRE_THROWS(simulate::calculateCosts({optCostInvalid}, sim));
+  optCostInvalid.targetValues = std::vector<double>(correctSize - 1, 1.3);
+  REQUIRE_THROWS(simulate::calculateCosts({optCostInvalid}, sim));
+  // too large
+  optCostInvalid.targetValues = std::vector<double>(correctSize + 1, 1.5);
+  REQUIRE_THROWS(simulate::calculateCosts({optCostInvalid}, sim));
+}

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -1,0 +1,85 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "sme/model.hpp"
+#include "sme/optimize.hpp"
+
+using namespace sme;
+using namespace sme::test;
+
+TEST_CASE("Optimize ABtoC model for zero concentration of A",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  sme::simulate::OptimizeOptions optimizeOptions;
+  optimizeOptions.nParticles = 3;
+  // optimization parameter: k1 parameter of reaction r1
+  optimizeOptions.optParams.push_back(
+      {sme::simulate::OptParamType::ReactionParameter, "k1", "r1", 0.05, 0.21});
+  // optimization cost: absolute difference of concentration of species A from
+  // zero
+  optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Concentration,
+                                      simulate::OptCostDiffType::Absolute,
+                                      1.0,
+                                      0,
+                                      0,
+                                      {}});
+  // simulation time: 10
+  optimizeOptions.simulationTime = 10.0;
+  sme::simulate::Optimization optimization(model, optimizeOptions);
+  double cost{optimization.fitness()[0]};
+  double k1{optimization.params()[0]};
+  for (std::size_t i = 1; i < 3; ++i) {
+    optimization.evolve();
+    REQUIRE(optimization.iterations() == i);
+    // cost should decrease or stay the same with each iteration
+    REQUIRE(optimization.fitness()[0] <= cost);
+    // k1 should increase to minimize concentration of A
+    REQUIRE(optimization.params()[0] >= k1);
+    cost = optimization.fitness()[0];
+    k1 = optimization.params()[0];
+  }
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") ==
+          dbl_approx(0.1));
+  optimization.applyParametersToModel(&model);
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") == dbl_approx(k1));
+}
+
+TEST_CASE("Optimize ABtoC model for zero concentration of C",
+          "[Q][core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  sme::simulate::OptimizeOptions optimizeOptions;
+  optimizeOptions.nParticles = 3;
+  // optimization parameter: k1 parameter of reaction r1
+  optimizeOptions.optParams.push_back(
+      {sme::simulate::OptParamType::ReactionParameter, "k1", "r1", 0.02, 0.88});
+  // optimization cost: absolute difference of concentration of species C from
+  // zero
+  optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Concentration,
+                                      simulate::OptCostDiffType::Absolute,
+                                      0.23,
+                                      0,
+                                      2,
+                                      {}});
+  // simulation time: 1
+  optimizeOptions.simulationTime = 1.0;
+  sme::simulate::Optimization optimization(model, optimizeOptions);
+  double cost{optimization.fitness()[0]};
+  double k1{optimization.params()[0]};
+  for (std::size_t i = 1; i < 3; ++i) {
+    optimization.evolve();
+    REQUIRE(optimization.iterations() == i);
+    // cost should decrease or stay the same with each iteration
+    REQUIRE(optimization.fitness()[0] <= cost);
+    // k1 should decrease to minimize concentration of C
+    REQUIRE(optimization.params()[0] <= k1);
+    cost = optimization.fitness()[0];
+    k1 = optimization.params()[0];
+  }
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") ==
+          dbl_approx(0.1));
+  optimization.applyParametersToModel(&model);
+  REQUIRE(model.getReactions().getParameterValue("r1", "k1") == dbl_approx(k1));
+}

--- a/docs/developer/simulate/inc.rst
+++ b/docs/developer/simulate/inc.rst
@@ -23,8 +23,8 @@ SimulationData
 
 .. doxygenstruct:: sme::simulate::AvgMinMax
 
-Options
--------
+SimulationOptions
+-----------------
 
 .. doxygenstruct:: sme::simulate::Options
 
@@ -39,3 +39,23 @@ Options
 .. doxygenstruct:: sme::simulate::DuneOptions
 
 .. doxygenenum:: sme::simulate::DuneDiscretizationType
+
+Optimization
+------------
+
+.. doxygenclass:: sme::simulate::Optimization
+
+OptimizationOptions
+-------------------
+
+.. doxygenstruct:: sme::simulate::OptimizeOptions
+
+.. doxygenstruct:: sme::simulate::OptParam
+
+.. doxygenenum:: sme::simulate::OptParamType
+
+.. doxygenstruct:: sme::simulate::OptCost
+
+.. doxygenenum:: sme::simulate::OptCostType
+
+.. doxygenenum:: sme::simulate::OptCostDiffType

--- a/docs/developer/simulate/src.rst
+++ b/docs/developer/simulate/src.rst
@@ -40,3 +40,8 @@ PixelSim
 --------
 
 .. doxygenclass:: sme::simulate::PixelSim
+
+PagmoUDP
+--------
+
+.. doxygenclass:: sme::simulate::PagmoUDP

--- a/gui/dialogs/dialogabout.cpp
+++ b/gui/dialogs/dialogabout.cpp
@@ -13,6 +13,7 @@
 #include <muParserDef.h>
 #include <oneapi/tbb/version.h>
 #include <opencv2/opencv.hpp>
+#include <pagmo/config.hpp>
 #include <qcustomplot.h>
 #include <sbml/common/libsbml-version.h>
 #include <spdlog/version.h>
@@ -99,6 +100,9 @@ DialogAbout::DialogAbout(QWidget *parent)
                        CEREAL_VERSION_PATCH));
   libraries.append(dep("zlib", "https://zlib.net/", ZLIB_VER_MAJOR,
                        ZLIB_VER_MINOR, ZLIB_VER_REVISION));
+  libraries.append(dep("pagmo", "https://esa.github.io/pagmo2",
+                       PAGMO_VERSION_MAJOR, PAGMO_VERSION_MINOR,
+                       PAGMO_VERSION_PATCH));
   libraries.append("</ul>");
   ui->lblLibraries->setText(libraries);
 }


### PR DESCRIPTION
- add `OptimizeOptions` struct which contains
  - PSO parameters
    - number of particles
  - Simulation parameters
    - simulation time
  - Model parameters to fit with lower/upper bounds
    - Parameter
    - ReactionParameter
  - Cost functions to minimize
    - Concentration
    - ConcentrationDcdt
- add `Optimize` class
  - takes a Model and OptimizeOptions
  - evolve() does an iteration of PSO
  - params() returns current best set of fitted model parameters
  - fitness() returns the fitness / cost function for the best set of parameters
- add `UDP` class
  - implements a Pagmo User Defined Problem
    - fitness()
      - given supplied parameters, set them in the model, do simulation, calculate and return fitness
    - bounds()
      - returns lower/upper bounds for each parameter
  - currently thread-safe but inefficient
    - Pagmo requires copy constructor of UDP, in particular multithreading makes a lot of copies
    - This involves making a copy of the Model which can be expensive
- add Pagmo as a hard dependency
- update deps to improve thread safety of libsbml & symengine
  - manylinux -> 2022.02.28
  - sme_deps -> 2022.02.28