### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
         script: [codecov, sonar, asan, ubsan]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ccache-${{ github.job }}-${{ matrix.script }}-${{ runner.os }}-
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Get static libs
         run: sudo ./ci/getlibs.sh linux
       - name: Install apt dependencies and use clang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
     - name: Set "latest" version number unless commit is tagged
@@ -35,7 +35,7 @@ jobs:
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Get static libs
       run: sudo ./ci/getlibs.sh linux
     - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Set "latest" version number unless commit is tagged
@@ -67,7 +67,7 @@ jobs:
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Get static libs
         run: sudo ./ci/getlibs.sh osx
       - name: Build script
@@ -83,7 +83,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CIBUILDWHEEL_VERSION: 2.14.0
+  CIBUILDWHEEL_VERSION: 2.16.0
   CIBW_BUILD_VERBOSITY: 3
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
       CIBW_ENVIRONMENT: 'CMAKE_ARGS="-DSME_BUILD_CORE=off -DCMAKE_PREFIX_PATH=/opt/smelibs;/opt/smelibs/lib64/cmake"'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
     - name: Set "latest" version number unless commit is tagged
@@ -45,7 +45,7 @@ jobs:
         restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==$CIBUILDWHEEL_VERSION
     - name: Build wheels
@@ -65,7 +65,7 @@ jobs:
       CIBW_SKIP: 'pp*-*'
       CIBW_TEST_SKIP: 'pp3*-macosx_x86_64'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Set "latest" version number unless commit is tagged
@@ -79,7 +79,7 @@ jobs:
           restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Download static libraries
         run: sudo ./ci/getlibs.sh osx
       - name: Build wheels
@@ -99,7 +99,7 @@ jobs:
       CIBW_SKIP: 'pp*-*'
       CIBW_TEST_SKIP: "pp3*-win_amd64"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2
@@ -145,7 +145,7 @@ jobs:
           verbose: true
       - run: |
           mkdir latest
-          mv dist/sme-*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl latest/sme-latest-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+          mv dist/sme-*-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl latest/sme-latest-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - uses: svenstaro/upload-release-action@v2
         # if this is an untagged commit to main: upload selected wheels to github latest release
         if: github.ref == 'refs/heads/main'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     - id: requirements-txt-fixer
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     - id: black
     - id: black-jupyter

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.11"
   apt_packages:
     - ffmpeg
 

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -4,7 +4,7 @@
 
 set -e -x
 
-PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.10.*)
+PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.11.*)
 export PATH="$PYDIR/x64:$PYDIR/x64/Scripts:$PATH"
 echo "PATH=$PATH"
 
@@ -46,7 +46,7 @@ make -j2 VERBOSE=1
 ccache -s -v
 
 # check dependencies
-objdump.exe -x sme/sme.cp310-win_amd64.pyd > sme_obj.txt
+objdump.exe -x sme/sme.cp311-win_amd64.pyd > sme_obj.txt
 head -n 20 sme_obj.txt
 head -n 1000 sme_obj.txt | grep "DLL Name"
 
@@ -57,7 +57,7 @@ tail -n 100 tests.txt
 
 # python tests
 cd ..
-mv build/sme/sme.cp310-win_amd64.pyd .
+mv build/sme/sme.cp311-win_amd64.pyd .
 python -m pip install -r sme/requirements-test.txt
 python -m pytest sme/test -v
 

--- a/ci/windows-wheels.sh
+++ b/ci/windows-wheels.sh
@@ -4,7 +4,7 @@
 
 set -e -x
 
-PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.10.*)
+PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.11.*)
 export PATH="$PYDIR/x64:$PYDIR/x64/Scripts:$PATH"
 echo "PATH=$PATH"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 breathe
 docutils
-https://github.com/spatial-model-editor/spatial-model-editor/releases/download/latest/sme-latest-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+https://github.com/spatial-model-editor/spatial-model-editor/releases/download/latest/sme-latest-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 ipykernel
 matplotlib
 myst_parser


### PR DESCRIPTION
- use Python 3.11 in CI and docs build
- bump cibuildwheel to 2.16 (adds Python 3.12 support)
- bump checkout to v4
