### PR TITLE
add target images to DialogOptimize

### DIFF
--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -109,9 +109,14 @@ std::size_t element_index(const Container &c, const Element &e,
 
 /**
  * @brief Grayscale image from array of pixel intensities
+ *
+ * If a positive value is supplied for `maxValue` it determines the value that
+ * corresponds to white in the image, otherwise by default the maximum value
+ * from `values` is used.
  */
 QImage toGrayscaleIntensityImage(const QSize &imageSize,
-                                 const std::vector<double> &values);
+                                 const std::vector<double> &values,
+                                 double maxValue = -1.0);
 
 /**
  * @brief The type of an object as a string

--- a/core/common/src/utils.cpp
+++ b/core/common/src/utils.cpp
@@ -6,13 +6,17 @@
 namespace sme::common {
 
 QImage toGrayscaleIntensityImage(const QSize &imageSize,
-                                 const std::vector<double> &values) {
+                                 const std::vector<double> &values,
+                                 double maxValue) {
   QImage img(imageSize, QImage::Format_RGB32);
   if (values.size() != img.width() * img.height()) {
     img.fill(0);
   } else {
     double scaleFactor{0.0};
-    double maxValue{max(values)};
+    if (maxValue < 0) {
+      // use maximum value from supplied values
+      maxValue = max(values);
+    }
     if (maxValue > 0.0) {
       scaleFactor = 255.0 / maxValue;
     }
@@ -20,6 +24,7 @@ QImage toGrayscaleIntensityImage(const QSize &imageSize,
     for (int y = img.height() - 1; y >= 0; --y) {
       for (int x = 0; x < img.width(); ++x) {
         auto intensity{static_cast<int>(scaleFactor * (*value))};
+        intensity = std::clamp(intensity, 0, 255);
         img.setPixel(x, y, qRgb(intensity, intensity, intensity));
         ++value;
       }

--- a/core/simulate/src/optimize_impl.hpp
+++ b/core/simulate/src/optimize_impl.hpp
@@ -13,7 +13,8 @@ void applyParameters(const pagmo::vector_double &values,
 
 double calculateCosts(const std::vector<OptCost> &optCosts,
                       const std::vector<std::size_t> &optCostIndices,
-                      const sme::simulate::Simulation &sim);
+                      const sme::simulate::Simulation &sim,
+                      std::vector<std::vector<double>> &currentTargets);
 
 /**
  * @brief Implements a Pagmo User Defined Problem to evolve
@@ -25,19 +26,15 @@ double calculateCosts(const std::vector<OptCost> &optCosts,
 
 class PagmoUDP {
 private:
-  const std::string *xmlModel{nullptr};
-  const OptimizeOptions *optimizeOptions{nullptr};
-  const std::vector<OptTimestep> *optTimesteps{nullptr};
+  const OptConstData *optConstData{nullptr};
   ThreadsafeModelQueue *modelQueue{nullptr};
-  const sme::simulate::Optimization *optimization{nullptr};
+  sme::simulate::Optimization *optimization{nullptr};
 
 public:
   PagmoUDP() = default;
-  explicit PagmoUDP(const std::string *xmlModel,
-                    const OptimizeOptions *optimizeOptions,
-                    const std::vector<OptTimestep> *optTimesteps,
+  explicit PagmoUDP(const OptConstData *optConstData,
                     ThreadsafeModelQueue *modelQueue,
-                    const Optimization *optimization);
+                    Optimization *optimization);
   [[nodiscard]] pagmo::vector_double
   fitness(const pagmo::vector_double &dv) const;
   [[nodiscard]] std::pair<pagmo::vector_double, pagmo::vector_double>

--- a/gui/dialogs/dialogoptimize.hpp
+++ b/gui/dialogs/dialogoptimize.hpp
@@ -18,6 +18,8 @@ class DialogOptimize : public QDialog {
 public:
   explicit DialogOptimize(sme::model::Model &model, QWidget *parent = nullptr);
   ~DialogOptimize() override;
+  QString getParametersString() const;
+  void applyToModel() const;
 
 private:
   sme::model::Model &model;
@@ -27,10 +29,9 @@ private:
   std::size_t nPlottedIterations{0};
   QTimer plotRefreshTimer;
   void init();
-  void btnStart_clicked();
-  void btnStop_clicked();
+  void cmbTarget_currentIndexChanged(int index);
+  void btnStartStop_clicked();
   void btnSetup_clicked();
-  void btnApplyToModel_clicked();
   void updatePlots();
   void finalizePlots();
 };

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -25,48 +25,142 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
-      <widget class="QCustomPlot" name="pltParams" native="true"/>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCustomPlot" name="pltFitness" native="true"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QPushButton" name="btnStart">
-       <property name="text">
-        <string>Start</string>
+    <layout class="QVBoxLayout" name="vlayout0">
+     <item>
+      <widget class="QSplitter" name="splitter">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+       <widget class="QWidget" name="">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="3" column="0" colspan="2">
+          <widget class="QLabel" name="lblResultLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Values using current best parameters:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblCmbTargetLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Target:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QLabelMouseTracker" name="lblResult" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+           </property>
+           <property name="text" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QLabelMouseTracker" name="lblTarget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+           </property>
+           <property name="text" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbTarget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QLabel" name="lblTargetLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Target values:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="">
+        <layout class="QVBoxLayout" name="vlayout2">
+         <item>
+          <widget class="QCustomPlot" name="pltFitness" native="true"/>
+         </item>
+         <item>
+          <widget class="QCustomPlot" name="pltParams" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QPushButton" name="btnApplyToModel">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Apply to model</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QPushButton" name="btnStop">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Stop</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QPushButton" name="btnSetup">
-       <property name="text">
-        <string>Setup</string>
-       </property>
-      </widget>
+     <item>
+      <layout class="QHBoxLayout" name="vlayout1">
+       <item>
+        <widget class="QPushButton" name="btnSetup">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Setup</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnStartStop">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Start</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -84,16 +178,19 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QLabelMouseTracker</class>
+   <extends>QWidget</extends>
+   <header>qlabelmousetracker.hpp</header>
+  </customwidget>
+  <customwidget>
    <class>QCustomPlot</class>
    <extends>QWidget</extends>
    <header>qcustomplot.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>btnStart</tabstop>
-  <tabstop>btnStop</tabstop>
   <tabstop>btnSetup</tabstop>
-  <tabstop>btnApplyToModel</tabstop>
+  <tabstop>btnStartStop</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -8,7 +8,7 @@ using namespace sme;
 using namespace sme::test;
 
 TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
-                            "dialogs][gui][optimize]") {
+                            "dialogs][gui][optimize][Q]") {
   auto model{getExampleModel(Mod::ABtoC)};
   model.getSimulationSettings().simulatorType =
       sme::simulate::SimulatorType::Pixel;
@@ -33,35 +33,33 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     model.getOptimizeOptions() = {};
     DialogOptimize dia(model);
     // get pointers to widgets within dialog
-    auto *btnStart{dia.findChild<QPushButton *>("btnStart")};
-    REQUIRE(btnStart != nullptr);
-    auto *btnStop{dia.findChild<QPushButton *>("btnStop")};
-    REQUIRE(btnStop != nullptr);
+    auto *btnStartStop{dia.findChild<QPushButton *>("btnStartStop")};
+    REQUIRE(btnStartStop != nullptr);
     auto *btnSetup{dia.findChild<QPushButton *>("btnSetup")};
     REQUIRE(btnSetup != nullptr);
-    auto *btnApplyToModel{dia.findChild<QPushButton *>("btnApplyToModel")};
-    REQUIRE(btnApplyToModel != nullptr);
     // no valid initial optimize options
-    REQUIRE(btnStart->isEnabled() == false);
-    REQUIRE(btnStop->isEnabled() == false);
+    REQUIRE(btnStartStop->text() == "Start");
+    REQUIRE(btnStartStop->isEnabled() == false);
     REQUIRE(btnSetup->isEnabled() == true);
-    REQUIRE(btnApplyToModel->isEnabled() == false);
+    REQUIRE(dia.getParametersString().isEmpty());
   }
   SECTION("existing optimizeOptions") {
     DialogOptimize dia(model);
     // get pointers to widgets within dialog
-    auto *btnStart{dia.findChild<QPushButton *>("btnStart")};
-    REQUIRE(btnStart != nullptr);
-    auto *btnStop{dia.findChild<QPushButton *>("btnStop")};
-    REQUIRE(btnStop != nullptr);
+    auto *btnStartStop{dia.findChild<QPushButton *>("btnStartStop")};
+    REQUIRE(btnStartStop != nullptr);
     auto *btnSetup{dia.findChild<QPushButton *>("btnSetup")};
     REQUIRE(btnSetup != nullptr);
-    auto *btnApplyToModel{dia.findChild<QPushButton *>("btnApplyToModel")};
-    REQUIRE(btnApplyToModel != nullptr);
     // valid initial optimize options
-    REQUIRE(btnStart->isEnabled() == true);
-    REQUIRE(btnStop->isEnabled() == false);
+    REQUIRE(btnStartStop->isEnabled() == true);
     REQUIRE(btnSetup->isEnabled() == true);
-    REQUIRE(btnApplyToModel->isEnabled() == false);
+    // no initial parameters
+    REQUIRE(dia.getParametersString().isEmpty());
+    // evolve params for 3secs
+    sendMouseClick(btnStartStop);
+    wait(3000);
+    sendMouseClick(btnStartStop);
+    auto lines{dia.getParametersString().split("\n")};
+    REQUIRE(lines.size() == 1);
   }
 }

--- a/gui/dialogs/dialogoptsetup.ui
+++ b/gui/dialogs/dialogoptsetup.ui
@@ -110,7 +110,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Population:</string>
+        <string>Population per thread:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -141,6 +141,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="whatsThis">
+        <string>The number of CPU threads to use</string>
+       </property>
        <property name="minimum">
         <number>1</number>
        </property>
@@ -158,7 +161,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Islands:</string>
+        <string>Threads:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -589,16 +589,23 @@ void MainWindow::actionFinalize_non_spatial_import_triggered() {
 }
 
 void MainWindow::action_Optimization_triggered() {
-  // todo: load optimization options from model?
   if (!isValidModelAndGeometryImage()) {
     SPDLOG_DEBUG("invalid geometry and/or model: ignoring");
     return;
   }
   try {
-    DialogOptimize dialogOptimize(model, {});
+    DialogOptimize dialogOptimize(model);
     if (dialogOptimize.exec() == QDialog::Accepted) {
-      SPDLOG_INFO("todo: offer to apply optimization params to model(?)");
-      // todo: save optimization options to model?
+      auto paramsString{dialogOptimize.getParametersString()};
+      if (!paramsString.isEmpty()) {
+        auto result{QMessageBox::question(
+            this, "Apply optimized parameters to model?",
+            "Apply these optimized parameters to model?\n\n" + paramsString,
+            QMessageBox::Yes | QMessageBox::No)};
+        if (result == QMessageBox::Yes) {
+          dialogOptimize.applyToModel();
+        }
+      }
     }
   } catch (const std::invalid_argument &e) {
     QMessageBox::warning(this, "Optimize error", e.what());


### PR DESCRIPTION
- add QLabelMousetracker of target and current best values
  - add combobox to choose target if there are multiple targets
- PagmoUDP now updates Optimize with results if fitness is better than existing fitness
- add Optimization::getUpdatedBestResultImage
  - returns an image of best results for the specified cost index
  - only returns a value if the index or the values have changed
  - white in image normalized to match that of corresponding target values image
- resolves #761

change UI of DialogOptimize

- vsplit with target/result images on left, fitness/parameter graphs on right
- combine "start" & "stop" buttons
- remove "apply to model" button
  - instead offer to apply parameters when dialog is closed with OK
  - list parameters and values in this dialog
- use log scale for fitness / parameter graphs
