### PR TITLE
fix spurious simulation times being added to model simulation settings upon simulation

### DIFF
--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -241,15 +241,21 @@ std::size_t Simulation::doMultipleTimesteps(
     updateConcentrations(0);
     ++nCompletedTimesteps;
   }
+  if (data->timePoints.size() == 1) {
+    SPDLOG_DEBUG("No existing simulation data: removing any existing times "
+                 "from model simulation settings");
+    settings->times.clear();
+  }
+  for (const auto &timestep : timesteps) {
+    settings->times.push_back(timestep);
+  }
   std::size_t nStepsTotal{0};
   for (const auto &timestep : timesteps) {
     nStepsTotal += timestep.first;
   }
   QElapsedTimer timer;
   timer.start();
-  for (const auto &timestep : timesteps) {
-    settings->times.push_back(timestep);
-  }
+
   // ensure there is enough space that push_back won't cause a reallocation
   // todo: there should be a mutex/lock here in case reserve() reallocates
   // to avoid a user getting garbage data while the vector contents are moving


### PR DESCRIPTION
- when starting a simulation timestep
  - if model has no existing simulation results
    - clear any existing simulation times in model settings
- clicking reset & simulate in the GUI now re-creates the same simulation results in all cases
- resolves #745
