### PR TITLE
non-isotropic voxel support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: v16.0.6
     hooks:
       - id: clang-format
+        types_or: [c++, c, cuda]
 
   - repo: https://github.com/lovesegfault/beautysh
     rev: v6.2.1
@@ -37,7 +38,7 @@ repos:
       - id: beautysh
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.24.1
+    rev: 0.26.3
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/core/common/include/sme/image_stack.hpp
+++ b/core/common/include/sme/image_stack.hpp
@@ -54,6 +54,7 @@ public:
   void rescaleXY(QSize size);
   void flipYAxis();
   void convertToIndexed();
+  ImageStack scaled(int width, int height);
   ImageStack scaledToWidth(int width);
   ImageStack scaledToHeight(int height);
 };

--- a/core/common/include/sme/tiff.hpp
+++ b/core/common/include/sme/tiff.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "sme/image_stack.hpp"
+#include "sme/voxel.hpp"
 #include <QImage>
 #include <QString>
 #include <cstddef>
@@ -21,7 +22,8 @@ namespace sme::common {
 using TiffDataType = uint16_t;
 
 double writeTIFF(const std::string &filename, const QSize &imageSize,
-                 const std::vector<double> &conc, double pixelWidth);
+                 const std::vector<double> &conc,
+                 const sme::common::VolumeF &voxelSize);
 
 class TiffReader {
 private:

--- a/core/common/include/sme/voxel.hpp
+++ b/core/common/include/sme/voxel.hpp
@@ -89,4 +89,10 @@ inline VolumeF operator*(const VolumeF &a, const Volume &b) {
 
 inline VolumeF operator*(const Volume &a, const VolumeF &b) { return b * a; }
 
+inline VolumeF operator/(const VolumeF &a, const Volume &b) {
+  return {a.width() / static_cast<double>(b.width()),
+          a.height() / static_cast<double>(b.height()),
+          a.depth() / static_cast<double>(b.depth())};
+}
+
 } // namespace sme::common

--- a/core/common/src/image_stack.cpp
+++ b/core/common/src/image_stack.cpp
@@ -110,6 +110,16 @@ void ImageStack::convertToIndexed() {
   }
 }
 
