### PR TITLE
add minimum versions for rtd requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,5 @@ myst_parser
 nbsphinx
 numpy
 pandoc
-sphinx
-sphinx_rtd_theme
+sphinx>=4.5.0
+sphinx_rtd_theme>=1.0.0


### PR DESCRIPTION
- projects created before oct 2020 on rtd have very old pre-installed versions of sphinx-rtd-theme & sphinx
- specify minimum versions for these in requirements.txt to upgrade them to more recent versions
