### PR TITLE
multi-threading improvements

### DIFF
--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -22,11 +22,9 @@ void PixelSim::calculateDcdt() {
   // calculate dcd/dt in all compartments
   for (auto &sim : simCompartments) {
     if (useTBB) {
-      sim->evaluateReactions_tbb();
-      sim->evaluateDiffusionOperator_tbb();
+      sim->evaluateReactionsAndDiffusion_tbb();
     } else {
-      sim->evaluateReactions();
-      sim->evaluateDiffusionOperator();
+      sim->evaluateReactionsAndDiffusion();
     }
   }
   // membrane contribution to dc/dt

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -90,12 +90,10 @@ public:
 
   // dcdt = result of applying diffusion operator to conc
   void evaluateDiffusionOperator(std::size_t begin, std::size_t end);
-  void evaluateDiffusionOperator();
-  void evaluateDiffusionOperator_tbb();
   // dcdt += result of applying reaction expressions to conc
   void evaluateReactions(std::size_t begin, std::size_t end);
-  void evaluateReactions();
-  void evaluateReactions_tbb();
+  void evaluateReactionsAndDiffusion();
+  void evaluateReactionsAndDiffusion_tbb();
   void spatiallyAverageDcdt();
   void doForwardsEulerTimestep(double dt, std::size_t begin, std::size_t end);
   void doForwardsEulerTimestep(double dt);


### PR DESCRIPTION
- use tbb static_partitioner
  - our loops are homogeneous, so this gives less overhead & better cache persistence
- increase tbb grain size from default 1 to 64
  - 1 is too fine-grained given our typically cheap loop iterations
- combine compartment diffusion & reactions calculations to reduce threading overhead
  - single parallel_for: less threading overhead, more cache persistence
- add test that changing number of threads for pixel simulation doesn't change simulation results to within approx machine precision
- resolves #742
