### PR TITLE
improve `DialogAnalytic` handling of 1/0, inf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [1.3.0]
+## [latest]
+### Fixed
+- crash caused by analytic initial species concentrations involving dividing by zero [#805](https://github.com/spatial-model-editor/spatial-model-editor/issues/805)
+
+## [1.3.0] - 2022-06-10
 ### Added
 - [parameter fitting](https://spatial-model-editor.readthedocs.io/en/stable/reference/parameter-fitting.html) functionality to GUI [#757](https://github.com/spatial-model-editor/spatial-model-editor/issues/757)
 - support for reading SBML files compressed with bzip2 [#246](https://github.com/spatial-model-editor/spatial-model-editor/issues/246)

--- a/core/common/src/symbolic_t.cpp
+++ b/core/common/src/symbolic_t.cpp
@@ -502,6 +502,21 @@ TEST_CASE("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     CAPTURE(sym.getErrorMessage());
     REQUIRE(sym.getErrorMessage().empty());
   }
+  SECTION("expression with 1/0: parses but doesn't compile") {
+    // 1/0 gives complex inf which is ok for parsing but not for llvm
+    // compilation
+    common::Symbolic sym("1/0", {}, {}, {});
+    REQUIRE(sym.isValid() == true);
+    REQUIRE(sym.isCompiled() == false);
+    CAPTURE(sym.getErrorMessage());
+    REQUIRE(sym.getErrorMessage().empty());
+    sym.compile();
+    REQUIRE(sym.isValid() == false);
+    REQUIRE(sym.isCompiled() == false);
+    CAPTURE(sym.getErrorMessage());
+    REQUIRE(sym.getErrorMessage().substr(0, 30) ==
+            "Failed to compile expression: ");
+  }
   SECTION("expression with nan: parses but doesn't compile") {
     // nan parses ok but not supported by llvm compilation
     common::Symbolic sym("nan");

--- a/gui/dialogs/dialoganalytic_t.cpp
+++ b/gui/dialogs/dialoganalytic_t.cpp
@@ -46,6 +46,28 @@ TEST_CASE("DialogAnalytic",
       REQUIRE(dia.isExpressionValid() == false);
       REQUIRE(dia.getExpression().empty() == true);
     }
+    SECTION("1/0") {
+      // https://github.com/spatial-model-editor/spatial-model-editor/issues/805
+      mwt.addUserAction({"Delete", "1", "/", "0"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.isExpressionValid() == false);
+      REQUIRE(dia.getExpression().empty() == true);
+    }
+    SECTION("nan") {
+      mwt.addUserAction({"Delete", "n", "a", "n"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.isExpressionValid() == false);
+      REQUIRE(dia.getExpression().empty() == true);
+    }
+    SECTION("inf") {
+      mwt.addUserAction({"Delete", "i", "n", "f"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.isExpressionValid() == false);
+      REQUIRE(dia.getExpression().empty() == true);
+    }
     SECTION("unknown function: sillyfunc") {
       mwt.addUserAction({"Delete", "s", "i", "l", "l", "y", "f", "u", "n", "c",
                          "(", "x", ")"});

--- a/gui/widgets/qplaintextmathedit.cpp
+++ b/gui/widgets/qplaintextmathedit.cpp
@@ -24,7 +24,15 @@ void QPlainTextMathEdit::importVariableMath(const std::string &expr) {
   setPlainText(variablesToDisplayNames(expr).c_str());
 }
 
-void QPlainTextMathEdit::compileMath() { sym.compile(); }
+bool QPlainTextMathEdit::compileMath() {
+  if (!expressionIsValid || !sym.isValid()) {
+    return false;
+  }
+  sym.compile();
+  expressionIsValid = sym.isValid() && sym.isCompiled();
+  currentErrorMessage = sym.getErrorMessage().c_str();
+  return expressionIsValid;
+}
 
 double QPlainTextMathEdit::evaluateMath(const std::vector<double> &variables) {
   sym.eval(result, variables);

--- a/gui/widgets/qplaintextmathedit.hpp
+++ b/gui/widgets/qplaintextmathedit.hpp
@@ -23,7 +23,7 @@ public:
   const QString &getMath() const;
   const std::string &getVariableMath() const;
   void importVariableMath(const std::string &expr);
-  void compileMath();
+  bool compileMath();
   double evaluateMath(const std::vector<double> &variables = {});
   const QString &getErrorMessage() const;
   const std::vector<std::string> &getVariables() const;


### PR DESCRIPTION
- `QPlainTextMathEdit::compileMath()`
  - now returns true if compile succeeded
  - if compile fails, sets error message and returns false
- `DialogAnalytic` shows error message if calling the above returns false
  - e.g. `1/0` parses ok as complex inf and then fails to compile
  - resolves #805
- extend existing `DialogAnalytic` check for `NaN` values to also check for `inf`
