### PR TITLE
Drop Qt5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,38 +27,20 @@ set(CMAKE_CTEST_ARGUMENTS "-j${NPROC};--progress;--output-on-failure;-E;gui")
 find_package(dune-copasi REQUIRED)
 
 # find required Qt modules
-option(
-  SME_WITH_QT6
-  "Use Qt6"
-  ON)
-if(SME_WITH_QT6)
-  find_package(
-    Qt6 QUIET
-    COMPONENTS Core
-               Gui
-               Widgets
-               OpenGLWidgets
-               OpenGL)
-endif()
-if(NOT Qt6_FOUND)
-  find_package(
-    Qt5
-    COMPONENTS Core
-               Gui
-               Widgets
-    REQUIRED)
-  get_target_property(
-    QtCore_location
-    Qt5::Core
-    LOCATION)
-  message(STATUS "Found QtCore: ${QtCore_location}")
-else()
-  get_target_property(
-    QtCore_location
-    Qt6::Core
-    LOCATION)
-  message(STATUS "Found QtCore: ${QtCore_location}")
-endif()
+find_package(
+  Qt6
+  CONFIG
+  REQUIRED
+  COMPONENTS Core
+             Gui
+             Widgets
+             OpenGLWidgets
+             OpenGL)
+get_target_property(
+  QtCore_location
+  Qt6::Core
+  LOCATION)
+message(STATUS "Found QtCore: ${QtCore_location}")
 
 # enable Qt utils: moc, uic, rcc
 set(CMAKE_AUTOMOC ON)
@@ -177,5 +159,4 @@ message(STATUS "SME_EXTRA_CORE_DEFS: ${SME_EXTRA_CORE_DEFS}")
 message(STATUS "SME_EXTRA_GUI_LIBS: ${SME_EXTRA_GUI_LIBS}")
 message(STATUS "SME_EXTRA_EXE_LIBS: ${SME_EXTRA_EXE_LIBS}")
 message(STATUS "SME_USE_STATIC_LIBS: ${SME_USE_STATIC_LIBS}")
-message(STATUS "SME_WITH_QT6: ${SME_WITH_QT6}")
 message(STATUS "SME_QT_DISABLE_UNICODE: ${SME_QT_DISABLE_UNICODE}")

--- a/gui/widgets/plotwrapper.cpp
+++ b/gui/widgets/plotwrapper.cpp
@@ -159,11 +159,7 @@ void PlotWrapper::clear() {
 }
 
 double PlotWrapper::xValue(const QMouseEvent *event) const {
-#if QT_VERSION < 0x060000
-  const auto &pos{event->localPos()};
-#else
   const auto &pos{event->position()};
-#endif
   double key;
   double val;
   plot->graph(0)->pixelsToCoords(pos, key, val);

--- a/gui/widgets/qopenglmousetracker_t.cpp
+++ b/gui/widgets/qopenglmousetracker_t.cpp
@@ -25,7 +25,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   test.show();
 
-  wait(1000);
+  wait(100);
 
   // camera position
   test.SetCameraPosition(0, 0, -10);
@@ -37,13 +37,13 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
       QDir::current().filePath("tmp_sphere.ply").toStdString());
   test.addMesh(sphereMesh, redColor);
 
-  wait(1000);
+  wait(100);
 
   QFile::copy(":/test/rendering/Objects/teapot.ply", "tmp_teapot.ply");
   QFileInfo info("tmp_teapot.ply");
   REQUIRE(QFile::exists("tmp_teapot.ply"));
 
-  wait(1000);
+  wait(100);
 
   rendering::SMesh teapotMesh = rendering::ObjectLoader::LoadMesh(
       QDir::current().filePath("tmp_teapot.ply").toStdString());
@@ -72,7 +72,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(blueColor != QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   sendMouseClick(&test, {0, 0});
 
@@ -80,7 +80,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(blueColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   sendMouseClick(&test, {376, 366});
 
@@ -88,7 +88,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(redColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   // reset
   sendMouseClick(&test, {412, 445});
@@ -97,7 +97,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(blackColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   // reset
   sendMouseClick(&test, {412, 445});
@@ -106,7 +106,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(blackColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   sendMouseClick(&test, {0, 0});
 
@@ -114,7 +114,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(blueColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   sendMouseClick(&test, {376, 366});
 
@@ -122,7 +122,7 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
 
   REQUIRE(redColor == QcolorSelection);
 
-  wait(1000);
+  wait(100);
 
   // reset
   sendMouseClick(&test, {412, 445});
@@ -130,6 +130,4 @@ TEST_CASE("QOpenGLMouseTracker: OpenGL", tags) {
   QcolorSelection = QColor(test.getColour());
 
   REQUIRE(blackColor == QcolorSelection);
-
-  wait(1000);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,16 +13,11 @@ if(SME_BUILD_GUI)
   target_compile_definitions(tests PRIVATE SME_ENABLE_GUI_TESTS)
 endif()
 
-if(SME_WITH_QT6)
-  find_package(Qt6 QUIET COMPONENTS Test)
-endif()
-if(NOT Qt6_FOUND)
-  find_package(
-    Qt5
-    COMPONENTS Test
-    REQUIRED)
-endif()
-
+find_package(
+  Qt6
+  REQUIRED
+  CONFIG
+  COMPONENTS Test)
 set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
 add_library(testlib resources/test_resources.qrc)

--- a/test/test_utils/qt_test_utils.cpp
+++ b/test/test_utils/qt_test_utils.cpp
@@ -33,15 +33,8 @@ void sendKeyEvents(QObject *object, const QStringList &keySeqStrings,
       str = s;
     }
     auto keyCombination{QKeySequence(s)[0]};
-#if QT_VERSION < 0x060000
-    int key{keyCombination & Qt::Key::Key_unknown};
-    auto modifier{static_cast<Qt::KeyboardModifier>(
-        static_cast<std::size_t>(keyCombination) &
-        Qt::KeyboardModifier::KeyboardModifierMask)};
-#else
     auto key{keyCombination.key()};
     auto modifier{keyCombination.keyboardModifiers()};
-#endif
     qDebug() << "  - " << static_cast<Qt::Key>(key) << modifier;
     // send key press & key release events to the object
     auto press = new QKeyEvent(QEvent::KeyPress, key, modifier, str);


### PR DESCRIPTION
- make Qt6 mandatory
- remove Qt5 compatibility code
- resolves #902

also: reduce waits in QOpenGLMouseTracker tests
