### PR TITLE
Fix function evaluation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
+## [1.3.5] - 2023-03-02
+### Fixed
+- incorrect function evaluations in some cases [#855](https://github.com/spatial-model-editor/spatial-model-editor/issues/855), [#856](https://github.com/spatial-model-editor/spatial-model-editor/issues/856), [#857](https://github.com/spatial-model-editor/spatial-model-editor/issues/857)
+
 ## [1.3.4] - 2023-02-23
 ### Fixed
-- incorrect initial concentrations with DUNE simulator for some models [#852](https://github.com/spatial-model-editor/spatial-model-editor/issues/710) and [#830](https://github.com/spatial-model-editor/spatial-model-editor/issues/852).
+- incorrect initial concentrations with DUNE simulator for some models [#852](https://github.com/spatial-model-editor/spatial-model-editor/issues/852)
 
 ## [1.3.3] - 2022-12-05
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.3.4
+  VERSION 1.3.5
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 

--- a/core/common/include/sme/symbolic.hpp
+++ b/core/common/include/sme/symbolic.hpp
@@ -33,14 +33,16 @@ public:
       const std::vector<std::string> &expressions,
       const std::vector<std::string> &variables = {},
       const std::vector<std::pair<std::string, double>> &constants = {},
-      const std::vector<SymbolicFunction> &functions = {});
+      const std::vector<SymbolicFunction> &functions = {},
+      bool allow_unknown_symbols = false);
   explicit Symbolic(
       const std::string &expression,
       const std::vector<std::string> &variables = {},
       const std::vector<std::pair<std::string, double>> &constants = {},
-      const std::vector<SymbolicFunction> &functions = {})
+      const std::vector<SymbolicFunction> &functions = {},
+      bool allow_unknown_symbols = false)
       : Symbolic(std::vector<std::string>{expression}, variables, constants,
-                 functions) {}
+                 functions, allow_unknown_symbols) {}
   Symbolic(Symbolic &&) noexcept;
   Symbolic(const Symbolic &) = delete;
   Symbolic &operator=(Symbolic &&) noexcept;

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -23,6 +23,7 @@ class ModelCompartments;
 class ModelGeometry;
 class ModelParameters;
 class ModelReactions;
+class ModelFunctions;
 struct Settings;
 
 class ModelSpecies {
@@ -36,6 +37,7 @@ private:
   const ModelGeometry *modelGeometry = nullptr;
   const ModelParameters *modelParameters = nullptr;
   ModelReactions *modelReactions = nullptr;
+  const ModelFunctions *modelFunctions = nullptr;
   simulate::SimulationData *simulationData = nullptr;
   Settings *sbmlAnnotation = nullptr;
   void removeInitialAssignment(const QString &id);
@@ -47,7 +49,8 @@ public:
   ModelSpecies();
   ModelSpecies(libsbml::Model *model, const ModelCompartments *compartments,
                const ModelGeometry *geometry, const ModelParameters *parameters,
-               simulate::SimulationData *data, Settings *annotation);
+               const ModelFunctions *functions, simulate::SimulationData *data,
+               Settings *annotation);
   void setReactionsPtr(ModelReactions *reactions);
   void setSimulationDataPtr(simulate::SimulationData *data);
   [[nodiscard]] bool containsNonSpatialReactiveSpecies() const;

--- a/core/model/src/model.cpp
+++ b/core/model/src/model.cpp
@@ -86,8 +86,8 @@ void Model::initModelData(bool emptySpatialModel) {
   modelParameters = std::make_unique<ModelParameters>(model);
   modelSpecies = std::make_unique<ModelSpecies>(
       model, modelCompartments.get(), modelGeometry.get(),
-      modelParameters.get(), smeFileContents->simulationData.get(),
-      settings.get());
+      modelParameters.get(), modelFunctions.get(),
+      smeFileContents->simulationData.get(), settings.get());
   modelCompartments->setSpeciesPtr(modelSpecies.get());
   modelEvents = std::make_unique<ModelEvents>(model, modelParameters.get(),
                                               modelSpecies.get());
