### PR TITLE
add image of target values to DialogOptCost

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,5 +7,6 @@ coverage:
       default:
         target: 80
 ignore:
-  - "**/*_t.cpp"  # tests code
-  - "**/ext/**/*" # external library code
+  - "**/*_t.cpp" # tests
+  - "**/test/**/*"  # tests
+  - "**/ext/**/*" # external libraries

--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <QColor>
+#include <QImage>
 #include <QPoint>
 #include <QRgb>
 #include <QSize>
@@ -105,6 +106,12 @@ std::size_t element_index(const Container &c, const Element &e,
   }
   return static_cast<std::size_t>(std::distance(cbegin(c), iter));
 }
+
+/**
+ * @brief Grayscale image from array of pixel intensities
+ */
+QImage toGrayscaleIntensityImage(const QSize &imageSize,
+                                 const std::vector<double> &values);
 
 /**
  * @brief The type of an object as a string

--- a/core/common/src/utils.cpp
+++ b/core/common/src/utils.cpp
@@ -5,6 +5,29 @@
 
 namespace sme::common {
 
+QImage toGrayscaleIntensityImage(const QSize &imageSize,
+                                 const std::vector<double> &values) {
+  QImage img(imageSize, QImage::Format_RGB32);
+  if (values.size() != img.width() * img.height()) {
+    img.fill(0);
+  } else {
+    double scaleFactor{0.0};
+    double maxValue{max(values)};
+    if (maxValue > 0.0) {
+      scaleFactor = 255.0 / maxValue;
+    }
+    auto value{values.cbegin()};
+    for (int y = img.height() - 1; y >= 0; --y) {
+      for (int x = 0; x < img.width(); ++x) {
+        auto intensity{static_cast<int>(scaleFactor * (*value))};
+        img.setPixel(x, y, qRgb(intensity, intensity, intensity));
+        ++value;
+      }
+    }
+  }
+  return img;
+}
+
 std::vector<std::string> toStdString(const QStringList &q) {
   std::vector<std::string> v;
   v.reserve(static_cast<std::size_t>(q.size()));

--- a/core/common/src/utils_t.cpp
+++ b/core/common/src/utils_t.cpp
@@ -181,4 +181,49 @@ TEST_CASE("Utils", "[core/common/utils][core/common][core][utils]") {
     REQUIRE(qpi.getIndex(v[0]).value() == 0);
     REQUIRE(qpi.getPoints().size() == v.size());
   }
+  SECTION("toGrayscaleIntensityImage") {
+    SECTION("all values identical and non-zero should be white") {
+      QSize sz1(2, 2);
+      auto img1{common::toGrayscaleIntensityImage(
+          sz1, std::vector<double>{1.2, 1.2, 1.2, 1.2})};
+      REQUIRE(img1.size() == sz1);
+      REQUIRE(img1.pixel(0, 0) == qRgb(255, 255, 255));
+      REQUIRE(img1.pixel(0, 1) == qRgb(255, 255, 255));
+      REQUIRE(img1.pixel(1, 0) == qRgb(255, 255, 255));
+      REQUIRE(img1.pixel(1, 1) == qRgb(255, 255, 255));
+    }
+    SECTION("all values zero should be black") {
+      QSize sz1(2, 2);
+      auto img1{common::toGrayscaleIntensityImage(
+          sz1, std::vector<double>{0, 0, 0, 0})};
+      REQUIRE(img1.size() == sz1);
+      REQUIRE(img1.pixel(0, 0) == qRgb(0, 0, 0));
+      REQUIRE(img1.pixel(0, 1) == qRgb(0, 0, 0));
+      REQUIRE(img1.pixel(1, 0) == qRgb(0, 0, 0));
+      REQUIRE(img1.pixel(1, 1) == qRgb(0, 0, 0));
+    }
+    SECTION("pixels start bottom-left, scan along x, end at top right") {
+      QSize sz1(2, 2);
+      auto img1{common::toGrayscaleIntensityImage(
+          sz1, std::vector<double>{1.0, 2.0, 3.0, 4.0})};
+      REQUIRE(img1.size() == sz1);
+      REQUIRE(img1.pixel(0, 1) == qRgb(63, 63, 63));
+      REQUIRE(img1.pixel(1, 1) == qRgb(127, 127, 127));
+      REQUIRE(img1.pixel(0, 0) == qRgb(191, 191, 191));
+      REQUIRE(img1.pixel(1, 0) == qRgb(255, 255, 255));
+    }
+    SECTION("invalid array size produces black image") {
+      QSize sz1(11, 13);
+      // array too small
+      auto img1{common::toGrayscaleIntensityImage(sz1, std::vector<double>{})};
+      REQUIRE(img1.size() == sz1);
+      REQUIRE(img1.pixel(0, 0) == qRgb(0, 0, 0));
+      QSize sz2(1, 1);
+      // array too large
+      auto img2{common::toGrayscaleIntensityImage(
+          sz2, std::vector<double>{1.0, 2.0})};
+      REQUIRE(img2.size() == sz2);
+      REQUIRE(img2.pixel(0, 0) == qRgb(0, 0, 0));
+    }
+  }
 }

--- a/gui/dialogs/dialogconcentrationimage.ui
+++ b/gui/dialogs/dialogconcentrationimage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>740</width>
-    <height>544</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -79,6 +79,7 @@ DialogOptCost::DialogOptCost(
     ui->txtEpsilon->setText(QString::number(optCost.epsilon));
     ui->txtEpsilon->setEnabled(optCost.optCostDiffType ==
                                sme::simulate::OptCostDiffType::Relative);
+    updateImage();
     for (const auto &defaultOptCost : defaultOptCosts) {
       ui->cmbSpecies->addItem(defaultOptCost.name.c_str());
       if (defaultOptCost.name == optCost.name) {
@@ -124,6 +125,7 @@ void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
     ui->txtEpsilon->setText(QString::number(optCost.epsilon));
     ui->txtEpsilon->setEnabled(optCost.optCostDiffType ==
                                sme::simulate::OptCostDiffType::Relative);
+    updateImage();
   }
 }
 
@@ -151,6 +153,7 @@ void DialogOptCost::btnEditTargetValues_clicked() {
       optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt);
   if (dialog.exec() == QDialog::Accepted) {
     optCost.targetValues = dialog.getConcentrationArray();
+    updateImage();
   }
 }
 
@@ -162,4 +165,11 @@ void DialogOptCost::txtWeight_editingFinished() {
 void DialogOptCost::txtEpsilon_editingFinished() {
   optCost.epsilon = ui->txtEpsilon->text().toDouble();
   ui->txtEpsilon->setText(toQStr(optCost.epsilon));
+}
+
+void DialogOptCost::updateImage() {
+  const auto &imageSize{
+      model.getSpeciesGeometry(optCost.id.c_str()).compartmentImageSize};
+  ui->lblImage->setImage(
+      sme::common::toGrayscaleIntensityImage(imageSize, optCost.targetValues));
 }

--- a/gui/dialogs/dialogoptcost.hpp
+++ b/gui/dialogs/dialogoptcost.hpp
@@ -33,4 +33,5 @@ private:
   void btnEditTargetValues_clicked();
   void txtWeight_editingFinished();
   void txtEpsilon_editingFinished();
+  void updateImage();
 };

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>517</width>
-    <height>364</height>
+    <width>606</width>
+    <height>652</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,67 +28,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="3">
-      <widget class="QComboBox" name="cmbSpecies">
-       <property name="currentIndex">
-        <number>-1</number>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="3">
-      <widget class="QPushButton" name="btnEditTargetValues">
-       <property name="text">
-        <string>Edit Target Values</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
-      <widget class="QLineEdit" name="txtWeight"/>
-     </item>
-     <item row="2" column="3">
-      <widget class="QComboBox" name="cmbDiffType">
-       <item>
-        <property name="text">
-         <string>Absolute</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Relative</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="QLineEdit" name="txtSimulationTime"/>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="lblSimulationTimeLabel">
-       <property name="text">
-        <string>Simulation time:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="lblScaleFactorLabel">
-       <property name="text">
-        <string>Weight:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="lblDiffTypeLabel">
-       <property name="text">
-        <string>Difference type:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="lblSpeciesLabel">
        <property name="text">
@@ -99,7 +38,24 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cmbSpecies">
+       <property name="currentIndex">
+        <number>-1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblCostTypeLabel">
+       <property name="text">
+        <string>Target type:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QComboBox" name="cmbCostType">
        <item>
         <property name="text">
@@ -113,27 +69,78 @@
        </item>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblCostTypeLabel">
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblSimulationTimeLabel">
        <property name="text">
-        <string>Target type:</string>
+        <string>Simulation time:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="txtSimulationTime"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabelMouseTracker" name="lblImage" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+       </property>
+       <property name="text" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QPushButton" name="btnEditTargetValues">
+       <property name="text">
+        <string>Edit Target Values</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="lblDiffTypeLabel">
+       <property name="text">
+        <string>Difference type:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="lblLowerBoundLabel">
-       <property name="text">
-        <string>Target values:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="cmbDiffType">
+       <item>
+        <property name="text">
+         <string>Absolute</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Relative</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="6" column="0">
+      <widget class="QLabel" name="lblWeightLabel">
+       <property name="text">
+        <string>Weight:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="txtWeight"/>
+     </item>
+     <item row="7" column="0">
       <widget class="QLabel" name="lblEpsilonLabel">
        <property name="text">
         <string>Epsilon:</string>
@@ -143,8 +150,18 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
+     <item row="7" column="1">
       <widget class="QLineEdit" name="txtEpsilon"/>
+     </item>
+     <item row="3" column="0" rowspan="2">
+      <widget class="QLabel" name="lblTargetValuesLabel">
+       <property name="text">
+        <string>Target values:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -160,12 +177,19 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QLabelMouseTracker</class>
+   <extends>QWidget</extends>
+   <header>qlabelmousetracker.hpp</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbSpecies</tabstop>
   <tabstop>cmbCostType</tabstop>
-  <tabstop>cmbDiffType</tabstop>
   <tabstop>txtSimulationTime</tabstop>
   <tabstop>btnEditTargetValues</tabstop>
+  <tabstop>cmbDiffType</tabstop>
   <tabstop>txtWeight</tabstop>
   <tabstop>txtEpsilon</tabstop>
  </tabstops>

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -85,7 +85,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
     REQUIRE(txtEpsilon->isEnabled());
-    mwt.addUserAction({"Tab", "Down", "Tab", "Up"});
+    mwt.addUserAction({"Tab", "Down", "Tab", "Tab", "Tab", "Up"});
     mwt.start();
     dia.exec();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
@@ -142,7 +142,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "6", "2", ".", "8"});
+    mwt.addUserAction({"Tab", "Tab", "6", "2", ".", "8"});
     mwt.start();
     dia.exec();
     REQUIRE(dia.getOptCost().name == "cell/Mt");

--- a/gui/dialogs/dialogoptsetup.cpp
+++ b/gui/dialogs/dialogoptsetup.cpp
@@ -136,6 +136,8 @@ DialogOptSetup::DialogOptSetup(const sme::model::Model &model, QWidget *parent)
   }
   connect(ui->lstTargets, &QListWidget::currentRowChanged, this,
           &DialogOptSetup::lstTargets_currentRowChanged);
+  connect(ui->lstTargets, &QListWidget::itemDoubleClicked, this,
+          &DialogOptSetup::lstTargets_itemDoubleClicked);
   connect(ui->btnAddTarget, &QPushButton::clicked, this,
           &DialogOptSetup::btnAddTarget_clicked);
   connect(ui->btnEditTarget, &QPushButton::clicked, this,
@@ -144,6 +146,8 @@ DialogOptSetup::DialogOptSetup(const sme::model::Model &model, QWidget *parent)
           &DialogOptSetup::btnRemoveTarget_clicked);
   connect(ui->lstParameters, &QListWidget::currentRowChanged, this,
           &DialogOptSetup::lstParameters_currentRowChanged);
+  connect(ui->lstParameters, &QListWidget::itemDoubleClicked, this,
+          &DialogOptSetup::lstParameters_itemDoubleClicked);
   connect(ui->btnAddParameter, &QPushButton::clicked, this,
           &DialogOptSetup::btnAddParameter_clicked);
   connect(ui->btnEditParameter, &QPushButton::clicked, this,
@@ -171,6 +175,12 @@ void DialogOptSetup::lstTargets_currentRowChanged(int row) {
   }
   ui->btnEditTarget->setEnabled(true);
   ui->btnRemoveTarget->setEnabled(true);
+}
+
+void DialogOptSetup::lstTargets_itemDoubleClicked(QListWidgetItem *item) {
+  if (item != nullptr) {
+    btnEditTarget_clicked();
+  }
 }
 
 void DialogOptSetup::btnAddTarget_clicked() {
@@ -218,6 +228,12 @@ void DialogOptSetup::lstParameters_currentRowChanged(int row) {
   }
   ui->btnEditParameter->setEnabled(true);
   ui->btnRemoveParameter->setEnabled(true);
+}
+
+void DialogOptSetup::lstParameters_itemDoubleClicked(QListWidgetItem *item) {
+  if (item != nullptr) {
+    btnEditParameter_clicked();
+  }
 }
 
 void DialogOptSetup::btnAddParameter_clicked() {

--- a/gui/dialogs/dialogoptsetup.hpp
+++ b/gui/dialogs/dialogoptsetup.hpp
@@ -2,6 +2,7 @@
 #include "sme/model.hpp"
 #include "sme/optimize_options.hpp"
 #include <QDialog>
+#include <QListWidgetItem>
 #include <memory>
 
 namespace Ui {
@@ -25,10 +26,12 @@ private:
   std::vector<sme::simulate::OptCost> defaultOptCosts;
   std::unique_ptr<Ui::DialogOptSetup> ui;
   void lstTargets_currentRowChanged(int row);
+  void lstTargets_itemDoubleClicked(QListWidgetItem *item);
   void btnAddTarget_clicked();
   void btnEditTarget_clicked();
   void btnRemoveTarget_clicked();
   void lstParameters_currentRowChanged(int row);
+  void lstParameters_itemDoubleClicked(QListWidgetItem *item);
   void btnAddParameter_clicked();
   void btnEditParameter_clicked();
   void btnRemoveParameter_clicked();

--- a/gui/widgets/qlabelmousetracker_t.cpp
+++ b/gui/widgets/qlabelmousetracker_t.cpp
@@ -4,8 +4,7 @@
 
 using namespace sme::test;
 
-static const char *tags{
-    "[gui/widgets/qlabelmousetracker][gui/widgets][gui][qlabelmousetracker"};
+static const char *tags{"[gui/widgets/qlabelmousetracker][gui/widgets][gui]"};
 
 TEST_CASE("QLabelMouseTracker: single pixel, single colour image", tags) {
   QLabelMouseTracker mouseTracker;

--- a/test/test_utils/qt_test_utils.cpp
+++ b/test/test_utils/qt_test_utils.cpp
@@ -123,6 +123,29 @@ void sendMouseClick(QWidget *widget, const QPoint &pos,
   QTest::mouseClick(widget, button, {}, pos, mouseDelay);
 }
 
+void sendMouseClick(QListWidgetItem *item, Qt::MouseButton button) {
+  // can't send mouseclick to list item as it is not a widget
+  auto widget{item->listWidget()->viewport()};
+  // find the position of the desired item within the list
+  auto pos{item->listWidget()->visualItemRect(item).center()};
+  QTest::mouseClick(widget, button, {}, pos, mouseDelay);
+}
+
+void sendMouseDoubleClick(QWidget *widget, const QPoint &pos,
+                          Qt::MouseButton button) {
+  // DClick seems to only work if widget is already selected
+  QTest::mouseClick(widget, button, {}, pos, mouseDelay);
+  QTest::mouseDClick(widget, button, {}, pos, mouseDelay);
+}
+
+void sendMouseDoubleClick(QListWidgetItem *item, Qt::MouseButton button) {
+  auto pos{item->listWidget()->visualItemRect(item).center()};
+  auto widget{item->listWidget()->viewport()};
+  // DClick seems to only work if widget is already selected
+  QTest::mouseClick(widget, button, {}, pos, mouseDelay);
+  QTest::mouseDClick(widget, button, {}, pos, mouseDelay);
+}
+
 void sendMouseDrag(QWidget *widget, const QPoint &start, const QPoint &end,
                    Qt::MouseButton button) {
   sendMousePress(widget, start, button);
@@ -218,6 +241,8 @@ void ModalWidgetTimer::start() {
   timer.start();
 }
 
-const QString &ModalWidgetTimer::getResult(int i) const { return results[i]; }
+const QString &ModalWidgetTimer::getResult(int i) const {
+  return results.at(i);
+}
 
 } // namespace sme::test

--- a/test/test_utils/qt_test_utils.hpp
+++ b/test/test_utils/qt_test_utils.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <QListWidgetItem>
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -13,9 +14,9 @@
 namespace sme::test {
 
 // delay in ms to insert between key events
-const int keyDelay = 0;
+constexpr int keyDelay{0};
 // delay in ms to insert between mouse events
-const int mouseDelay = 0;
+constexpr int mouseDelay{0};
 
 void wait(int milliseconds = 100);
 
@@ -42,6 +43,15 @@ void sendMouseRelease(QWidget *widget, const QPoint &pos = {},
 
 void sendMouseClick(QWidget *widget, const QPoint &pos = {},
                     Qt::MouseButton button = Qt::MouseButton::LeftButton);
+
+void sendMouseClick(QListWidgetItem *item,
+                    Qt::MouseButton button = Qt::MouseButton::LeftButton);
+
+void sendMouseDoubleClick(QWidget *widget, const QPoint &pos = {},
+                          Qt::MouseButton button = Qt::MouseButton::LeftButton);
+
+void sendMouseDoubleClick(QListWidgetItem *item,
+                          Qt::MouseButton button = Qt::MouseButton::LeftButton);
 
 void sendMouseDrag(QWidget *widget, const QPoint &startPos,
                    const QPoint &endPos,


### PR DESCRIPTION
- add image of current target values above "edit target values" button
- move difference type below this
- resolves #760
- add `toGrayscaleIntensityImage` to utils
  - converts an array of values to a grayscale image of pixel intensities

also

- double click on cost or param in DialogOptSetup now equivalent to selecting an item then clicking on edit button
