### PR TITLE
update species analytic concentrations when parameters are modified

### DIFF
--- a/core/model/include/sme/model_parameters.hpp
+++ b/core/model/include/sme/model_parameters.hpp
@@ -16,6 +16,7 @@ class Species;
 namespace sme::model {
 
 class ModelEvents;
+class ModelSpecies;
 
 struct IdName {
   std::string id;
@@ -48,11 +49,13 @@ private:
   libsbml::Model *sbmlModel{nullptr};
   bool hasUnsavedChanges{false};
   ModelEvents *modelEvents{nullptr};
+  ModelSpecies *modelSpecies{nullptr};
 
 public:
   ModelParameters();
   explicit ModelParameters(libsbml::Model *model);
   void setEventsPtr(ModelEvents *events);
+  void setSpeciesPtr(ModelSpecies *species);
   [[nodiscard]] const QStringList &getIds() const;
   [[nodiscard]] const QStringList &getNames() const;
   QString setName(const QString &id, const QString &name);

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -74,6 +74,7 @@ public:
       geometry::Field &field, const std::string &expr,
       const std::map<std::string, double, std::less<>> &substitutions = {});
   [[nodiscard]] QString getAnalyticConcentration(const QString &id) const;
+  void updateAllAnalyticConcentrations();
   void
   setSampledFieldConcentration(const QString &id,
                                const std::vector<double> &concentrationArray);

--- a/core/model/src/model.cpp
+++ b/core/model/src/model.cpp
@@ -86,6 +86,7 @@ void Model::initModelData(bool emptySpatialModel) {
   modelEvents = std::make_unique<ModelEvents>(model, modelParameters.get(),
                                               modelSpecies.get());
   modelParameters->setEventsPtr(modelEvents.get());
+  modelParameters->setSpeciesPtr(modelSpecies.get());
   modelReactions = std::make_unique<ModelReactions>(
       model, modelCompartments.get(), modelMembranes.get(), isNonSpatialModel);
   modelCompartments->setReactionsPtr(modelReactions.get());

--- a/core/model/src/model_parameters.cpp
+++ b/core/model/src/model_parameters.cpp
@@ -4,6 +4,7 @@
 #include "sbml_utils.hpp"
 #include "sme/logger.hpp"
 #include "sme/model_events.hpp"
+#include "sme/model_species.hpp"
 #include <QString>
 #include <memory>
 #include <sbml/SBMLTypes.h>
@@ -145,6 +146,10 @@ void ModelParameters::setEventsPtr(ModelEvents *events) {
   modelEvents = events;
 }
 
+void ModelParameters::setSpeciesPtr(ModelSpecies *species) {
+  modelSpecies = species;
+}
+
 const QStringList &ModelParameters::getIds() const { return ids; }
 
 const QStringList &ModelParameters::getNames() const { return names; }
@@ -224,6 +229,10 @@ void ModelParameters::setExpression(const QString &id, const QString &expr) {
     asgn->setMath(astNode.get());
     SPDLOG_INFO("  -> assignment rule expression '{}'",
                 mathASTtoString(astNode.get()));
+  }
+  // in case the modified parameter was used in a species initial concentration:
+  if (modelSpecies != nullptr) {
+    modelSpecies->updateAllAnalyticConcentrations();
   }
 }
 

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -129,7 +129,7 @@ ModelSpecies::getSampledFieldConcentrationFromSBML(const QString &id) const {
     const auto *geom = getOrCreateGeometry(sbmlModel);
     const auto *sf = geom->getSampledField(sampledFieldID);
     // use string instead of vector of doubles overload to avoid libsbml issue
-    // with stringtreams & subnormal doubles on macos:
+    // with stringstreams & subnormal doubles on macos:
     // https://github.com/spatial-model-editor/spatial-model-editor/issues/465
     std::stringstream ss{sf->getSamples()};
     double val;
@@ -587,6 +587,18 @@ void ModelSpecies::setFieldConcAnalytic(
     field.setConcentration(i, conc);
   }
   field.setIsUniformConcentration(false);
+}
+
+void ModelSpecies::updateAllAnalyticConcentrations() {
+  for (auto &field : fields) {
+    const auto analyticConcentration{
+        getAnalyticConcentration(field.getId().c_str()).toStdString()};
+    if (!analyticConcentration.empty()) {
+      SPDLOG_INFO("Updating species '{}' initial conc '{}'", field.getId(),
+                  analyticConcentration);
+      setFieldConcAnalytic(field, analyticConcentration);
+    }
+  }
 }
 
 QString ModelSpecies::getAnalyticConcentration(const QString &id) const {


### PR DESCRIPTION
- add `ModelSpecies::updateAllAnalyticConcentrations()`
  - re-evaluates all analytic initial concentrations
- add `ModelSpecies` pointer to `ModelParameters`
- `ModelParameters::setExpression` now calls `ModelSpecies::updateAllAnalyticConcentrations()` at the end
  - this is necessary if a species initial concentration expression depends on the modified parameter
  - due to the difficulty of keeping track of dependencies, we simply update all analytic concentrations when a parameter is modified
- resolves #776
