### PR TITLE
add bzip2 libsbml support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,8 +27,8 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.04.27
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.04.27
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.04.29
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2014_x86_64:2022.04.29
       CIBW_SKIP: '*-manylinux_i686 *-musllinux* pp39-manylinux_x86_64'
       CIBW_ENVIRONMENT: 'SME_BUILD_CORE=off'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [latest]
+### Added
+- support for reading SBML files compressed with bzip2 [#246](https://github.com/spatial-model-editor/spatial-model-editor/issues/246)
+
 ## [1.2.2] - 2022-04-28
 ### Added
 - support for reading compressed sampledFields [#709](https://github.com/spatial-model-editor/spatial-model-editor/issues/709)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Spatial Model Editor makes use of the following open source libraries:
 
 - [zlib](https://zlib.net/) - license: [zlib](https://zlib.net/zlib_license.html)
 
+- [bzip2](https://www.sourceware.org/bzip2/) - license: [BSD-style](https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;h=81a37eab7a5be1a34456f38adb74928cc9073e9b;hb=6a8690fc8d26c815e798c588f796eabe9d684cf0)
+
 - [pagmo](https://esa.github.io/pagmo2/index.html) - license: [GPL](https://github.com/esa/pagmo2/blob/master/COPYING.gpl3)
 
 ## Licensing Note

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2022.04.27"
+SME_DEPS_VERSION="2022.04.29"
 OS=$1
 
 set -e -x

--- a/gui/dialogs/dialogabout.cpp
+++ b/gui/dialogs/dialogabout.cpp
@@ -4,6 +4,7 @@
 #include "ui_dialogabout.h"
 #include <CGAL/version_macros.h>
 #include <boost/version.hpp>
+#include <bzlib.h>
 #include <cereal/version.hpp>
 #include <dune/copasi/config.h>
 #include <expat.h>
@@ -100,9 +101,8 @@ DialogAbout::DialogAbout(QWidget *parent)
                        CEREAL_VERSION_PATCH));
   libraries.append(dep("zlib", "https://zlib.net/", ZLIB_VER_MAJOR,
                        ZLIB_VER_MINOR, ZLIB_VER_REVISION));
-  libraries.append(dep("pagmo", "https://esa.github.io/pagmo2",
-                       PAGMO_VERSION_MAJOR, PAGMO_VERSION_MINOR,
-                       PAGMO_VERSION_PATCH));
+  libraries.append(dep("bzip2", "https://www.sourceware.org/bzip2",
+                       BZ_API(BZ2_bzlibVersion)()));
   libraries.append("</ul>");
   ui->lblLibraries->setText(libraries);
 }


### PR DESCRIPTION
- sme_deps/manylinux -> 2022.04.29
  - includes bzip2 & libsbml compiled with bzip2 enabled
- update deps in README & GUI About dialog
- resolves #246 