+ImageStack ImageStack::scaled(int width, int height) {
+  ImageStack scaled{*this};
+  for (std::size_t z = 0; z < sz.depth(); ++z) {
+    scaled.imgs[z] = imgs[z].scaled(width, height, Qt::IgnoreAspectRatio,
+                                    Qt::FastTransformation);
+    scaled.sz = {scaled.imgs[z].size(), sz.depth()};
+  }
+  return scaled;
+}
+
 ImageStack ImageStack::scaledToWidth(int width) {
   ImageStack scaled{*this};
   for (std::size_t z = 0; z < sz.depth(); ++z) {

--- a/core/common/src/tiff.cpp
+++ b/core/common/src/tiff.cpp
@@ -16,7 +16,8 @@ constexpr TiffDataType TiffDataTypeMaxValue =
     std::numeric_limits<TiffDataType>::max();
 
 double writeTIFF(const std::string &filename, const QSize &imageSize,
-                 const std::vector<double> &conc, double pixelWidth) {
+                 const std::vector<double> &conc,
+                 const sme::common::VolumeF &voxelSize) {
   // todo: add ORIGIN to TIFF file!
   SPDLOG_TRACE("found {} concentration values", conc.size());
   double maxConc = *std::max_element(conc.cbegin(), conc.cend());
@@ -66,8 +67,8 @@ double writeTIFF(const std::string &filename, const QSize &imageSize,
   TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_CENTIMETER);
   // NB: factor to convert from pixel location to physical location
   // pixelX = TIFFTAG_XRESOLUTION * physicalX, etc.
-  TIFFSetField(tif, TIFFTAG_XRESOLUTION, 1.0 / pixelWidth);
-  TIFFSetField(tif, TIFFTAG_YRESOLUTION, 1.0 / pixelWidth);
+  TIFFSetField(tif, TIFFTAG_XRESOLUTION, 1.0 / voxelSize.width());
+  TIFFSetField(tif, TIFFTAG_YRESOLUTION, 1.0 / voxelSize.height());
   // NB: location of (0,0) pixel
   TIFFSetField(tif, TIFFTAG_XPOSITION, 0.0);
   TIFFSetField(tif, TIFFTAG_YPOSITION, 0.0);

--- a/core/mesh/include/sme/mesh.hpp
+++ b/core/mesh/include/sme/mesh.hpp
@@ -38,7 +38,7 @@ private:
   // input data
   QImage img;
   QPointF origin;
-  double pixel{};
+  QSizeF pixel{};
   std::vector<std::size_t> boundaryMaxPoints;
   std::vector<std::size_t> compartmentMaxTriangleArea;
   // generated data
@@ -64,7 +64,7 @@ public:
    * @param[in] maxPoints the max points allowed for each boundary line
    * @param[in] maxTriangleArea the max triangle area allowed for each
    *    compartment
-   * @param[in] pixelWidth the physical width of a pixel
+   * @param[in] voxelSize the physical size of a pixel
    * @param[in] originPoint the physical location of the ``(0,0)`` pixel
    * @param[in] compartmentColours the colours of compartments in the image
    */
@@ -160,11 +160,11 @@ public:
    * The boundary lines and mesh use pixel units internally, and are rescaled
    * to physical values using the supplied physical origin and pixel width.
    *
-   * @param[in] pixelWidth the physical width of a pixel
-   * @param[in] originPoint the physical location of the ``(0,0)`` pixel
+   * @param[in] voxelSize the physical size of a voxel
+   * @param[in] originPoint the physical location of the ``(0,0,0)`` voxel
    */
-  void setPhysicalGeometry(double pixelWidth,
-                           const QPointF &originPoint = QPointF(0, 0));
+  void setPhysicalGeometry(const common::VolumeF &voxelSize,
+                           const common::VoxelF &originPoint = {0.0, 0.0, 0.0});
   /**
    * @brief The physical mesh vertices as a flat array of doubles
    *

--- a/core/model/include/sme/geometry.hpp
+++ b/core/model/include/sme/geometry.hpp
@@ -73,14 +73,14 @@ public:
 
 class Membrane {
 private:
-  std::vector<std::pair<std::size_t, std::size_t>> indexPair{};
+  std::array<std::vector<std::pair<std::size_t, std::size_t>>, 3> indexPairs{};
   std::string id{};
   const Compartment *compA{};
   const Compartment *compB{};
   sme::common::ImageStack images{};
-  const std::vector<std::pair<common::Voxel, common::Voxel>> *voxelPairs{};
 
 public:
+  enum FLUX_DIRECTION { X = 0, Y = 1, Z = 2 };
   Membrane() = default;
   Membrane(std::string membraneId, const Compartment *A, const Compartment *B,
            const std::vector<std::pair<common::Voxel, common::Voxel>>
@@ -89,9 +89,8 @@ public:
   void setId(const std::string &membraneId);
   [[nodiscard]] const Compartment *getCompartmentA() const;
   [[nodiscard]] const Compartment *getCompartmentB() const;
-  std::vector<std::pair<std::size_t, std::size_t>> &getIndexPairs();
   [[nodiscard]] const std::vector<std::pair<std::size_t, std::size_t>> &
-  getIndexPairs() const;
+  getIndexPairs(FLUX_DIRECTION fluxDirection) const;
   [[nodiscard]] const sme::common::ImageStack &getImages() const;
 };
 

--- a/core/model/src/model_geometry.cpp
+++ b/core/model/src/model_geometry.cpp
@@ -376,7 +376,7 @@ void ModelGeometry::setVoxelSize(const common::VolumeF &newVoxelSize,
               physicalOrigin.p.y(), physicalOrigin.z);
 
   if (mesh != nullptr) {
-    mesh->setPhysicalGeometry(voxelSize.width(), physicalOrigin.p);
+    mesh->setPhysicalGeometry(voxelSize, physicalOrigin);
   }
   // update xyz coordinates
   auto *geom = getOrCreateGeometry(sbmlModel);

--- a/core/model/src/model_membranes.cpp
+++ b/core/model/src/model_membranes.cpp
@@ -175,8 +175,6 @@ void ModelMembranes::importMembraneIdsAndNames() {
 }
 
 void ModelMembranes::exportToSBML(const common::VolumeF &voxelSize) {
-  // todo: this uses the x-z face area everywhere (i.e. assumes cubic voxels)
-  double voxelFaceArea{voxelSize.width() * voxelSize.depth()};
   if (sbmlModel == nullptr) {
     SPDLOG_WARN("no sbml model to export to - ignoring");
   }
@@ -200,8 +198,16 @@ void ModelMembranes::exportToSBML(const common::VolumeF &voxelSize) {
       // we set the model units, compartment units are then inferred from that
       comp->unsetUnits();
     }
-    auto nPixels{membranes[static_cast<std::size_t>(i)].getIndexPairs().size()};
-    double area{static_cast<double>(nPixels) * voxelFaceArea};
+    const auto &membrane{membranes[static_cast<std::size_t>(i)]};
+    double area{(static_cast<double>(
+                     membrane.getIndexPairs(geometry::Membrane::X).size()) *
+                 voxelSize.height() * voxelSize.depth()) +
+                (static_cast<double>(
+                     membrane.getIndexPairs(geometry::Membrane::Y).size()) *
+                 voxelSize.width() * voxelSize.depth()) +
+                (static_cast<double>(
+                     membrane.getIndexPairs(geometry::Membrane::Z).size()) *
+                 voxelSize.width() * voxelSize.height())};
     SPDLOG_INFO("  - size: {}", area);
     comp->setSize(area);
     auto *scp = dynamic_cast<libsbml::SpatialCompartmentPlugin *>(

--- a/core/model/src/model_membranes_t.cpp
+++ b/core/model/src/model_membranes_t.cpp
@@ -66,7 +66,9 @@ TEST_CASE("SBML membranes",
       REQUIRE(m.getCompartmentB()->getId() == "c0");
       REQUIRE(m.getImages().volume().depth() == 1);
       REQUIRE(m.getImages()[0].size() == img.size());
-      REQUIRE(m.getIndexPairs().size() == 4);
+      REQUIRE(m.getIndexPairs(sme::geometry::Membrane::X).size() == 2);
+      REQUIRE(m.getIndexPairs(sme::geometry::Membrane::Y).size() == 2);
+      REQUIRE(m.getIndexPairs(sme::geometry::Membrane::Z).size() == 0);
     }
   }
 }

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -1036,8 +1036,9 @@ TEST_CASE("Import Combine archive",
   REQUIRE(s.getCompartments().getCompartment("cytoplasm")->nVoxels() == 7800);
   REQUIRE(s.getCompartments().getCompartment("nucleus")->nVoxels() == 481);
   REQUIRE(s.getMembranes().getIds().size() == 1);
-  REQUIRE(s.getMembranes()
-              .getMembrane("cytoplasm_nucleus_membrane")
-              ->getIndexPairs()
-              .size() == 98);
+  const auto &membrane{
+      s.getMembranes().getMembrane("cytoplasm_nucleus_membrane")};
+  REQUIRE(membrane->getIndexPairs(sme::geometry::Membrane::X).size() == 48);
+  REQUIRE(membrane->getIndexPairs(sme::geometry::Membrane::Y).size() == 50);
+  REQUIRE(membrane->getIndexPairs(sme::geometry::Membrane::Z).size() == 0);
 }

--- a/core/simulate/include/sme/duneconverter.hpp
+++ b/core/simulate/include/sme/duneconverter.hpp
@@ -4,6 +4,10 @@
 #pragma once
 
 #include "sme/simulate_options.hpp"
+#include "sme/voxel.hpp"
+#include <QPoint>
+#include <QSize>
+#include <QSizeF>
 #include <QString>
 #include <map>
 #include <vector>
@@ -34,20 +38,18 @@ public:
   [[nodiscard]] const mesh::Mesh *getMesh() const;
   [[nodiscard]] const std::vector<std::vector<std::vector<double>>> &
   getConcentrations() const;
-  [[nodiscard]] double getXOrigin() const;
-  [[nodiscard]] double getYOrigin() const;
-  [[nodiscard]] double getPixelWidth() const;
-  [[nodiscard]] int getImageWidth() const;
+  [[nodiscard]] common::VoxelF getOrigin() const;
+  [[nodiscard]] common::VolumeF getVoxelSize() const;
+  [[nodiscard]] common::Volume getImageSize() const;
 
 private:
   std::vector<QString> iniFiles;
   bool independentCompartments{true};
   const mesh::Mesh *mesh;
   std::vector<std::vector<std::vector<double>>> concentrations;
-  double x0;
-  double y0;
-  double a;
-  int w;
+  common::VoxelF origin;
+  common::VolumeF voxelSize;
+  common::Volume imageSize;
 };
 
 } // namespace simulate

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -184,7 +184,7 @@ static void addCompartment(
         double max = common::writeTIFF(
             tiffFilename.toStdString(),
             f->getCompartment()->getCompartmentImages()[0].size(), conc,
-            model.getGeometry().getVoxelSize().width());
+            model.getGeometry().getVoxelSize());
         tiffs.push_back(sampledFieldName);
         ini.addValue(duneName,
                      QString("%1*%2(x,y)").arg(max).arg(sampledFieldName));
@@ -335,10 +335,9 @@ DuneConverter::DuneConverter(
     const std::map<std::string, double, std::less<>> &substitutions,
     bool forExternalUse, const QString &outputIniFile, int doublePrecision)
     : mesh{model.getGeometry().getMesh()},
-      x0{model.getGeometry().getPhysicalOrigin().p.x()},
-      y0{model.getGeometry().getPhysicalOrigin().p.y()},
-      a{model.getGeometry().getVoxelSize().width()},
-      w{model.getGeometry().getImages()[0].width()} {
+      origin{model.getGeometry().getPhysicalOrigin()},
+      voxelSize{model.getGeometry().getVoxelSize()},
+      imageSize{model.getGeometry().getImages().volume()} {
 
   independentCompartments = modelHasIndependentCompartments(model);
 
@@ -457,12 +456,10 @@ DuneConverter::getConcentrations() const {
   return concentrations;
 }
 
-double DuneConverter::getXOrigin() const { return x0; }
+common::VoxelF DuneConverter::getOrigin() const { return origin; }
 
-double DuneConverter::getYOrigin() const { return y0; }
+common::VolumeF DuneConverter::getVoxelSize() const { return voxelSize; }
 
-double DuneConverter::getPixelWidth() const { return a; }
-
-int DuneConverter::getImageWidth() const { return w; }
+common::Volume DuneConverter::getImageSize() const { return imageSize; }
 
 } // namespace sme::simulate

--- a/core/simulate/src/dunesim.hpp
+++ b/core/simulate/src/dunesim.hpp
@@ -57,7 +57,7 @@ private:
   std::vector<DuneSimCompartment> duneCompartments;
   // dimensions of model
   QSize geometryImageSize;
-  double pixelSize;
+  QSizeF pixelSize;
   QPointF pixelOrigin;
   void initDuneSimCompartments(
       const std::vector<const geometry::Compartment *> &comps);

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -66,8 +66,9 @@ private:
   std::vector<double> dcdt;
   std::vector<double> s2;
   std::vector<double> s3;
-  // dimensionless diffusion constants for each species
-  std::vector<double> diffConstants;
+  // dimensionless diffusion constants in x,y,z directions for each species
+  // i.e. [{D/dx^2, D/dy^2, D/dz^2}, {}, .. ]
+  std::vector<std::array<double, 3>> diffConstants;
   const geometry::Compartment *comp;
   std::size_t nPixels;
   std::size_t nSpecies;
@@ -139,6 +140,7 @@ private:
   const geometry::Membrane *membrane;
   SimCompartment *compA;
   SimCompartment *compB;
+  common::VolumeF voxelSize{};
   std::size_t nExtraVars{0};
 
 public:

--- a/docs/reference/maths.rst
+++ b/docs/reference/maths.rst
@@ -4,15 +4,15 @@ Maths
 Reaction-Diffusion
 ------------------
 
-The system of PDEs that we simulate in each compartment is the two-dimensional reaction-diffusion equation:
+The system of PDEs that we simulate in each compartment is the three-dimensional reaction-diffusion equation:
 
 .. math::
 
-   \frac{\partial c_s}{\partial t} = D_s \left( \frac{\partial^2}{\partial x^2} + \frac{\partial^2}{\partial y^2} \right) c_s + R_s
+   \frac{\partial c_s}{\partial t} = D_s \left( \frac{\partial^2}{\partial x^2} + \frac{\partial^2}{\partial y^2} + \frac{\partial^2}{\partial z^2} \right) c_s + R_s
 
 where
 
-* :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y)` and time :math:`t`
+* :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y, z)` and time :math:`t`
 * :math:`D_s` is the diffusion constant for species :math:`s`
 * :math:`R_s` is the reaction term for species :math:`s`
 
@@ -21,21 +21,21 @@ and we assume that
 * the diffusion constant :math:`D_s` is a scalar that does not vary with position or time
 * the reaction term :math:`R_s` is a function that can depend on the concentrations of other species in the model, but only locally, i.e. the concentrations at the same spatial coordinate.
 
-.. note::
-
-    This is equivalent to simulating a 3-d system with no spatial variation in the z-direction. In our simulations we then assume that we are simulating a 2-d slice of such a 3-d system with unit length in the z-direction (i.e. the system has extent 1 in the length units of our model in the z-direction). This allows the user to use the usual 3-d units for concentration, etc.
-
 Compartment Reactions
 ---------------------
 
-Compartment reaction terms correspond to the :math:`R_s` term in the reaction-diffusion equation, and describe the rate of change of species concentration with time, and are evaluated at every point inside the compartment
+Compartment reaction terms correspond to the :math:`R_s` term in the reaction-diffusion equation,
+and describe the rate of change of species concentration with time.
+They are evaluated at every point inside the compartment
 
 Membrane reactions
 ------------------
 
-Membrane reactions are reactions that occur on the membrane between two compartments, and describe the species amount that crosses the membrane per unit membrane area per unit time.
+Membrane reactions are reactions that occur on the membrane between two compartments,
+and describe the species amount that crosses the membrane per unit membrane area per unit time.
 
 Boundary Conditions
 -------------------
 
-All boundaries have "zero-flux" Neumann boundary conditions, whether they are boundaries between two compartments or boundaries between a compartment and the outside (except for the flux caused by any membrane reactions).
+All boundaries have "zero-flux" Neumann boundary conditions,
+whether they are boundaries between two compartments or boundaries between a compartment and the outside (except for the flux caused by any membrane reactions).

--- a/gui/dialogs/dialoggeometryimage.cpp
+++ b/gui/dialogs/dialoggeometryimage.cpp
@@ -17,14 +17,16 @@ DialogGeometryImage::DialogGeometryImage(
   ui->lblImage->setZSlider(ui->slideZIndex);
   ui->lblImage->setImage(rescaledImage);
   ui->btnApplyColours->setEnabled(false);
-  for (auto *cmb : {ui->cmbUnitsWidth, ui->cmbUnitsHeight}) {
-    for (const auto &u : units.getLengthUnits()) {
-      cmb->addItem(u.name);
-    }
-    cmb->setCurrentIndex(units.getLengthIndex());
+  for (const auto &u : units.getLengthUnits()) {
+    ui->cmbUnitsWidth->addItem(u.name);
   }
+  ui->cmbUnitsWidth->setCurrentIndex(units.getLengthIndex());
   modelUnitSymbol = ui->cmbUnitsWidth->currentText();
   voxelLocalUnits = voxelModelUnits;
+  auto imageSizeLocalUnits{rescaledImage.volume() * voxelLocalUnits};
+  ui->txtImageWidth->setText(toQStr(imageSizeLocalUnits.width()));
+  ui->txtImageHeight->setText(toQStr(imageSizeLocalUnits.height()));
+  ui->txtImageDepth->setText(toQStr(imageSizeLocalUnits.depth()));
   ui->spinPixelsX->setValue(rescaledImage.volume().width());
   ui->spinPixelsY->setValue(rescaledImage.volume().height());
   ui->lblZSlices->setText(
@@ -45,15 +47,7 @@ DialogGeometryImage::DialogGeometryImage(
   connect(ui->txtImageDepth, &QLineEdit::editingFinished, this,
           &DialogGeometryImage::txtImageDepth_editingFinished);
   connect(ui->cmbUnitsWidth, qOverload<int>(&QComboBox::activated), this,
-          [this](int index) {
-            ui->cmbUnitsHeight->setCurrentIndex(index);
-            updateVoxelSize();
-          });
-  connect(ui->cmbUnitsHeight, qOverload<int>(&QComboBox::activated), this,
-          [this](int index) {
-            ui->cmbUnitsWidth->setCurrentIndex(index);
-            updateVoxelSize();
-          });
+          &DialogGeometryImage::updateVoxelSize);
   connect(ui->spinPixelsX, qOverload<int>(&QSpinBox::valueChanged), this,
           &DialogGeometryImage::spinPixelsX_valueChanged);
   connect(ui->spinPixelsY, qOverload<int>(&QSpinBox::valueChanged), this,
@@ -85,16 +79,30 @@ const sme::common::ImageStack &DialogGeometryImage::getAlteredImage() const {
 }
 
 void DialogGeometryImage::updateVoxelSize() {
-  // calculate image volume in local units
-  auto imageSizeLocalUnits{rescaledImage.volume() * voxelLocalUnits};
-  ui->txtImageWidth->setText(toQStr(imageSizeLocalUnits.width()));
-  ui->txtImageHeight->setText(toQStr(imageSizeLocalUnits.height()));
-  ui->txtImageDepth->setText(toQStr(imageSizeLocalUnits.depth()));
-  // calculate voxel volume in model units
+  // Physical volume in local units
+  bool isValidDouble{false};
+  double imageWidth{ui->txtImageWidth->text().toDouble(&isValidDouble)};
+  if (!isValidDouble) {
+    return;
+  }
+  double imageHeight{ui->txtImageHeight->text().toDouble(&isValidDouble)};
+  if (!isValidDouble) {
+    return;
+  }
+  double imageDepth{ui->txtImageDepth->text().toDouble(&isValidDouble)};
+  if (!isValidDouble) {
+    return;
+  }
+  sme::common::VolumeF volumeLocalUnits{imageWidth, imageHeight, imageDepth};
+  // Physical volume in model units
   const auto &localUnit{
       units.getLengthUnits().at(ui->cmbUnitsWidth->currentIndex())};
   const auto &modelUnit{units.getLength()};
-  voxelModelUnits = sme::model::rescale(voxelLocalUnits, localUnit, modelUnit);
+  sme::common::VolumeF volumeModelUnits{
+      sme::model::rescale(volumeLocalUnits, localUnit, modelUnit)};
+  // Physical voxel volume in model units
+  voxelModelUnits = volumeModelUnits / rescaledImage.volume();
+  ui->lblImage->setPhysicalSize(volumeModelUnits, modelUnit.name);
   ui->lblPixelSize->setText(QString("%1 %4 x %2 %4 x %3 %4")
                                 .arg(voxelModelUnits.width())
                                 .arg(voxelModelUnits.height())
@@ -132,7 +140,6 @@ void DialogGeometryImage::enableWidgets(bool enable) {
   ui->txtImageWidth->setEnabled(enable);
   ui->cmbUnitsWidth->setEnabled(enable);
   ui->txtImageHeight->setEnabled(enable);
-  ui->cmbUnitsHeight->setEnabled(enable);
   ui->txtImageDepth->setEnabled(enable);
   ui->spinPixelsX->setEnabled(enable);
   ui->spinPixelsY->setEnabled(enable);
@@ -154,30 +161,13 @@ void DialogGeometryImage::lblImage_mouseClicked(
   updateColours();
 }
 
-void DialogGeometryImage::txtImageWidth_editingFinished() {
-  double imageWidth{ui->txtImageWidth->text().toDouble()};
-  double voxelWidth{imageWidth /
-                    static_cast<double>(rescaledImage.volume().width())};
-  voxelLocalUnits = {voxelWidth, voxelWidth, voxelLocalUnits.depth()};
-  updateVoxelSize();
-}
+void DialogGeometryImage::txtImageWidth_editingFinished() { updateVoxelSize(); }
 
 void DialogGeometryImage::txtImageHeight_editingFinished() {
-  double imageHeight{ui->txtImageHeight->text().toDouble()};
-  double voxelHeight{imageHeight /
-                     static_cast<double>(rescaledImage.volume().height())};
-  voxelLocalUnits = {voxelHeight, voxelHeight, voxelLocalUnits.depth()};
   updateVoxelSize();
 }
 
-void DialogGeometryImage::txtImageDepth_editingFinished() {
-  double imageDepth{ui->txtImageDepth->text().toDouble()};
-  double voxelDepth{imageDepth /
-                    static_cast<double>(rescaledImage.volume().depth())};
-  voxelLocalUnits = {voxelLocalUnits.width(), voxelLocalUnits.height(),
-                     voxelDepth};
-  updateVoxelSize();
-}
+void DialogGeometryImage::txtImageDepth_editingFinished() { updateVoxelSize(); }
 
 void DialogGeometryImage::spinPixelsX_valueChanged(int value) {
   if (value <= 0) {
@@ -186,12 +176,16 @@ void DialogGeometryImage::spinPixelsX_valueChanged(int value) {
   if (value != coloredImage.volume().width()) {
     alteredSize = true;
   }
-  rescaledImage = coloredImage.scaledToWidth(value);
+  if (ui->chkKeepAspectRatio->isChecked()) {
+    rescaledImage = coloredImage.scaledToWidth(value);
+    ui->spinPixelsY->blockSignals(true);
+    ui->spinPixelsY->setValue(rescaledImage.volume().height());
+    ui->spinPixelsY->blockSignals(false);
+  } else {
+    rescaledImage = coloredImage.scaled(value, rescaledImage.volume().height());
+  }
   ui->lblImage->setImage(rescaledImage);
-  ui->spinPixelsY->blockSignals(true);
-  ui->spinPixelsY->setValue(rescaledImage.volume().height());
-  ui->spinPixelsY->blockSignals(false);
-  txtImageWidth_editingFinished();
+  updateVoxelSize();
 }
 
 void DialogGeometryImage::spinPixelsY_valueChanged(int value) {
@@ -201,12 +195,16 @@ void DialogGeometryImage::spinPixelsY_valueChanged(int value) {
   if (value != coloredImage.volume().height()) {
     alteredSize = true;
   }
-  rescaledImage = coloredImage.scaledToHeight(value);
+  if (ui->chkKeepAspectRatio->isChecked()) {
+    rescaledImage = coloredImage.scaledToHeight(value);
+    ui->spinPixelsX->blockSignals(true);
+    ui->spinPixelsX->setValue(rescaledImage.volume().width());
+    ui->spinPixelsX->blockSignals(false);
+  } else {
+    rescaledImage = coloredImage.scaled(rescaledImage.volume().width(), value);
+  }
   ui->lblImage->setImage(rescaledImage);
-  ui->spinPixelsX->blockSignals(true);
-  ui->spinPixelsX->setValue(rescaledImage.volume().width());
-  ui->spinPixelsX->blockSignals(false);
-  txtImageHeight_editingFinished();
+  updateVoxelSize();
 }
 
 void DialogGeometryImage::btnResetPixels_clicked() {

--- a/gui/dialogs/dialoggeometryimage.ui
+++ b/gui/dialogs/dialoggeometryimage.ui
@@ -52,19 +52,6 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QSpinBox" name="spinPixelsX">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>4096</number>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1" colspan="5">
       <widget class="QSlider" name="slideZIndex">
        <property name="orientation">
@@ -97,9 +84,6 @@
         <number>4096</number>
        </property>
       </widget>
-     </item>
-     <item row="3" column="5">
-      <widget class="QComboBox" name="cmbUnitsHeight"/>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="lblLabelImageHeight">
@@ -157,13 +141,6 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="5">
-      <widget class="QLabel" name="lblUnitsDepth">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
      <item row="5" column="5">
       <widget class="QPushButton" name="btnResetPixels">
        <property name="text">
@@ -203,7 +180,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Voxel count:</string>
+        <string>Image resolution:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -228,19 +205,6 @@
      </item>
      <item row="2" column="5">
       <widget class="QComboBox" name="cmbUnitsWidth"/>
-     </item>
-     <item row="5" column="2">
-      <widget class="QLabel" name="lblLabelPixelsTimes">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>x</string>
-       </property>
-      </widget>
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="lblLabelColours">
@@ -274,6 +238,29 @@
      <item row="4" column="1" colspan="4">
       <widget class="QLineEdit" name="txtImageDepth"/>
      </item>
+     <item row="5" column="2">
+      <widget class="QSpinBox" name="spinPixelsX">
+       <property name="suffix">
+        <string>px</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>4096</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="chkKeepAspectRatio">
+       <property name="text">
+        <string>Fix aspect ratio</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -300,8 +287,8 @@
   <tabstop>txtImageWidth</tabstop>
   <tabstop>cmbUnitsWidth</tabstop>
   <tabstop>txtImageHeight</tabstop>
-  <tabstop>cmbUnitsHeight</tabstop>
   <tabstop>txtImageDepth</tabstop>
+  <tabstop>chkKeepAspectRatio</tabstop>
   <tabstop>spinPixelsX</tabstop>
   <tabstop>spinPixelsY</tabstop>
   <tabstop>btnResetPixels</tabstop>

--- a/gui/dialogs/dialoggeometryimage_t.cpp
+++ b/gui/dialogs/dialoggeometryimage_t.cpp
@@ -40,70 +40,70 @@ TEST_CASE("DialogGeometryImage",
   REQUIRE(btnApplyColours != nullptr);
   auto *btnResetColours{dim.findChild<QPushButton *>("btnResetColours")};
   REQUIRE(btnResetColours != nullptr);
-  SECTION("user sets width to 1, same units, pixel volume -> 0.01") {
+  SECTION("user sets width to 1, same units, width -> 0.01") {
     mwt.addUserAction({"Tab", "1"});
     mwt.start();
     dim.exec();
     REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.01));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.01));
+    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
-  SECTION("user sets width to 1e-8, pixel volume -> 1e-10") {
+  SECTION("user sets width to 1e-8, width -> 1e-10") {
     mwt.addUserAction({"Tab", "1", "e", "-", "8"});
     mwt.start();
     dim.exec();
     REQUIRE(dim.getVoxelSize().width() == dbl_approx(1e-10));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1e-10));
+    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
-  SECTION("user sets height to 10, pixel volume -> 0.2") {
+  SECTION("user sets height to 10, height -> 0.2") {
     mwt.addUserAction({"Tab", "Tab", "Tab", "1", "0"});
     mwt.start();
     dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.2));
+    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
     REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.2));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
-  SECTION("user sets height to 10, units to dm, pixel volume -> 0.02") {
+  SECTION("user sets height to 10, units to dm, height -> 0.02, others /=10") {
     mwt.addUserAction({"Tab", "Tab", "Down", "Tab", "1", "0"});
     mwt.start();
     dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.02));
+    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.1));
     REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.02));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(0.1));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
-  SECTION("user sets height to 10, units to cm, pixel volume -> 0.002") {
+  SECTION(
+      "user sets height to 10, units to cm, height -> 0.002, others /=100") {
     mwt.addUserAction({"Tab", "Tab", "Down", "Down", "Tab", "1", "0"});
     mwt.start();
     dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.002));
+    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.01));
     REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.002));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(0.01));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
-  SECTION("user sets width to 9 & units to dm, then height 10, units um,"
-          " pixel volume -> 0.0000002") {
-    mwt.addUserAction({"Tab", "9", "Tab", "Down", "Tab", "1", "0", "Tab",
+  SECTION("user sets width to 9 & units to dm, then height 10, units um") {
+    mwt.addUserAction({"Tab", "9", "Tab", "Down", "Tab", "1", "0", "Shift+Tab",
                        "Down", "Down", "Down"});
     mwt.start();
     dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.0000002));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.0000002));
+    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.09 * 1e-6));
+    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.2 * 1e-6));
     REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1e-6));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
   SECTION("user sets depth to 4, no change of units") {
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Backspace", "4"});
+    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Backspace", "4"});
     mwt.start();
     dim.exec();
     REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
@@ -122,8 +122,8 @@ TEST_CASE("DialogGeometryImage",
     mwt.start();
     dim2.exec();
     REQUIRE(dim2.getVoxelSize().width() == dbl_approx(10.0));
-    REQUIRE(dim2.getVoxelSize().height() == dbl_approx(10.0));
-    REQUIRE(dim2.getVoxelSize().depth() == dbl_approx(1000.0));
+    REQUIRE(dim2.getVoxelSize().height() == dbl_approx(22e3));
+    REQUIRE(dim2.getVoxelSize().depth() == dbl_approx(1e3));
     REQUIRE(dim.imageSizeAltered() == false);
     REQUIRE(dim.imageColoursAltered() == false);
   }
@@ -179,8 +179,8 @@ TEST_CASE("DialogGeometryImage",
     REQUIRE(dim.getAlteredImage().volume().width() == 100);
     REQUIRE(dim.getAlteredImage().volume().height() == 50);
     REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Tab",
-                       "5", "Tab", "Space", "Tab", "Tab", "Tab"});
+    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Tab", "5",
+                       "Tab", "Space", "Tab", "Tab", "Tab"});
     mwt.start();
     dim.exec();
     REQUIRE(dim.imageSizeAltered() == false);
@@ -204,7 +204,7 @@ TEST_CASE("DialogGeometryImage",
     REQUIRE(dim.getAlteredImage().volume().height() == 50);
     REQUIRE(dim.getAlteredImage().volume().depth() == 1);
     mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab",
-                       "Tab", "Space", "Space", "Tab"});
+                       "Space", "Space", "Tab"});
     mwt.start();
     dim.exec();
     REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -543,19 +543,19 @@ void MainWindow::actionEdit_geometry_image_triggered() {
                              model.getUnits());
   if (dialog.exec() == QDialog::Accepted) {
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    auto voxelSize{dialog.getVoxelSize()};
-    SPDLOG_INFO("Set new voxel volume {}x{}x{}", voxelSize.width(),
-                voxelSize.height(), voxelSize.depth());
-    model.getGeometry().setVoxelSize(voxelSize);
     tabSimulate->reset();
     if (dialog.imageSizeAltered() || dialog.imageColoursAltered()) {
       SPDLOG_INFO("Importing altered geometry image");
       bool keepColourAssignments{!dialog.imageColoursAltered()};
       model.getGeometry().importGeometryFromImages(dialog.getAlteredImage(),
                                                    keepColourAssignments);
-      ui->tabMain->setCurrentIndex(0);
-      tabMain_currentChanged(0);
     }
+    auto voxelSize{dialog.getVoxelSize()};
+    SPDLOG_INFO("Set new voxel volume {}x{}x{}", voxelSize.width(),
+                voxelSize.height(), voxelSize.depth());
+    model.getGeometry().setVoxelSize(voxelSize);
+    ui->tabMain->setCurrentIndex(0);
+    tabMain_currentChanged(0);
     enableTabs();
     QGuiApplication::restoreOverrideCursor();
   }

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -594,7 +594,7 @@
      <bool>true</bool>
     </property>
     <property name="text">
-     <string>&amp;DUNE (high quality)</string>
+     <string>&amp;DUNE (FEM)</string>
     </property>
    </action>
    <action name="actionSimTypePixel">
@@ -605,7 +605,7 @@
      <bool>false</bool>
     </property>
     <property name="text">
-     <string>&amp;Pixel (fast but unreliable)</string>
+     <string>&amp;Pixel (FDM)</string>
     </property>
    </action>
   </actiongroup>

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -96,6 +96,8 @@ void TabGeometry::loadModelData(const QString &selection) {
     ui->btnChangeCompartment->setEnabled(true);
   }
   lblGeometry->setImage(model.getGeometry().getImages());
+  lblGeometry->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                               model.getUnits().getLength().name);
   enableTabs();
   selectMatchingOrFirstItem(ui->listCompartments, selection);
 }
@@ -318,6 +320,8 @@ void TabGeometry::spinBoundaryIndex_valueChanged(int value) {
       model.getGeometry().getMesh()->getBoundaryMaxPoints(boundaryIndex)));
   ui->lblCompBoundary->setImages(
       model.getGeometry().getMesh()->getBoundariesImages(size, boundaryIndex));
+  ui->lblCompBoundary->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                       model.getUnits().getLength().name);
   QGuiApplication::restoreOverrideCursor();
 }
 
@@ -329,6 +333,8 @@ void TabGeometry::spinMaxBoundaryPoints_valueChanged(int value) {
       boundaryIndex, static_cast<size_t>(value));
   ui->lblCompBoundary->setImages(
       model.getGeometry().getMesh()->getBoundariesImages(size, boundaryIndex));
+  ui->lblCompBoundary->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                       model.getUnits().getLength().name);
   QGuiApplication::restoreOverrideCursor();
 }
 
@@ -369,6 +375,8 @@ void TabGeometry::spinMaxTriangleArea_valueChanged(int value) {
       compIndex, static_cast<std::size_t>(value));
   ui->lblCompMesh->setImages(
       model.getGeometry().getMesh()->getMeshImages(size, compIndex));
+  ui->lblCompMesh->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                   model.getUnits().getLength().name);
   QGuiApplication::restoreOverrideCursor();
 }
 
@@ -429,13 +437,15 @@ void TabGeometry::listCompartments_itemSelectionChanged() {
     // update image of compartment
     const auto *comp{model.getCompartments().getCompartment(compId)};
     ui->lblCompShape->setImage(comp->getCompartmentImages());
+    ui->lblCompShape->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                      model.getUnits().getLength().name);
     ui->lblCompShape->setText("");
     // update mesh or boundary image if tab is currently visible
     tabCompartmentGeometry_currentChanged(
         ui->tabCompartmentGeometry->currentIndex());
     // update compartment volume
     double volume{model.getCompartments().getSize(compId)};
-    ui->lblCompSize->setText(QString("Volume: %1 %2 (%3 pixels)")
+    ui->lblCompSize->setText(QString("Volume: %1 %2 (%3 voxels)")
                                  .arg(QString::number(volume, 'g', 13))
                                  .arg(model.getUnits().getVolume().name)
                                  .arg(comp->nVoxels()));
@@ -469,7 +479,11 @@ void TabGeometry::listMembranes_itemSelectionChanged() {
   // update image
   const auto *m{model.getMembranes().getMembrane(membraneId)};
   ui->lblCompShape->setImage(m->getImages());
-  auto nPixels{m->getIndexPairs().size()};
+  ui->lblCompShape->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                    model.getUnits().getLength().name);
+  auto nVoxelPairs{m->getIndexPairs(sme::geometry::Membrane::X).size() +
+                   m->getIndexPairs(sme::geometry::Membrane::Y).size() +
+                   m->getIndexPairs(sme::geometry::Membrane::Z).size()};
   // update colour box
   QImage img(1, 2, QImage::Format_RGB32);
   img.setPixel(0, 0, m->getCompartmentA()->getColour());
@@ -478,13 +492,15 @@ void TabGeometry::listMembranes_itemSelectionChanged() {
   ui->lblCompartmentColour->setText("");
   // update membrane length
   double area{model.getMembranes().getSize(membraneId)};
-  ui->lblCompSize->setText(QString("Area: %1 %2^2 (%3 pixels)")
+  ui->lblCompSize->setText(QString("Area: %1 %2^2 (%3 voxel faces)")
                                .arg(QString::number(area, 'g', 13))
                                .arg(model.getUnits().getLength().name)
-                               .arg(nPixels));
+                               .arg(nVoxelPairs));
   if (const auto *mesh{model.getGeometry().getMesh()}; mesh != nullptr) {
     ui->lblCompMesh->setImages(mesh->getMeshImages(
         ui->lblCompMesh->size(),
         static_cast<std::size_t>(currentRow + ui->listCompartments->count())));
+    ui->lblCompMesh->setPhysicalSize(model.getGeometry().getPhysicalSize(),
+                                     model.getUnits().getLength().name);
   }
 }

--- a/gui/tabs/tabgeometry_t.cpp
+++ b/gui/tabs/tabgeometry_t.cpp
@@ -68,7 +68,7 @@ TEST_CASE("TabGeometry",
       // select compartments
       REQUIRE(listCompartments->currentItem()->text() == "Outside");
       REQUIRE(txtCompartmentName->text() == "Outside");
-      REQUIRE(lblCompSize->text() == "Volume: 5441000 L (5441 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 5441000 L (5441 voxels)");
       REQUIRE(tabCompartmentGeometry->currentIndex() == 0);
       REQUIRE(lblCompShape->getImage().volume().depth() == 1);
       REQUIRE(lblCompShape->getImage()[0].pixel(1, 1) == 0xff000200);
@@ -86,7 +86,7 @@ TEST_CASE("TabGeometry",
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Cell");
-      REQUIRE(lblCompSize->text() == "Volume: 4034000 L (4034 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 4034000 L (4034 voxels)");
       REQUIRE(lblCompShape->getImage()[0].pixel(20, 20) == 0xff9061c1);
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Cell");
@@ -95,7 +95,7 @@ TEST_CASE("TabGeometry",
       sendKeyEvents(listMembranes, {" "});
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(listMembranes->currentItem()->text() == "Outside <-> Cell");
-      REQUIRE(lblCompSize->text() == "Area: 338 m^2 (338 pixels)");
+      REQUIRE(lblCompSize->text() == "Area: 338 m^2 (338 voxel faces)");
       REQUIRE(txtCompartmentName->text() == "Outside <-> Cell");
       // change membrane name
       txtCompartmentName->setFocus();
@@ -111,7 +111,7 @@ TEST_CASE("TabGeometry",
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Nucleus");
-      REQUIRE(lblCompSize->text() == "Volume: 525000 L (525 pixels)");
+      REQUIRE(lblCompSize->text() == "Volume: 525000 L (525 voxels)");
       REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Nucleus");
       REQUIRE(lblCompShape->getImage()[0].pixel(50, 50) == 0xffc58560);

--- a/gui/widgets/qlabelmousetracker.cpp
+++ b/gui/widgets/qlabelmousetracker.cpp
@@ -156,9 +156,8 @@ static std::pair<double, double>
 getGridWidth(const sme::common::VolumeF &physicalSize, const QSize &imageSize) {
   constexpr double minWidthPixels{20};
   // start with grid of width 1 physical unit
-  double gridPixelWidth{static_cast<double>(imageSize.width()) /
-                        physicalSize.width()};
-  double gridPhysicalWidth{1.0};
+  double gridPixelWidth{static_cast<double>(imageSize.width())};
+  double gridPhysicalWidth{physicalSize.width()};
   // rescale with in pixels to: ~ [1, 2] * minWidthPixels
   // hopefully with reasonably nice looking numerical intervals
   while (gridPixelWidth < minWidthPixels) {
@@ -189,14 +188,19 @@ static QString getGridPointLabel(int i, double gridPhysicalWidth,
   return label;
 }
 
-static QSize getActualImageSize(const QSize &before, const QSize &after) {
-  QSize sz{after};
-  if (after.width() * before.height() > after.height() * before.width()) {
-    sz.rwidth() = before.width() * after.height() / before.height();
-  } else {
-    sz.rheight() = before.height() * after.width() / before.width();
+static QSize getPixmapSize(const QSize &displaySize,
+                           double physicalAspectRatio) {
+  double displayAspectRatio{static_cast<double>(displaySize.width()) /
+                            static_cast<double>(displaySize.height())};
+  if (displayAspectRatio > physicalAspectRatio) {
+    return {std::max(1, static_cast<int>(displaySize.height() *
+                                         physicalAspectRatio)),
+            displaySize.height()};
   }
-  return sz;
+  return {
+      displaySize.width(),
+      std::max(1, static_cast<int>(displaySize.width() / physicalAspectRatio)),
+  };
 }
 
 void QLabelMouseTracker::resizeImage(const QSize &size) {
@@ -221,10 +225,10 @@ void QLabelMouseTracker::resizeImage(const QSize &size) {
   QSize availableSize{size};
   availableSize.rwidth() -= offset.x();
   availableSize.rheight() -= offset.y();
-  auto scaledImage{image[currentVoxel.z].scaled(availableSize, aspectRatioMode,
-                                                transformationMode)};
-  pixmapImageSize =
-      getActualImageSize(image[currentVoxel.z].size(), scaledImage.size());
+  pixmapImageSize = getPixmapSize(availableSize,
+                                  physicalSize.width() / physicalSize.height());
+  auto scaledImage{image[currentVoxel.z].scaled(
+      pixmapImageSize, aspectRatioMode, transformationMode)};
   p.drawImage(QPoint(offset.x(), 0), scaledImage);
   SPDLOG_DEBUG("resize -> {}x{}, pixmap -> {}x{}, image -> {}x{}", size.width(),
                size.height(), pixmap.width(), pixmap.height(),

--- a/gui/widgets/qlabelmousetracker.hpp
+++ b/gui/widgets/qlabelmousetracker.hpp
@@ -58,14 +58,14 @@ protected:
 
 private:
   QSlider *zSlider{nullptr};
-  Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio;
+  Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio;
   Qt::TransformationMode transformationMode = Qt::FastTransformation;
   bool setCurrentPixel(const QPoint &pos);
   void resizeImage(const QSize &size);
   sme::common::ImageStack image;
   // Pixmap used to display scaled version of image
   QPixmap pixmap;
-  // volume of actual image in pixmap (may be smaller than pixmap)
+  // size of actual image in pixmap (may be smaller than pixmap)
   QSize pixmapImageSize;
   sme::common::ImageStack maskImage;
   sme::common::Voxel currentVoxel{0, 0, 0};

--- a/gui/widgets/qlabelmousetracker_t.cpp
+++ b/gui/widgets/qlabelmousetracker_t.cpp
@@ -4,7 +4,8 @@
 
 using namespace sme::test;
 
-static const char *tags{"[gui/widgets/qlabelmousetracker][gui/widgets][gui]"};
+static const char *tags{
+    "[qlabelmousetracker][gui/widgets/qlabelmousetracker][gui/widgets][gui]"};
 
 TEST_CASE("QLabelMouseTracker: single pixel, single colour image", tags) {
   QLabelMouseTracker mouseTracker;
@@ -81,85 +82,145 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
   REQUIRE(mouseTracker.getImage()[0].pixel(2, 2) == img.pixel(2, 2));
   int imgDisplaySize = std::min(mouseTracker.width(), mouseTracker.height());
   CAPTURE(imgDisplaySize);
-
   std::vector<QRgb> clicks;
   QObject::connect(&mouseTracker, &QLabelMouseTracker::mouseClicked,
                    [&clicks](QRgb c) { clicks.push_back(c); });
-  REQUIRE(clicks.size() == 0);
-  // mouse click (0,1)
-  // pix (0,0) <-> col2
-  sendMouseMove(&mouseTracker, {99, 99});
-  sendMouseClick(&mouseTracker, {0, 1});
-  REQUIRE(clicks.size() == 1);
-  REQUIRE(clicks.back() == col2);
-  REQUIRE(mouseTracker.getColour() == col2);
 
-  // mouse click (3,7)
-  // pix (0,0) <-> col2
-  sendMouseClick(&mouseTracker, {3, 7});
-  REQUIRE(clicks.size() == 2);
-  REQUIRE(clicks.back() == col2);
-  REQUIRE(mouseTracker.getColour() == col2);
+  SECTION("Resize QLabelMousetracker widget") {
+    REQUIRE(clicks.size() == 0);
+    // mouse click (0,1)
+    // pix (0,0) <-> col2
+    sendMouseMove(&mouseTracker, {99, 99});
+    sendMouseClick(&mouseTracker, {0, 1});
+    REQUIRE(clicks.size() == 1);
+    REQUIRE(clicks.back() == col2);
+    REQUIRE(mouseTracker.getColour() == col2);
 
-  // mouse click (5,44)
-  // pix (0,1) <-> col3
-  sendMouseClick(&mouseTracker,
-                 QPoint(static_cast<int>(0.05 * imgDisplaySize),
-                        static_cast<int>(0.44 * imgDisplaySize)));
-  REQUIRE(clicks.size() == 3);
-  REQUIRE(clicks.back() == col3);
-  REQUIRE(mouseTracker.getColour() == col3);
+    // mouse click (3,7)
+    // pix (0,0) <-> col2
+    sendMouseClick(&mouseTracker, {3, 7});
+    REQUIRE(clicks.size() == 2);
+    REQUIRE(clicks.back() == col2);
+    REQUIRE(mouseTracker.getColour() == col2);
 
-  // mouse click (5,84)
-  // pix (0,2) <-> col3
-  sendMouseClick(&mouseTracker,
-                 QPoint(static_cast<int>(0.05 * imgDisplaySize),
-                        static_cast<int>(0.84 * imgDisplaySize)));
-  REQUIRE(clicks.size() == 4);
-  REQUIRE(clicks.back() == col3);
-  REQUIRE(mouseTracker.getColour() == col3);
+    // mouse click (5,44)
+    // pix (0,1) <-> col3
+    sendMouseClick(&mouseTracker,
+                   QPoint(static_cast<int>(0.05 * imgDisplaySize),
+                          static_cast<int>(0.44 * imgDisplaySize)));
+    REQUIRE(clicks.size() == 3);
+    REQUIRE(clicks.back() == col3);
+    REQUIRE(mouseTracker.getColour() == col3);
 
-  // mouse clicks (99,99), (5,84), (50,50)
-  // pix (2,2),(0,2),(1,1) <-> col1,col3,col4
-  clicks.clear();
-  sendMouseClick(&mouseTracker, {99, 99});
-  sendMouseMove(&mouseTracker, {79, 19});
-  REQUIRE(mouseTracker.getRelativePosition().x() == dbl_approx(2.0 / 3.0));
-  REQUIRE(mouseTracker.getRelativePosition().y() == dbl_approx(0.0));
-  sendMouseClick(&mouseTracker, {5, 84});
-  sendMouseClick(&mouseTracker, {50, 50});
-  REQUIRE(clicks.size() == 3);
-  REQUIRE(clicks[0] == col1);
-  REQUIRE(clicks[1] == col3);
-  REQUIRE(clicks[2] == col4);
-  REQUIRE(mouseTracker.getColour() == col4);
+    // mouse click (5,84)
+    // pix (0,2) <-> col3
+    sendMouseClick(&mouseTracker,
+                   QPoint(static_cast<int>(0.05 * imgDisplaySize),
+                          static_cast<int>(0.84 * imgDisplaySize)));
+    REQUIRE(clicks.size() == 4);
+    REQUIRE(clicks.back() == col3);
+    REQUIRE(mouseTracker.getColour() == col3);
 
-  // resized to 600x600, mouseclick (300,300)
-  // pix (1,1) <-> col4
-  mouseTracker.resize(600, 600);
-  wait();
-  sendMouseClick(&mouseTracker, {300, 300});
-  REQUIRE(clicks.size() == 4);
-  REQUIRE(clicks.back() == col4);
-  REQUIRE(mouseTracker.getColour() == col4);
+    // mouse clicks (99,99), (5,84), (50,50)
+    // pix (2,2),(0,2),(1,1) <-> col1,col3,col4
+    clicks.clear();
+    sendMouseClick(&mouseTracker, {99, 99});
+    sendMouseMove(&mouseTracker, {79, 19});
+    REQUIRE(mouseTracker.getRelativePosition().x() == dbl_approx(2.0 / 3.0));
+    REQUIRE(mouseTracker.getRelativePosition().y() == dbl_approx(0.0));
+    sendMouseClick(&mouseTracker, {5, 84});
+    sendMouseClick(&mouseTracker, {50, 50});
+    REQUIRE(clicks.size() == 3);
+    REQUIRE(clicks[0] == col1);
+    REQUIRE(clicks[1] == col3);
+    REQUIRE(clicks[2] == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
 
-  // resized to 6x6, mouseclick (1,3)
-  // pix (0,1) <-> col3
-  mouseTracker.resize(6, 6);
-  wait();
-  sendMouseClick(&mouseTracker, {1, 3});
-  REQUIRE(clicks.size() == 5);
-  REQUIRE(clicks.back() == col3);
-  REQUIRE(mouseTracker.getColour() == col3);
+    // resized to 600x600, mouseclick (300,300)
+    // pix (1,1) <-> col4
+    mouseTracker.resize(600, 600);
+    wait();
+    sendMouseClick(&mouseTracker, {300, 300});
+    REQUIRE(clicks.size() == 4);
+    REQUIRE(clicks.back() == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
 
-  // resized to 900x3, mouseclick (2,2)
-  // pix (2,0) <-> col1
-  mouseTracker.resize(900, 3);
-  wait();
-  sendMouseClick(&mouseTracker, {2, 2});
-  REQUIRE(clicks.size() == 6);
-  REQUIRE(clicks.back() == col1);
-  REQUIRE(mouseTracker.getColour() == col1);
+    // resized to 6x6, mouseclick (1,3)
+    // pix (0,1) <-> col3
+    mouseTracker.resize(6, 6);
+    wait();
+    sendMouseClick(&mouseTracker, {1, 3});
+    REQUIRE(clicks.size() == 5);
+    REQUIRE(clicks.back() == col3);
+    REQUIRE(mouseTracker.getColour() == col3);
+
+    // resized to 900x3, mouseclick (2,2)
+    // pix (2,0) <-> col1
+    mouseTracker.resize(900, 3);
+    wait();
+    sendMouseClick(&mouseTracker, {2, 2});
+    REQUIRE(clicks.size() == 6);
+    REQUIRE(clicks.back() == col1);
+    REQUIRE(mouseTracker.getColour() == col1);
+  }
+  SECTION("Resize physical volume") {
+    // 100px x 100px mousetracker widget size:
+    // 1:1 aspect ratio physical size
+    mouseTracker.setPhysicalSize({0.77, 0.77, 0.77}, "");
+    // click on middle (1,1) pixel
+    sendMouseClick(&mouseTracker, QPoint(50, 50));
+    REQUIRE(clicks.size() == 1);
+    REQUIRE(clicks.back() == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
+    // 2:1 aspect ratio physical size
+    mouseTracker.setPhysicalSize({2.0, 1.0, 1.0}, "");
+    // click outside geometry
+    sendMouseClick(&mouseTracker, QPoint(50, 52));
+    REQUIRE(clicks.size() == 1);
+    // click on middle (1,1) pixel
+    sendMouseClick(&mouseTracker, QPoint(50, 25));
+    REQUIRE(clicks.size() == 2);
+    REQUIRE(clicks.back() == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
+    // 5:1 aspect ratio physical size
+    mouseTracker.setPhysicalSize({50.0, 10.0, 1.0}, "");
+    // click outside geometry
+    sendMouseClick(&mouseTracker, QPoint(50, 22));
+    REQUIRE(clicks.size() == 2);
+    // click on middle (1,1) pixel
+    sendMouseClick(&mouseTracker, QPoint(50, 10));
+    REQUIRE(clicks.size() == 3);
+    REQUIRE(clicks.back() == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
+    // 1:3 aspect ratio physical size
+    mouseTracker.setPhysicalSize({3.0, 9.0, 1.0}, "");
+    // click outside geometry
+    sendMouseClick(&mouseTracker, QPoint(35, 50));
+    REQUIRE(clicks.size() == 3);
+    // click on middle (1,1) pixel
+    sendMouseClick(&mouseTracker, QPoint(17, 50));
+    REQUIRE(clicks.size() == 4);
+    REQUIRE(clicks.back() == col4);
+    REQUIRE(mouseTracker.getColour() == col4);
+    // 1:100000 aspect ratio physical size: display width clipped to single
+    // pixel
+    mouseTracker.setPhysicalSize({1.0, 100000.0, 1.0}, "");
+    // click outside geometry
+    sendMouseClick(&mouseTracker, QPoint(3, 50));
+    REQUIRE(clicks.size() == 4);
+    // click on geometry
+    sendMouseClick(&mouseTracker, QPoint(0, 50));
+    REQUIRE(clicks.size() == 5);
+    // 100000:1 aspect ratio physical size: display height clipped to single
+    // pixel
+    mouseTracker.setPhysicalSize({100000.0, 1.0, 1.0}, "");
+    // click outside geometry
+    sendMouseClick(&mouseTracker, QPoint(50, 3));
+    REQUIRE(clicks.size() == 5);
+    // click on geometry
+    sendMouseClick(&mouseTracker, QPoint(50, 0));
+    REQUIRE(clicks.size() == 6);
+  }
 }
 
 TEST_CASE("QLabelMouseTracker: image and mask", tags) {


### PR DESCRIPTION
  - update docs
    - non-uniform grid laplacian & euler stability bounds
  - `geometry::Membrane`
    - provide a vector of indexPairs for each flux direction
    - remove unused non-const getIndexPairs()
    - don't store voxelPairs vector
  - export to sbml calculates correct membrane area for non-cubic voxels
  - `Pixel`
    - support non-cubic voxels in diffusion term
    - spatially dependent reaction terms support non-cubic voxels
    - update Euler stability bound
    - do each flux direction separately for membrane reaction terms
      - divide by length of voxel in this direction to give change in concentration for that voxel
  - `TabGeometry`
    - "pixels" -> "voxels" / "voxel faces" as appropriate
  - `DialogGeometryImage`
    - allow width/height to be edited separately -> non-square xy pixels
    - allow x/y resolution to be modified either together maintaining aspect ratio or separately
  - `QLabelMouseTracker`
    - adjust displayed image aspect ratio according to physical size
  - Mesh generation
    - Mesh supports non-cubic voxels
    - Note: currently non-isotropic meshing is suboptimal
      - meshing is first done with unit pixel size, then scaled to physical size
      - should adapt this to triangulate using correct aspect ratio, maybe even correct physical points?
  - Dune
    - mesh generation and functions now support non-isotropic voxels
  - resolves #879
