### PR TITLE
stop optimization simulations early when optimization is stopped

### DIFF
--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -87,7 +87,7 @@ public:
    */
   [[nodiscard]] bool getIsStopping() const;
   /**
-   * @brief Stop the evolution after the current iteration is complete
+   * @brief Stop the evolution as soon as possible
    */
   void requestStop();
 };

--- a/core/simulate/src/optimize_impl.hpp
+++ b/core/simulate/src/optimize_impl.hpp
@@ -25,17 +25,19 @@ double calculateCosts(const std::vector<OptCost> &optCosts,
 
 class PagmoUDP {
 private:
-  ThreadsafeModelQueue *modelQueue{nullptr};
   const std::string *xmlModel{nullptr};
   const OptimizeOptions *optimizeOptions{nullptr};
   const std::vector<OptTimestep> *optTimesteps{nullptr};
+  ThreadsafeModelQueue *modelQueue{nullptr};
+  const sme::simulate::Optimization *optimization{nullptr};
 
 public:
   PagmoUDP() = default;
   explicit PagmoUDP(const std::string *xmlModel,
                     const OptimizeOptions *optimizeOptions,
                     const std::vector<OptTimestep> *optTimesteps,
-                    ThreadsafeModelQueue *modelQueue);
+                    ThreadsafeModelQueue *modelQueue,
+                    const Optimization *optimization);
   [[nodiscard]] pagmo::vector_double
   fitness(const pagmo::vector_double &dv) const;
   [[nodiscard]] std::pair<pagmo::vector_double, pagmo::vector_double>

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -1,5 +1,6 @@
 #include "catch_wrapper.hpp"
 #include "model_test_utils.hpp"
+#include "qt_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/optimize.hpp"
 
@@ -15,8 +16,49 @@ static bool is_sorted_descending(const std::vector<T> &v) {
   return std::is_sorted(v.begin(), v.end(), [](T a, T b) { return a > b; });
 }
 
-TEST_CASE("Optimize ABtoC model for zero concentration of A",
+TEST_CASE("Optimize ABtoC with all algorithms for zero concentration of A",
           "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  sme::simulate::OptimizeOptions optimizeOptions;
+  optimizeOptions.optAlgorithm.islands = 1;
+  optimizeOptions.optAlgorithm.population = 2;
+  // optimization parameter: k1 parameter of reaction r1
+  optimizeOptions.optParams.push_back(
+      {sme::simulate::OptParamType::ReactionParameter, "name", "k1", "r1", 0.05,
+       0.21});
+  // optimization cost: absolute difference of concentration of species A from
+  // zero, after simulating for time 1
+  optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Concentration,
+                                      simulate::OptCostDiffType::Absolute,
+                                      "name",
+                                      "A",
+                                      1.0,
+                                      1.0,
+                                      0,
+                                      0,
+                                      {}});
+  for (auto optAlgorithmType : sme::simulate::optAlgorithmTypes) {
+    CAPTURE(optAlgorithmType);
+    optimizeOptions.optAlgorithm.optAlgorithmType = optAlgorithmType;
+
+    model.getOptimizeOptions() = optimizeOptions;
+    model.getReactions().setParameterValue("r1", "k1", 0.1);
+    sme::simulate::Optimization optimization(model);
+    optimization.evolve();
+    REQUIRE(optimization.getIterations() == 1);
+    // cost should decrease or stay the same with each iteration
+    REQUIRE(is_sorted_descending(optimization.getFitness()));
+    // k1 should increase to minimize concentration of A
+    REQUIRE(is_sorted_ascending(optimization.getParams()));
+  }
+}
+
+TEST_CASE(
+    "Optimize ABtoC with all algorithms, multiple evolve calls, for zero "
+    "concentration of A",
+    "[core/simulate/optimize][core/simulate][core][optimize][expensive]") {
   auto model{getExampleModel(Mod::ABtoC)};
   model.getSimulationSettings().simulatorType =
       sme::simulate::SimulatorType::Pixel;
@@ -45,7 +87,7 @@ TEST_CASE("Optimize ABtoC model for zero concentration of A",
     model.getOptimizeOptions() = optimizeOptions;
     model.getReactions().setParameterValue("r1", "k1", 0.1);
     sme::simulate::Optimization optimization(model);
-    for (std::size_t i = 1; i < 4; ++i) {
+    for (std::size_t i = 1; i < 5; ++i) {
       optimization.evolve();
       REQUIRE(optimization.getIterations() == i);
       // cost should decrease or stay the same with each iteration
@@ -158,4 +200,49 @@ TEST_CASE("Save and load model with optimization settings",
   REQUIRE(optimizeOptions.optParams[0].parentId == "r1");
   REQUIRE(optimizeOptions.optParams[0].lowerBound == dbl_approx(0.02));
   REQUIRE(optimizeOptions.optParams[0].upperBound == dbl_approx(0.88));
+}
+
+TEST_CASE("Start long optimization in another thread & stop early",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  sme::simulate::OptimizeOptions optimizeOptions;
+  optimizeOptions.optAlgorithm.islands = 2;
+  optimizeOptions.optAlgorithm.population = 3;
+  // optimization parameter: k1 parameter of reaction r1
+  optimizeOptions.optParams.push_back(
+      {sme::simulate::OptParamType::ReactionParameter, "name", "k1", "r1", 0.05,
+       0.21});
+  // optimization cost: absolute difference of concentration of species A from
+  // zero, after simulating for time 1e6
+  optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Concentration,
+                                      simulate::OptCostDiffType::Absolute,
+                                      "name",
+                                      "A",
+                                      1e6,
+                                      1.0,
+                                      0,
+                                      0,
+                                      {}});
+  model.getOptimizeOptions() = optimizeOptions;
+  sme::simulate::Optimization optimization(model);
+  // run optimization in another thread
+  auto optSteps = std::async(std::launch::async,
+                             &simulate::Optimization::evolve, &optimization, 1);
+  // wait until it starts running
+  while (!optimization.getIsRunning()) {
+    sme::test::wait(10);
+  }
+  // request it to stop early
+  optimization.requestStop();
+  // this `.get()` blocks until optimization is finished
+  REQUIRE(optSteps.get() >= 1);
+  REQUIRE(optimization.getIsRunning() == false);
+  REQUIRE(optimization.getIsStopping() == false);
+  // stopped optimization before any simulation could complete, all fitness
+  // calls should return max double
+  REQUIRE(optimization.getFitness().size() >= 1);
+  REQUIRE(optimization.getFitness().back() ==
+          dbl_approx(std::numeric_limits<double>::max()));
 }


### PR DESCRIPTION
- pass `isStopping()` from `Optimization` as the `stopRunningCallback` to simulations from `PagmoUDP`
- if true, simulation stops early and `PagmoUDP::fitness()` returns infinite cost
- resolves #795