@@ -331,10 +331,7 @@ SpeciesGeometry Model::getSpeciesGeometry(const QString &speciesID) const {
 }
 
 std::string Model::inlineExpr(const std::string &mathExpression) const {
-  std::string inlined;
-  // inline any Function calls in expr
-  inlined = inlineFunctions(mathExpression, doc->getModel());
-  // inline any Assignment Rules in expr
+  std::string inlined = inlineFunctions(mathExpression, *modelFunctions);
   inlined = inlineAssignments(inlined, doc->getModel());
   return inlined;
 }

--- a/core/model/src/model_functions_t.cpp
+++ b/core/model/src/model_functions_t.cpp
@@ -1,4 +1,5 @@
 #include "catch_wrapper.hpp"
+#include "math_test_utils.hpp"
 #include "model_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/model_functions.hpp"
@@ -20,23 +21,24 @@ TEST_CASE("SBML functions",
     REQUIRE(funcs.getName("HK_kinetics") == "HK kinetics");
     REQUIRE(funcs.getArguments("HK_kinetics").size() == 10);
     REQUIRE(funcs.getArguments("HK_kinetics")[0] == "A");
-    REQUIRE(funcs.getExpression("HK_kinetics") ==
-            "Vmax * (A * B / (Kglc * Katp) - P * Q / (Kglc * Katp * Keq)) "
-            "/ ((1 + A / Kglc + P / Kg6p) * (1 + B / Katp + Q / Kadp))");
+    REQUIRE(
+        symEq(funcs.getExpression("HK_kinetics"),
+              "Vmax * (A * B / (Kglc * Katp) - P * Q / (Kglc * Katp * Keq)) "
+              "/ ((1 + A / Kglc + P / Kg6p) * (1 + B / Katp + Q / Kadp))"));
     SECTION("inline fn: Glycogen_synthesis_kinetics") {
       std::string expr = "Glycogen_synthesis_kinetics(abc)";
-      std::string inlined = "(abc)";
-      REQUIRE(s.inlineExpr(expr) == inlined);
+      std::string inlined = "abc";
+      REQUIRE(symEq(s.inlineExpr(expr), inlined));
     }
     SECTION("inline fn: ATPase_0") {
       std::string expr = "ATPase_0( a,b)";
-      std::string inlined = "(b * a)";
-      REQUIRE(s.inlineExpr(expr) == inlined);
+      std::string inlined = "b * a";
+      REQUIRE(symEq(s.inlineExpr(expr), inlined));
     }
     SECTION("inline fn: PDC_kinetics") {
       std::string expr = "PDC_kinetics(a,V,k,n)";
-      std::string inlined = "(V * (a / k)^n / (1 + (a / k)^n))";
-      REQUIRE(s.inlineExpr(expr) == inlined);
+      std::string inlined = "V * (a / k)^n / (1 + (a / k)^n)";
+      REQUIRE(symEq(s.inlineExpr(expr), inlined));
     }
     SECTION("edit function: PDC_kinetics") {
       REQUIRE(funcs.getArguments("PDC_kinetics").size() == 4);
@@ -59,11 +61,11 @@ TEST_CASE("SBML functions",
       REQUIRE(funcs.getArguments("PDC_kinetics")[2] == "Kpyr");
       REQUIRE(funcs.getArguments("PDC_kinetics")[3] == "nH");
       REQUIRE(funcs.getArguments("PDC_kinetics")[4] == "x");
-      REQUIRE(funcs.getExpression("PDC_kinetics") ==
-              "V * (x / k)^n / (1 + (a / k)^n)");
+      REQUIRE(symEq(funcs.getExpression("PDC_kinetics"),
+                    "V * (x / k)^n / (1 + (a / k)^n)"));
       std::string expr{"PDC_kinetics(a,V,k,n,Q)"};
-      std::string inlined{"(V * (Q / k)^n / (1 + (a / k)^n))"};
-      REQUIRE(s.inlineExpr(expr) == inlined);
+      std::string inlined{"V * (Q / k)^n / (1 + (a / k)^n)"};
+      REQUIRE(symEq(s.inlineExpr(expr), inlined));
       funcs.remove("PDC_kinetics");
       REQUIRE(funcs.getIds().size() == 16);
     }

--- a/core/model/src/model_geometry_t.cpp
+++ b/core/model/src/model_geometry_t.cpp
@@ -30,6 +30,7 @@ TEST_CASE("Model geometry",
     model::ModelMembranes mMembranes(doc->getModel());
     model::ModelGeometry mGeometry;
     model::ModelSpecies mSpecies;
+    model::ModelFunctions mFunctions(doc->getModel());
     model::ModelReactions mReactions(doc->getModel(), &mCompartments,
                                      &mMembranes, false);
     simulate::SimulationData simulationData{};
@@ -57,9 +58,9 @@ TEST_CASE("Model geometry",
       REQUIRE(mGeometry.getPhysicalPointAsString({0, 0}) == "x: 0 m, y: 99 m");
       model::ModelParameters mParameters(doc->getModel());
       simulate::SimulationData data;
-      mSpecies =
-          model::ModelSpecies(doc->getModel(), &mCompartments, &mGeometry,
-                              &mParameters, &data, &sbmlAnnotation);
+      mSpecies = model::ModelSpecies(doc->getModel(), &mCompartments,
+                                     &mGeometry, &mParameters, &mFunctions,
+                                     &data, &sbmlAnnotation);
       mSpecies.setReactionsPtr(&mReactions);
       REQUIRE(m.getIsValid() == true);
       REQUIRE(m.getMesh() != nullptr);

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -230,12 +230,13 @@ ModelSpecies::ModelSpecies(libsbml::Model *model,
                            const ModelCompartments *compartments,
                            const ModelGeometry *geometry,
                            const ModelParameters *parameters,
+                           const ModelFunctions *functions,
                            simulate::SimulationData *data, Settings *annotation)
     : ids{importIds(model)}, names{importNamesAndMakeUnique(model)},
       compartmentIds{importCompartmentIds(model)}, sbmlModel{model},
       modelCompartments{compartments}, modelGeometry{geometry},
-      modelParameters{parameters}, simulationData{data}, sbmlAnnotation{
-                                                             annotation} {
+      modelParameters{parameters}, modelFunctions{functions},
+      simulationData{data}, sbmlAnnotation{annotation} {
   makeInitialConcentrationsValid(model);
   for (int i = 0; i < ids.size(); ++i) {
     const auto &id = ids[i];
@@ -547,7 +548,7 @@ void ModelSpecies::setFieldConcAnalytic(
     geometry::Field &field, const std::string &expr,
     const std::map<std::string, double, std::less<>> &substitutions) {
   SPDLOG_INFO("expr: {}", expr);
-  auto inlinedExpr = inlineFunctions(expr, sbmlModel);
+  auto inlinedExpr = inlineFunctions(expr, *modelFunctions);
   inlinedExpr = inlineAssignments(inlinedExpr, sbmlModel);
   SPDLOG_INFO("  - inlined expr: {}", inlinedExpr);
   std::string xId{modelParameters->getSpatialCoordinates().x.id};

--- a/core/model/src/sbml_math.cpp
+++ b/core/model/src/sbml_math.cpp
@@ -1,16 +1,16 @@
 #include "sbml_math.hpp"
 #include "sme/logger.hpp"
+#include "sme/symbolic.hpp"
 #include <memory>
 #include <sbml/SBMLTransforms.h>
 
 namespace sme::model {
 
 std::string inlineFunctions(const std::string &mathExpression,
-                            const libsbml::Model *model) {
-  auto math{mathStringToAST(mathExpression)};
-  libsbml::SBMLTransforms::replaceFD(math.get(),
-                                     model->getListOfFunctionDefinitions());
-  return "(" + mathASTtoString(math.get()) + ")";
+                            const model::ModelFunctions &modelFunctions) {
+  common::Symbolic sym{
+      mathExpression, {}, {}, modelFunctions.getSymbolicFunctions(), true};
+  return "(" + sym.inlinedExpr() + ")";
 }
 
 std::string inlineAssignments(const std::string &mathExpression,

--- a/core/model/src/sbml_math.hpp
+++ b/core/model/src/sbml_math.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "sme/model_functions.hpp"
 #include <map>
 #include <memory>
 #include <sbml/SBMLTypes.h>
@@ -15,12 +16,9 @@ class ASTNode;
 
 namespace sme::model {
 
-// return supplied math expression as string with any Function calls and/or
-// Assignment rules inlined e.g. given mathExpression = "z*f(x,y)" where the
-// SBML model contains a function "f(a,b) = a*b-2" it returns "z*(x*y-2)"
-// todo: replace with libSBML equivalent
+// return supplied math expression as string with any Function calls inlined
 std::string inlineFunctions(const std::string &mathExpression,
-                            const libsbml::Model *model);
+                            const model::ModelFunctions &modelFunctions);
 
 // return supplied math expression as string with any Assignment rules
 // inlined

--- a/core/model/src/sbml_math_t.cpp
+++ b/core/model/src/sbml_math_t.cpp
@@ -8,19 +8,40 @@ using namespace sme::test;
 
 TEST_CASE("SBML Math",
           "[core/model/sbml_math][core/model][core][model][sbml_math]") {
-  auto model{getExampleModel(Mod::ABtoC)};
-  auto &functions{model.getFunctions()};
-  functions.add("f0");
-  functions.setExpression("f0", "66");
-  functions.add("f1");
-  functions.addArgument("f1", "x");
-  functions.setExpression("f1", "2*x");
-  auto doc{toSbmlDoc(model)};
-  REQUIRE(model::inlineFunctions("f0()", doc->getModel()) == "(66)");
-  REQUIRE(model::inlineFunctions("f1(x)", doc->getModel()) == "(2 * x)");
-  REQUIRE(model::inlineFunctions("f1(2)", doc->getModel()) == "(2 * 2)");
-  REQUIRE(model::inlineFunctions("f1(f1(y))", doc->getModel()) ==
-          "(2 * (2 * y))");
-  REQUIRE(model::inlineFunctions("f1(f1(f0()))", doc->getModel()) ==
-          "(2 * (2 * 66))");
+  SECTION("Functions can call other functions") {
+    auto model{getExampleModel(Mod::ABtoC)};
+    auto &functions{model.getFunctions()};
+    functions.add("f0");
+    functions.setExpression("f0", "66");
+    functions.add("f1");
+    functions.addArgument("f1", "x");
+    functions.setExpression("f1", "2*x");
+    REQUIRE(symEq(model::inlineFunctions("f0()", functions), "66"));
+    REQUIRE(symEq(model::inlineFunctions("f1(x)", functions), "2*x"));
+    REQUIRE(symEq(model::inlineFunctions("f1(2)", functions), "4"));
+    REQUIRE(
+        symEq(model::inlineFunctions("f1(f1(y))", functions), "2 * (2 * y)"));
+    REQUIRE(symEq(model::inlineFunctions("f1(f1(f0()))", functions),
+                  "2 * (2 * 66)"));
+  }
+  SECTION("Function args can have same id as they are called with") {
+    // https://github.com/spatial-model-editor/spatial-model-editor/issues/855
+    // https://github.com/spatial-model-editor/spatial-model-editor/issues/856
+    // https://github.com/spatial-model-editor/spatial-model-editor/issues/857
+    auto s{getExampleModel(Mod::ABtoC)};
+    auto &funcs{s.getFunctions()};
+    funcs.add("f");
+    funcs.addArgument("f", "A");
+    funcs.addArgument("f", "B");
+    funcs.setExpression("f", "A*B");
+    REQUIRE(symEq(s.inlineExpr("f(x,y)"), "x*y"));
+    REQUIRE(symEq(s.inlineExpr("f(x,2)"), "2*x"));
+    REQUIRE(symEq(s.inlineExpr("f(5,y)"), "5*y"));
+    REQUIRE(symEq(s.inlineExpr("f(1,B)"), "B"));
+    REQUIRE(symEq(s.inlineExpr("f(B,1)"), "B"));
+    // in the above libsbml replaces each bvar in turn:
+    // A*B -> replace any A with B: B*B -> replace any B with 1 -> 1*1
+    REQUIRE(symEq(s.inlineExpr("f(A,B)"), "B*A"));
+    REQUIRE(symEq(s.inlineExpr("f(B,A)"), "A*B"));
+  }
 }

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="1.3.4",
+    version="1.3.5",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",


### PR DESCRIPTION
- Use Symbolic instead of libsbml to inline functions
  - avoid bug in `libsbml::SBMLTransforms::replaceFD`
  - add `allow_unknown_symbols` option to Symbolic for this purpose
- inlineFunctions() now takes `ModelFunctions` instead of the sbml model
  - required adding `ModelFunctions` to the `ModelSpecies` constructor
- Add regression tests
- bump version to 1.3.5
- resolves #855
- resolves #856
- resolves #857
