### PR TITLE
Make use of some c++20 features to improve maintainability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-
 # stop Qt from defining UNICODE on windows to avoid dune issues: this used to be
 # opt-in, but now done by default for Qt >= 6.1.2. See
 # https://codereview.qt-project.org/c/qt/qtbase/+/350443

--- a/benchmark/bench.hpp
+++ b/benchmark/bench.hpp
@@ -13,7 +13,7 @@
 
 // Each dataset for constructing benchmarks is stored as a custom type
 struct ABtoC {
-  sme::common::ImageStack imgs{QImage{":/geometry/circle-100x100.png"}};
+  sme::common::ImageStack imgs{{QImage{":/geometry/circle-100x100.png"}}};
   std::vector<QRgb> colours{imgs[0].pixel(1, 1), imgs[0].pixel(50, 50)};
   std::vector<std::size_t> maxTriangleArea{10, 10};
   sme::common::VoxelF origin{0.0, 0.0, 0.0};
@@ -35,7 +35,7 @@ struct ABtoC {
 
 struct VerySimpleModel {
   sme::common::ImageStack imgs{
-      QImage{":/geometry/concave-cell-nucleus-100x100.png"}};
+      {QImage{":/geometry/concave-cell-nucleus-100x100.png"}}};
   std::vector<QRgb> colours{imgs[0].pixel(0, 0), imgs[0].pixel(35, 20),
                             imgs[0].pixel(40, 50)};
   std::vector<std::size_t> maxTriangleArea{10, 10, 10};
@@ -57,7 +57,7 @@ struct VerySimpleModel {
 };
 
 struct LiverCells {
-  sme::common::ImageStack imgs{QImage{":/geometry/liver-cells-200x100.png"}};
+  sme::common::ImageStack imgs{{QImage{":/geometry/liver-cells-200x100.png"}}};
   std::vector<QRgb> colours{imgs[0].pixel(50, 50), imgs[0].pixel(40, 20),
                             imgs[0].pixel(21, 14)};
   std::vector<std::size_t> maxTriangleArea{2, 2, 2};

--- a/cli/spatial-cli.cpp
+++ b/cli/spatial-cli.cpp
@@ -3,9 +3,13 @@
 #include <fmt/core.h>
 
 int main(int argc, char *argv[]) {
-  CLI::App app;
+  CLI::App app{"Spatial Model Editor CLI"};
   auto params{sme::cli::setupCLI(app)};
-  CLI11_PARSE(app, argc, argv);
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError &e) {
+    return app.exit(e);
+  }
   if (params.outputFile.empty()) {
     params.outputFile = params.inputFile;
   }

--- a/cli/src/cli_params.cpp
+++ b/cli/src/cli_params.cpp
@@ -19,7 +19,7 @@ static void addParams(CLI::App &app, Params &params) {
   app.add_option("-s,--simulator", params.simType,
                  "The simulator to use: dune or pixel")
       ->transform(CLI::CheckedTransformer(
-          std::map<std::string, simulate::SimulatorType>{
+          std::map<std::string, simulate::SimulatorType, std::less<>>{
               {"dune", simulate::SimulatorType::DUNE},
               {"pixel", simulate::SimulatorType::Pixel}},
           CLI::ignore_case))

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(core STATIC)
+target_compile_features(core PUBLIC cxx_std_20)
 add_library(
   sme::core
   ALIAS
@@ -163,7 +164,3 @@ add_subdirectory(common)
 add_subdirectory(mesh)
 add_subdirectory(model)
 add_subdirectory(simulate)
-
-# set Compile options and warnings
-set_target_properties(core PROPERTIES CXX_STANDARD 17)
-set_target_properties(core PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/core/common/include/sme/image_stack.hpp
+++ b/core/common/include/sme/image_stack.hpp
@@ -2,6 +2,7 @@
 
 #include "sme/voxel.hpp"
 #include <QImage>
+#include <QString>
 
 namespace sme::common {
 
@@ -20,6 +21,7 @@ public:
   ImageStack(const Volume &size, QImage::Format format);
   explicit ImageStack(std::vector<QImage> &&images);
   explicit ImageStack(const std::vector<QImage> &images);
+  explicit ImageStack(const QString &filename);
   /**
    * @brief Grayscale image from array of pixel intensities
    *
@@ -29,10 +31,6 @@ public:
    */
   ImageStack(const Volume &imageSize, const std::vector<double> &values,
              double maxValue = -1.0);
-  // todo: remove this constructor or make it explicit
-  // temporarily allow a QImage to implicitly be converted to a ImageStack
-  // to avoid refactoring a lot of test code
-  ImageStack(const QImage &image);
   inline QImage &operator[](std::size_t z) { return imgs[z]; }
   [[nodiscard]] inline const QImage &operator[](std::size_t z) const {
     return imgs[z];

--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -49,7 +50,7 @@ typename Container::value_type sum(const Container &c) {
  */
 template <typename Container>
 typename Container::value_type average(const Container &c) {
-  return sum(c) / static_cast<typename Container::value_type>(c.size());
+  return sum(c) / static_cast<typename Container::value_type>(std::size(c));
 }
 
 /**
@@ -57,7 +58,7 @@ typename Container::value_type average(const Container &c) {
  */
 template <typename Container>
 typename Container::value_type min(const Container &c) {
-  return *std::min_element(std::cbegin(c), std::cend(c));
+  return *std::ranges::min_element(c);
 }
 
 /**
@@ -65,7 +66,7 @@ typename Container::value_type min(const Container &c) {
  */
 template <typename Container>
 typename Container::value_type max(const Container &c) {
-  return *std::max_element(std::cbegin(c), std::cend(c));
+  return *std::ranges::max_element(c);
 }
 
 /**
@@ -74,11 +75,11 @@ typename Container::value_type max(const Container &c) {
 template <typename Container>
 std::vector<typename Container::value_type>
 get_unique_values(const Container &c) {
-  std::vector<typename Container::value_type> uniq_values(c);
-  std::sort(uniq_values.begin(), uniq_values.end());
-  uniq_values.erase(std::unique(uniq_values.begin(), uniq_values.end()),
-                    uniq_values.end());
-  return uniq_values;
+  std::vector<typename Container::value_type> unique_values(c);
+  std::ranges::sort(std::begin(unique_values), std::end(unique_values));
+  unique_values.erase(std::unique(unique_values.begin(), unique_values.end()),
+                      unique_values.end());
+  return unique_values;
 }
 
 /**
@@ -98,8 +99,8 @@ bool isItIndexes(const Container &c, std::size_t length) {
 template <typename Container>
 std::pair<typename Container::value_type, typename Container::value_type>
 minmax(const Container &c) {
-  auto p = std::minmax_element(std::cbegin(c), std::cend(c));
-  return {*p.first, *p.second};
+  const auto [min, max] = std::ranges::minmax_element(c);
+  return {*min, *max};
 }
 
 /**
@@ -107,8 +108,8 @@ minmax(const Container &c) {
  */
 template <typename Container>
 std::size_t min_element_index(const Container &c) {
-  return static_cast<std::size_t>(
-      std::distance(c.cbegin(), std::min_element(c.cbegin(), c.cend())));
+  return static_cast<std::size_t>(std::distance(
+      std::cbegin(c), std::min_element(std::cbegin(c), std::cend(c))));
 }
 
 /**
@@ -117,11 +118,11 @@ std::size_t min_element_index(const Container &c) {
 template <typename Container, typename Element>
 std::size_t element_index(const Container &c, const Element &e,
                           std::size_t index_if_not_found = 0) {
-  auto iter{std::find(cbegin(c), cend(c), e)};
-  if (iter == cend(c)) {
+  auto iter{std::ranges::find(c, e)};
+  if (iter == std::cend(c)) {
     return index_if_not_found;
   }
-  return static_cast<std::size_t>(std::distance(cbegin(c), iter));
+  return static_cast<std::size_t>(std::distance(std::cbegin(c), iter));
 }
 
 /**
@@ -212,26 +213,6 @@ template <typename T> std::string vectorToString(const std::vector<T> &vec) {
   }
   ss << vec.back();
   return ss.str();
-}
-
-/**
- * @brief Indices of elements if vector were sorted
- *
- * Returns a vector of indices, such that the vector would be sorted if the
- * elements were in this order.
- *
- * @tparam T the type of the values in the vector
- */
-template <typename T>
-std::vector<std::size_t>
-getIndicesOfSortedVector(const std::vector<T> &unsorted) {
-  std::vector<std::size_t> indices(unsorted.size(), 0);
-  std::iota(indices.begin(), indices.end(), 0);
-  std::sort(indices.begin(), indices.end(),
-            [&unsorted = unsorted](std::size_t i1, std::size_t i2) {
-              return unsorted[i1] < unsorted[i2];
-            });
-  return indices;
 }
 
 /**

--- a/core/common/include/sme/voxel.hpp
+++ b/core/common/include/sme/voxel.hpp
@@ -55,10 +55,6 @@ inline bool operator==(const Volume &a, const Volume &b) {
   return a.width() == b.width() && a.height() == b.height() &&
          a.depth() == b.depth();
 }
-inline bool operator!=(const Volume &a, const Volume &b) {
-  return a.width() != b.width() || a.height() != b.height() ||
-         a.depth() != b.depth();
-}
 
 class VolumeF {
 private:

--- a/core/common/src/simple_symbolic.cpp
+++ b/core/common/src/simple_symbolic.cpp
@@ -40,7 +40,7 @@ std::string SimpleSymbolic::substitute(
 }
 
 bool SimpleSymbolic::contains(const std::string &expr, const std::string &var) {
-  return symbols(expr).count(var) != 0;
+  return symbols(expr).contains(var);
 }
 
 std::set<std::string, std::less<>>

--- a/core/common/src/tiff.cpp
+++ b/core/common/src/tiff.cpp
@@ -11,16 +11,16 @@
 
 namespace sme::common {
 
-constexpr int TiffDataTypeBits = std::numeric_limits<TiffDataType>::digits;
-constexpr TiffDataType TiffDataTypeMaxValue =
-    std::numeric_limits<TiffDataType>::max();
+constexpr int TiffDataTypeBits{std::numeric_limits<TiffDataType>::digits};
+constexpr TiffDataType TiffDataTypeMaxValue{
+    std::numeric_limits<TiffDataType>::max()};
 
 double writeTIFF(const std::string &filename, const QSize &imageSize,
                  const std::vector<double> &conc,
                  const sme::common::VolumeF &voxelSize) {
   // todo: add ORIGIN to TIFF file!
   SPDLOG_TRACE("found {} concentration values", conc.size());
-  double maxConc = *std::max_element(conc.cbegin(), conc.cend());
+  double maxConc{common::max(conc)};
   SPDLOG_TRACE("  - max value: {}", maxConc);
 
   // convert to array of type TiffDataType

--- a/core/common/src/utils.cpp
+++ b/core/common/src/utils.cpp
@@ -9,16 +9,16 @@ namespace sme::common {
 std::vector<std::string> toStdString(const QStringList &q) {
   std::vector<std::string> v;
   v.reserve(static_cast<std::size_t>(q.size()));
-  std::transform(q.begin(), q.end(), std::back_inserter(v),
-                 [](const QString &s) { return s.toStdString(); });
+  std::ranges::transform(q, std::back_inserter(v),
+                         [](const QString &s) { return s.toStdString(); });
   return v;
 }
 
 QStringList toQString(const std::vector<std::string> &v) {
   QStringList q;
   q.reserve(static_cast<int>(v.size()));
-  std::transform(v.begin(), v.end(), std::back_inserter(q),
-                 [](const std::string &s) { return s.c_str(); });
+  std::ranges::transform(v, std::back_inserter(q),
+                         [](const std::string &s) { return s.c_str(); });
   return q;
 }
 

--- a/core/mesh/src/mesh_utils.cpp
+++ b/core/mesh/src/mesh_utils.cpp
@@ -1,5 +1,6 @@
 #include "mesh_utils.hpp"
 #include <algorithm>
+#include <ranges>
 
 namespace sme::mesh {
 
@@ -7,8 +8,7 @@ cv::Mat makeBinaryMask(const QImage &img, const std::vector<QRgb> &cols) {
   cv::Mat m(img.height(), img.width(), CV_8UC1, cv::Scalar(0));
   for (int y = 0; y < img.height(); ++y) {
     for (int x = 0; x < img.width(); ++x) {
-      if (std::find(cols.cbegin(), cols.cend(), img.pixel(x, y)) !=
-          cols.cend()) {
+      if (std::ranges::find(cols, img.pixel(x, y)) != cols.cend()) {
         m.at<uint8_t>(y, x) = 255;
       }
     }

--- a/core/mesh/src/triangulate.cpp
+++ b/core/mesh/src/triangulate.cpp
@@ -116,10 +116,9 @@ static void meshCdt(CDT &cdt,
   // resulting in the insertion of bad (tall/thin) triangles in the already
   // meshed compartment.
   auto sortedCompartments{compartments};
-  std::sort(sortedCompartments.begin(), sortedCompartments.end(),
-            [](const auto &a, const auto &b) {
-              return a.maxTriangleArea < b.maxTriangleArea;
-            });
+  std::ranges::sort(sortedCompartments, [](const auto &a, const auto &b) {
+    return a.maxTriangleArea < b.maxTriangleArea;
+  });
   for (const auto &compartment : sortedCompartments) {
     std::vector<CDT::Point> seeds;
     seeds.reserve(compartment.interiorPoints.size());

--- a/core/model/src/geometry.cpp
+++ b/core/model/src/geometry.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <initializer_list>
 #include <limits>
-#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -305,7 +304,7 @@ void Field::setConcentration(const std::vector<double> &concentration) {
 void Field::setUniformConcentration(double concentration) {
   SPDLOG_INFO("species {}, compartment {}", id, comp->getId());
   SPDLOG_INFO("  - concentration = {}", concentration);
-  std::fill(conc.begin(), conc.end(), concentration);
+  std::ranges::fill(conc, concentration);
   isUniformConcentration = true;
 }
 

--- a/core/model/src/geometry_analytic.cpp
+++ b/core/model/src/geometry_analytic.cpp
@@ -61,7 +61,7 @@ getCompartmentsAndAnalyticVolumes(
   // this gives them in the order in which they should be processed
   // when a pixel is contained in multiple volumes, the highest ordinal takes
   // precedence
-  std::sort(v.begin(), v.end(), [](const auto &a, const auto &b) {
+  std::ranges::sort(v, [](const auto &a, const auto &b) {
     return a.second->getOrdinal() > b.second->getOrdinal();
   });
   return v;

--- a/core/model/src/geometry_sampled_field.cpp
+++ b/core/model/src/geometry_sampled_field.cpp
@@ -71,8 +71,8 @@ makeEmptyImages(const libsbml::SampledField *sampledField) {
 
 static bool allSampledValuesSet(
     const std::vector<const libsbml::SampledVolume *> &sampledVolumes) {
-  return std::all_of(sampledVolumes.cbegin(), sampledVolumes.cend(),
-                     [](auto *s) { return s->isSetSampledValue(); });
+  return std::ranges::all_of(sampledVolumes,
+                             [](auto *s) { return s->isSetSampledValue(); });
 }
 
 static bool valuesAreAllQRgb(const std::vector<QRgb> &values) {
@@ -152,12 +152,12 @@ getMatchingSampledValues(const std::vector<T> &values,
   std::vector<bool> matches(values.size(), false);
   if (sfvol->isSetSampledValue()) {
     T sv = static_cast<T>(sfvol->getSampledValue());
-    std::transform(values.cbegin(), values.cend(), matches.begin(),
-                   [sv](auto v) { return v == sv; });
+    std::transform(values.begin(), values.end(), matches.begin(),
+                   [sv](const auto v) { return v == sv; });
   } else if (sfvol->isSetMinValue() && sfvol->isSetMaxValue()) {
     double min = sfvol->getMinValue();
     double max = sfvol->getMaxValue();
-    std::transform(values.cbegin(), values.cend(), matches.begin(),
+    std::transform(values.begin(), values.end(), matches.begin(),
                    [min, max](T v) {
                      auto vAsDouble{static_cast<double>(v)};
                      return vAsDouble >= min && vAsDouble < max;
@@ -218,7 +218,7 @@ static std::vector<QRgb> setImagePixels(
   auto iter = colours.begin();
   for (const auto *sampledVolume : sampledVolumes) {
     auto matches = getMatchingSampledValues(values, sampledVolume);
-    if (std::find(matches.cbegin(), matches.cend(), true) != matches.cend()) {
+    if (std::ranges::find(matches, true) != matches.cend()) {
       auto col{common::indexedColours()[iCol].rgb()};
       SPDLOG_WARN("Color {} is {}", iCol, col);
       auto sampledValue{

--- a/core/model/src/model_geometry_t.cpp
+++ b/core/model/src/model_geometry_t.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Model geometry",
       REQUIRE(qAlpha(innerCol) == 255);
       REQUIRE(m.getHasUnsavedChanges() == false);
       REQUIRE(mGeometry.getHasUnsavedChanges() == false);
-      mGeometry.importGeometryFromImages(img, false);
+      mGeometry.importGeometryFromImages(common::ImageStack{{img}}, false);
       REQUIRE(m.getHasUnsavedChanges() == true);
       REQUIRE(mGeometry.getHasUnsavedChanges() == true);
       REQUIRE(m.getIsValid() == false);
@@ -119,7 +119,7 @@ TEST_CASE("Model geometry",
     SECTION("import geometry & keep colour assignments") {
       QImage img(":/geometry/concave-cell-nucleus-100x100.png");
       REQUIRE(img.size() == QSize(100, 100));
-      m.getGeometry().importGeometryFromImages(img, true);
+      m.getGeometry().importGeometryFromImages(common::ImageStack{{img}}, true);
       auto cols2{m.getCompartments().getColours()};
       REQUIRE(cols2.size() == 3);
       REQUIRE(cols2[0] == c0);
@@ -129,7 +129,8 @@ TEST_CASE("Model geometry",
     SECTION("import geometry & don't keep colour assignments") {
       QImage img(":/geometry/concave-cell-nucleus-100x100.png");
       REQUIRE(img.size() == QSize(100, 100));
-      m.getGeometry().importGeometryFromImages(img, false);
+      m.getGeometry().importGeometryFromImages(common::ImageStack{{img}},
+                                               false);
       auto cols2{m.getCompartments().getColours()};
       REQUIRE(cols2.size() == 3);
       REQUIRE(cols2[0] == 0);
@@ -139,7 +140,7 @@ TEST_CASE("Model geometry",
     SECTION("import geometry & try to keep invalid colour assignments") {
       QImage img(":/geometry/two-blobs-100x100.png");
       REQUIRE(img.size() == QSize(100, 100));
-      m.getGeometry().importGeometryFromImages(img, true);
+      m.getGeometry().importGeometryFromImages(common::ImageStack{{img}}, true);
       // new geometry image only contains c0 from previous colours
       auto cols2{m.getCompartments().getColours()};
       REQUIRE(cols2.size() == 3);

--- a/core/model/src/model_membranes_t.cpp
+++ b/core/model/src/model_membranes_t.cpp
@@ -20,15 +20,15 @@ TEST_CASE("SBML membranes",
       QRgb col1 = qRgb(123, 123, 0);
       img.fill(col1);
       img.setPixel(1, 1, col0);
-      img = img.convertToFormat(QImage::Format_Indexed8);
+      common::ImageStack imgs{{img.convertToFormat(QImage::Format_Indexed8)}};
       std::vector<std::unique_ptr<geometry::Compartment>> compartments;
       compartments.push_back(
-          std::make_unique<geometry::Compartment>("c0", img, col0));
+          std::make_unique<geometry::Compartment>("c0", imgs, col0));
       compartments.push_back(
-          std::make_unique<geometry::Compartment>("c1", img, col1));
+          std::make_unique<geometry::Compartment>("c1", imgs, col1));
       QStringList names{"c0 name", "c1 name"};
       model::ModelMembranes ms;
-      ms.updateCompartmentImages(img);
+      ms.updateCompartmentImages(imgs);
       REQUIRE(ms.getIds().isEmpty());
       REQUIRE(ms.getMembranes().empty());
       REQUIRE(ms.getNames().isEmpty());

--- a/core/model/src/model_membranes_util.cpp
+++ b/core/model/src/model_membranes_util.cpp
@@ -29,7 +29,7 @@ OrderedIntPairIndex::OrderedIntPairIndex(int maxKeyValue)
 }
 
 void OrderedIntPairIndex::clear() {
-  std::fill(values.begin(), values.end(), nullIndex);
+  std::ranges::fill(values, nullIndex);
   nItems = 0;
 }
 

--- a/core/model/src/model_membranes_util_t.cpp
+++ b/core/model/src/model_membranes_util_t.cpp
@@ -71,7 +71,7 @@ TEST_CASE("SBML membranes utils",
       QRgb col0 = qRgb(0, 0, 0);
       img.fill(col0);
       model::ImageMembranePixels imp(
-          img.convertToFormat(QImage::Format_Indexed8));
+          common::ImageStack{{img.convertToFormat(QImage::Format_Indexed8)}});
       REQUIRE(imp.getImageSize().width() == img.width());
       REQUIRE(imp.getImageSize().height() == img.height());
       REQUIRE(imp.getImageSize().depth() == 1);
@@ -91,7 +91,8 @@ TEST_CASE("SBML membranes utils",
       // 2 0 0
       // 0 3 0
       model::ImageMembranePixels imp;
-      imp.setImages(img.convertToFormat(QImage::Format_Indexed8));
+      imp.setImages(
+          common::ImageStack{{img.convertToFormat(QImage::Format_Indexed8)}});
       REQUIRE(imp.getImageSize().width() == img.width());
       REQUIRE(imp.getImageSize().height() == img.height());
       REQUIRE(imp.getImageSize().depth() == 1);

--- a/core/model/src/model_reactions.cpp
+++ b/core/model/src/model_reactions.cpp
@@ -168,10 +168,10 @@ getValidSpeciesIds(const libsbml::Reaction *reaction,
   const auto *model{reaction->getModel()};
   std::string compA{reaction->getCompartment()};
   std::string compB{};
-  if (auto iter{std::find_if(membranes.cbegin(), membranes.cend(),
-                             [&compA](const auto &membrane) {
-                               return membrane.getId() == compA;
-                             })};
+  if (auto iter{std::ranges::find_if(membranes,
+                                     [&compA](const auto &membrane) {
+                                       return membrane.getId() == compA;
+                                     })};
       iter != membranes.cend()) {
     // reaction location is a membrane: species can come from either
     // neighbouring compartment
@@ -756,7 +756,7 @@ void ModelReactions::removeParameter(const QString &reactionId,
 
 bool ModelReactions::dependOnVariable(const QString &variableId) const {
   auto v{variableId.toStdString()};
-  return std::any_of(ids.begin(), ids.end(), [&v, this](const auto &id) {
+  return std::ranges::any_of(ids, [&v, this](const auto &id) {
     auto e{getRateExpression(id).toStdString()};
     return common::SimpleSymbolic::contains(e, v);
   });

--- a/core/model/src/model_reactions_t.cpp
+++ b/core/model/src/model_reactions_t.cpp
@@ -205,14 +205,14 @@ TEST_CASE("SBML reactions",
     REQUIRE(m.getMembranes().getIds().size() == 2);
     REQUIRE(m.getReactions().getIds(m.getMembranes().getIds()[0]).size() == 2);
     REQUIRE(m.getReactions().getIds(m.getMembranes().getIds()[1]).size() == 2);
-    QImage img(":/geometry/single-pixels-3x1.png");
-    m.getGeometry().importGeometryFromImages({img}, false);
+    common::ImageStack imgs{{QImage(":/geometry/single-pixels-3x1.png")}};
+    m.getGeometry().importGeometryFromImages(imgs, false);
     m.getGeometry().setVoxelSize({1.0, 1.0, 1.0});
     REQUIRE(m.getGeometry().getIsValid() == false);
     // assign valid compartment colours
-    m.getCompartments().setColour("c1", img.pixel(0, 0));
-    m.getCompartments().setColour("c2", img.pixel(1, 0));
-    m.getCompartments().setColour("c3", img.pixel(2, 0));
+    m.getCompartments().setColour("c1", imgs[0].pixel(0, 0));
+    m.getCompartments().setColour("c2", imgs[0].pixel(1, 0));
+    m.getCompartments().setColour("c3", imgs[0].pixel(2, 0));
     REQUIRE(m.getGeometry().getIsValid() == true);
     // recover membrane ids and membrane reactions
     REQUIRE(m.getMembranes().getIds().size() == 2);
@@ -220,12 +220,12 @@ TEST_CASE("SBML reactions",
     REQUIRE(m.getReactions().getIds(m.getMembranes().getIds()[1]).size() == 2);
     // repeat with different but valid colour assignments
     // https://github.com/spatial-model-editor/spatial-model-editor/issues/679
-    m.getGeometry().importGeometryFromImages({img}, false);
+    m.getGeometry().importGeometryFromImages(imgs, false);
     m.getGeometry().setVoxelSize({1.0, 1.0, 1.0});
     REQUIRE(m.getGeometry().getIsValid() == false);
-    m.getCompartments().setColour("c1", img.pixel(2, 0));
-    m.getCompartments().setColour("c2", img.pixel(1, 0));
-    m.getCompartments().setColour("c3", img.pixel(0, 0));
+    m.getCompartments().setColour("c1", imgs[0].pixel(2, 0));
+    m.getCompartments().setColour("c2", imgs[0].pixel(1, 0));
+    m.getCompartments().setColour("c3", imgs[0].pixel(0, 0));
     REQUIRE(m.getGeometry().getIsValid() == true);
     REQUIRE(m.getMembranes().getIds().size() == 2);
     REQUIRE(m.getReactions().getIds(m.getMembranes().getIds()[0]).size() == 2);
@@ -309,15 +309,15 @@ TEST_CASE("SBML reactions",
     REQUIRE(m.getReactions().getIds(locations[3]).size() == 2);
     REQUIRE(m.getReactions().getIds(locations[4]).size() == 2);
     REQUIRE(m.getReactions().getIds(locations[5]).size() == 0);
-    QImage img(":/geometry/single-pixels-3x1.png");
-    m.getGeometry().importGeometryFromImages({img}, false);
+    common::ImageStack imgs{{QImage(":/geometry/single-pixels-3x1.png")}};
+    m.getGeometry().importGeometryFromImages(imgs, false);
     m.getGeometry().setVoxelSize({1.0, 1.0, 1.0});
     REQUIRE(m.getGeometry().getIsValid() == false);
     // assign compartments such that c1-c3 and c3-c2 share borders,
     // i.e. remove c1-c2 membrane from model geometry
-    m.getCompartments().setColour("c1", img.pixel(0, 0));
-    m.getCompartments().setColour("c3", img.pixel(1, 0));
-    m.getCompartments().setColour("c2", img.pixel(2, 0));
+    m.getCompartments().setColour("c1", imgs[0].pixel(0, 0));
+    m.getCompartments().setColour("c3", imgs[0].pixel(1, 0));
+    m.getCompartments().setColour("c2", imgs[0].pixel(2, 0));
     REQUIRE(m.getGeometry().getIsValid() == true);
     REQUIRE(m.getMembranes().getIds().size() == 2);
     REQUIRE(m.getMembranes().getIds()[0] == "c1_c3_membrane");
@@ -344,9 +344,9 @@ TEST_CASE("SBML reactions",
     REQUIRE(m.getReactions().getIds(locations[5]).size() == 2);
     // reassign compartment geometry so that c1-c2 membrane exists again:
     REQUIRE(m.getGeometry().getIsValid() == true);
-    m.getCompartments().setColour("c3", img.pixel(2, 0));
+    m.getCompartments().setColour("c3", imgs[0].pixel(2, 0));
     REQUIRE(m.getGeometry().getIsValid() == false);
-    m.getCompartments().setColour("c2", img.pixel(1, 0));
+    m.getCompartments().setColour("c2", imgs[0].pixel(1, 0));
     REQUIRE(m.getGeometry().getIsValid() == true);
     REQUIRE(m.getMembranes().getIds().size() == 2);
     REQUIRE(m.getMembranes().getIds()[0] == "c1_c2_membrane");

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -286,7 +286,7 @@ void ModelSpecies::setSimulationDataPtr(simulate::SimulationData *data) {
 }
 
 bool ModelSpecies::containsNonSpatialReactiveSpecies() const {
-  return std::any_of(ids.begin(), ids.end(), [this](const auto &id) {
+  return std::ranges::any_of(ids, [this](const auto &id) {
     return !getIsSpatial(id) && isReactive(id);
   });
 }

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -101,7 +101,8 @@ TEST_CASE("SBML: import SBML doc without geometry",
   SECTION("import geometry & assign compartments") {
     // import geometry image & assign compartments to colours
     s.getGeometry().importGeometryFromImages(
-        QImage(":/geometry/single-pixels-3x1.png"), false);
+        common::ImageStack{{QImage(":/geometry/single-pixels-3x1.png")}},
+        false);
     s.getCompartments().setColour("compartment0", 0xffaaaaaa);
     s.getCompartments().setColour("compartment1", 0xff525252);
     // export it again
@@ -316,7 +317,7 @@ TEST_CASE("SBML: import SBML level 2 document",
 
   // import geometry image
   s.getGeometry().importGeometryFromImages(
-      QImage(":/geometry/single-pixels-3x1.png"), false);
+      common::ImageStack{{QImage(":/geometry/single-pixels-3x1.png")}}, false);
   REQUIRE(s.getReactions().getIsIncompleteODEImport());
   REQUIRE(s.getGeometry().getHasImage() == true);
   REQUIRE(s.getGeometry().getIsValid() == false);
@@ -396,10 +397,10 @@ TEST_CASE("SBML: create new model, import geometry from image",
   REQUIRE(s.getGeometry().getHasImage() == false);
   REQUIRE(s.getGeometry().getIsValid() == false);
   SECTION("Single pixel image") {
-    QImage img(1, 1, QImage::Format_RGB32);
+    common::ImageStack imgs{{QImage(1, 1, QImage::Format_RGB32)}};
     QRgb col = QColor(12, 243, 154).rgba();
-    img.setPixel(0, 0, col);
-    s.getGeometry().importGeometryFromImages(img, false);
+    imgs[0].setPixel(0, 0, col);
+    s.getGeometry().importGeometryFromImages(imgs, false);
     REQUIRE(s.getIsValid() == true);
     REQUIRE(s.getErrorMessage().isEmpty());
     REQUIRE(s.getGeometry().getHasImage() == true);
@@ -591,10 +592,10 @@ TEST_CASE("SBML: ABtoC.xml", "[core/model/model][core/model][core][model]") {
       REQUIRE(s.getSpecies().getIds("comp").size() == 0);
     }
     SECTION("image geometry imported, assigned to compartment") {
-      QImage img(":/geometry/circle-100x100.png");
+      common::ImageStack imgs{{QImage(":/geometry/circle-100x100.png")}};
       QRgb col = QColor(144, 97, 193).rgba();
-      REQUIRE(img.pixel(50, 50) == col);
-      s.getGeometry().importGeometryFromImages(img, false);
+      REQUIRE(imgs[0].pixel(50, 50) == col);
+      s.getGeometry().importGeometryFromImages(imgs, false);
       s.getCompartments().setColour("comp", col);
       REQUIRE(s.getGeometry().getImages().volume().depth() == 1);
       REQUIRE(s.getGeometry().getImages()[0].size() == QSize(100, 100));
@@ -948,7 +949,8 @@ TEST_CASE("SBML: import multi-compartment SBML doc without spatial geometry",
   REQUIRE(geometry.getHasImage() == false);
   REQUIRE(reactions.getIsIncompleteODEImport() == true);
   // import a geometry image
-  geometry.importGeometryFromImages(QImage(":test/geometry/cell.png"), false);
+  geometry.importGeometryFromImages(
+      common::ImageStack{{QImage(":test/geometry/cell.png")}}, false);
   auto colours{geometry.getImages()[0].colorTable()};
   REQUIRE(colours.size() == 4);
   REQUIRE(geometry.getIsValid() == false);

--- a/core/model/src/sbml_math.cpp
+++ b/core/model/src/sbml_math.cpp
@@ -81,8 +81,7 @@ static const libsbml::ASTNode *
 findUnknownName(const libsbml::ASTNode *node, libsbml::ASTNodeType_t nodeType,
                 const std::vector<std::string> &names) {
   if (node->getType() == nodeType &&
-      std::find(names.cbegin(), names.cend(), node->getName()) ==
-          names.cend()) {
+      std::ranges::find(names, node->getName()) == names.cend()) {
     return node;
   }
   for (unsigned int i = 0; i < node->getNumChildren(); ++i) {

--- a/core/simulate/src/duneconverter_impl.cpp
+++ b/core/simulate/src/duneconverter_impl.cpp
@@ -45,14 +45,12 @@ makeValidDuneSpeciesNames(const std::vector<std::string> &names) {
     std::string duneName = name;
     name = "";
     // if species name clashes with a reserved name, append an underscore
-    if (std::find(reservedNames.cbegin(), reservedNames.cend(), duneName) !=
-        reservedNames.cend()) {
+    if (std::ranges::find(reservedNames, duneName) != reservedNames.cend()) {
       duneName.append("_");
     }
     // if species name clashes with another species name,
     // append another underscore
-    while (std::find(duneNames.cbegin(), duneNames.cend(), duneName) !=
-           duneNames.cend()) {
+    while (std::ranges::find(duneNames, duneName) != duneNames.cend()) {
       duneName.append("_");
     }
     name = duneName;
@@ -64,7 +62,7 @@ makeValidDuneSpeciesNames(const std::vector<std::string> &names) {
 bool compartmentContainsNonConstantSpecies(const model::Model &model,
                                            const QString &compId) {
   const auto &specs = model.getSpecies().getIds(compId);
-  return std::any_of(specs.cbegin(), specs.cend(), [m = &model](const auto &s) {
+  return std::ranges::any_of(specs, [m = &model](const auto &s) {
     return !m->getSpecies().getIsConstant(s);
   });
 }
@@ -78,16 +76,6 @@ std::vector<std::string> getNonConstantSpecies(const model::Model &model,
     }
   }
   return v;
-}
-
-bool modelHasIndependentCompartments(const model::Model &model) {
-  for (const auto &memId : model.getMembranes().getIds()) {
-    if (!model.getReactions().getIds(memId).isEmpty()) {
-      // model has membrane reaction -> compartments coupled
-      return false;
-    }
-  }
-  return true;
 }
 
 } // namespace sme::simulate

--- a/core/simulate/src/duneconverter_impl.hpp
+++ b/core/simulate/src/duneconverter_impl.hpp
@@ -19,6 +19,4 @@ bool compartmentContainsNonConstantSpecies(const model::Model &model,
 std::vector<std::string> getNonConstantSpecies(const model::Model &model,
                                                const QString &compId);
 
-bool modelHasIndependentCompartments(const model::Model &model);
-
 } // namespace sme::simulate

--- a/core/simulate/src/duneconverter_impl_t.cpp
+++ b/core/simulate/src/duneconverter_impl_t.cpp
@@ -29,7 +29,6 @@ TEST_CASE("DUNE: DuneConverter impl",
     REQUIRE(nonConstantSpecies[0] == "A");
     REQUIRE(nonConstantSpecies[1] == "B");
     REQUIRE(nonConstantSpecies[2] == "C");
-    REQUIRE(simulate::modelHasIndependentCompartments(s) == true);
 
     // make all species constant
     s.getSpecies().setIsConstant("A", true);
@@ -38,7 +37,6 @@ TEST_CASE("DUNE: DuneConverter impl",
     REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "comp") ==
             false);
     REQUIRE(simulate::getNonConstantSpecies(s, "comp").empty());
-    REQUIRE(simulate::modelHasIndependentCompartments(s) == true);
   }
   SECTION("very-simple-model model") {
     auto s{getExampleModel(Mod::VerySimpleModel)};
@@ -48,7 +46,6 @@ TEST_CASE("DUNE: DuneConverter impl",
     REQUIRE(simulate::getNonConstantSpecies(s, "c1").size() == 1);
     REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
     REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
-    REQUIRE(simulate::modelHasIndependentCompartments(s) == false);
 
     // remove only non-constant species in compartment c1
     s.getSpecies().remove("B_c1");
@@ -58,7 +55,6 @@ TEST_CASE("DUNE: DuneConverter impl",
     REQUIRE(simulate::getNonConstantSpecies(s, "c1").empty());
     REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
     REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
-    REQUIRE(simulate::modelHasIndependentCompartments(s) == false);
 
     // remove membrane reactions
     s.getReactions().remove("A_uptake");
@@ -71,6 +67,5 @@ TEST_CASE("DUNE: DuneConverter impl",
     REQUIRE(simulate::getNonConstantSpecies(s, "c1").empty());
     REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
     REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
-    REQUIRE(simulate::modelHasIndependentCompartments(s) == true);
   }
 }

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -42,7 +42,7 @@ getOptTimesteps(const OptimizeOptions &options) {
   }
   // sort times
   std::vector sortedUniqueTimes{times};
-  std::sort(sortedUniqueTimes.begin(), sortedUniqueTimes.end());
+  std::ranges::sort(sortedUniqueTimes);
   // margin within which times are considered equal:
   constexpr double relativeEps{1e-13};
   double epsilon{sortedUniqueTimes.back() * relativeEps};
@@ -77,21 +77,22 @@ static std::unique_ptr<pagmo::algorithm>
 getPagmoAlgorithm(sme::simulate::OptAlgorithmType optAlgorithmType) {
   // https://esa.github.io/pagmo2/docs/cpp/cpp_docs.html#implemented-algorithms
   switch (optAlgorithmType) {
-  case sme::simulate::OptAlgorithmType::PSO:
+    using enum sme::simulate::OptAlgorithmType;
+  case PSO:
     return std::make_unique<pagmo::algorithm>(pagmo::pso());
-  case sme::simulate::OptAlgorithmType::GPSO:
+  case GPSO:
     return std::make_unique<pagmo::algorithm>(pagmo::pso_gen());
-  case sme::simulate::OptAlgorithmType::DE:
+  case DE:
     return std::make_unique<pagmo::algorithm>(pagmo::de());
-  case sme::simulate::OptAlgorithmType::iDE:
+  case iDE:
     return std::make_unique<pagmo::algorithm>(pagmo::sade(1, 2, 2));
-  case sme::simulate::OptAlgorithmType::jDE:
+  case jDE:
     return std::make_unique<pagmo::algorithm>(pagmo::sade(1, 2, 1));
-  case sme::simulate::OptAlgorithmType::pDE:
+  case pDE:
     return std::make_unique<pagmo::algorithm>(pagmo::de1220());
-  case sme::simulate::OptAlgorithmType::ABC:
+  case ABC:
     return std::make_unique<pagmo::algorithm>(pagmo::bee_colony());
-  case sme::simulate::OptAlgorithmType::gaco:
+  case gaco:
     return std::make_unique<pagmo::algorithm>(pagmo::gaco(1, 7));
   default:
     return std::make_unique<pagmo::algorithm>(pagmo::pso());

--- a/core/simulate/src/pde.cpp
+++ b/core/simulate/src/pde.cpp
@@ -116,7 +116,7 @@ const std::vector<std::vector<std::string>> &Pde::getJacobian() const {
 static std::optional<std::size_t>
 getSpeciesIndex(const model::Model *doc, const std::string &speciesID,
                 const std::vector<std::string> &speciesIDs) {
-  if (auto it = std::find(speciesIDs.cbegin(), speciesIDs.cend(), speciesID);
+  if (auto it = std::ranges::find(speciesIDs, speciesID);
       it != speciesIDs.cend() &&
       doc->getSpecies().isReactive(speciesID.c_str())) {
     return static_cast<std::size_t>(it - speciesIDs.cbegin());

--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -249,15 +249,13 @@ PixelSim::PixelSim(
         std::string compIdA = membrane.getCompartmentA()->getId();
         std::string compIdB = membrane.getCompartmentB()->getId();
         auto iterA =
-            std::find_if(simCompartments.begin(), simCompartments.end(),
-                         [&compIdA](const auto &c) {
-                           return c->getCompartmentId() == compIdA;
-                         });
+            std::ranges::find_if(simCompartments, [&compIdA](const auto &c) {
+              return c->getCompartmentId() == compIdA;
+            });
         auto iterB =
-            std::find_if(simCompartments.begin(), simCompartments.end(),
-                         [&compIdB](const auto &c) {
-                           return c->getCompartmentId() == compIdB;
-                         });
+            std::ranges::find_if(simCompartments, [&compIdB](const auto &c) {
+              return c->getCompartmentId() == compIdB;
+            });
         SimCompartment *compA{nullptr};
         if (iterA != simCompartments.cend()) {
           compA = iterA->get();

--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -59,8 +59,8 @@ void Simulation::initEvents() {
     double t{events.getTime(id)};
     SPDLOG_INFO("  - event '{}' at time {}", id.toStdString(), t);
     if (t >= t0) {
-      if (auto iter{std::find_if(evs.begin(), evs.end(),
-                                 [t](const auto &ev) { return ev.time == t; })};
+      if (auto iter{std::ranges::find_if(
+              evs, [t](const auto &ev) { return ev.time == t; })};
           iter != evs.end()) {
         SPDLOG_INFO("    -> adding to existing SimEvent at time {}",
                     iter->time);
@@ -77,8 +77,8 @@ void Simulation::initEvents() {
                   var, val, t);
     }
   }
-  std::sort(evs.begin(), evs.end(),
-            [](const auto &a, const auto &b) { return a.time < b.time; });
+  std::ranges::sort(
+      evs, [](const auto &a, const auto &b) { return a.time < b.time; });
   for (auto &ev : evs) {
     SPDLOG_INFO("Adding SimEvent at time {}", ev.time);
     for (const auto &id : ev.ids) {
@@ -487,7 +487,7 @@ common::ImageStack Simulation::getConcImage(
       }
     }
     for (auto &c : maxConcs) {
-      std::fill(c.begin(), c.end(), maxC);
+      std::ranges::fill(c, maxC);
     }
   }
   // apply minimum (avoid dividing by zero)

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -29,8 +29,8 @@ TEST_CASE("Simulate: very_simple_model, single pixel geometry",
   img.setPixel(0, 1, col2);
   img.setPixel(0, 2, col3);
   img.save("tmpsimsinglepixel.bmp");
-  s.getGeometry().importGeometryFromImages({QImage("tmpsimsinglepixel.bmp")},
-                                           false);
+  s.getGeometry().importGeometryFromImages(
+      common::ImageStack{{QImage("tmpsimsinglepixel.bmp")}}, false);
   s.getGeometry().setVoxelSize({1.0, 1.0, 1.0});
   s.getCompartments().setColour("c1", col1);
   s.getCompartments().setColour("c2", col2);

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -33,5 +33,3 @@ target_link_libraries(
          sme::core
          Qt::OpenGLWidgets
          Qt::OpenGL)
-set_property(TARGET gui PROPERTY CXX_STANDARD 17)
-set_target_properties(gui PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/gui/dialogs/dialogimage_t.cpp
+++ b/gui/dialogs/dialogimage_t.cpp
@@ -3,10 +3,10 @@
 #include <QLabel>
 
 TEST_CASE("DialogImage", "[gui/dialogs/image][gui/dialogs][gui][image]") {
-  QImage image(":/icon/icon128.png");
+  sme::common::ImageStack imageStack{{QImage(":/icon/icon128.png")}};
   QString title("my title");
   QString message("see image below:");
-  DialogImage dia(nullptr, title, message, image);
+  DialogImage dia(nullptr, title, message, imageStack);
   auto *lblMessage{dia.findChild<QLabel *>("lblMessage")};
   REQUIRE(lblMessage != nullptr);
   auto *lblImage{dia.findChild<QLabel *>("lblImage")};

--- a/gui/guiutils.cpp
+++ b/gui/guiutils.cpp
@@ -56,26 +56,15 @@ sme::common::ImageStack getImageFromUser(QWidget *parent,
   if (filename.isEmpty()) {
     return {};
   }
-  SPDLOG_DEBUG("  - import file {}", filename.toStdString());
-  // first try using tiffReader
-  sme::common::TiffReader tiffReader(filename.toStdString());
-  if (!tiffReader.empty()) {
-    return tiffReader.getImages();
-  } else {
-    SPDLOG_DEBUG(
-        "    -> tiffReader could not read file, trying QImage::load()");
-    QImage img;
-    bool success = img.load(filename);
-    if (success) {
-      return sme::common::ImageStack({img});
-    }
+  try {
+    return sme::common::ImageStack(filename);
+  } catch (const std::invalid_argument &e) {
+    QMessageBox::warning(
+        parent, "Could not open image file",
+        QString("Failed to open image file '%1'\nError message: '%2'")
+            .arg(filename)
+            .arg(e.what()));
   }
-  SPDLOG_DEBUG("    -> QImage::load() could not read file - giving up");
-  QMessageBox::warning(
-      parent, "Could not open image file",
-      QString("Failed to open image file '%1'\nError message: '%2'")
-          .arg(filename)
-          .arg(tiffReader.getErrorMessage()));
   return {};
 }
 

--- a/gui/rendering/Camera.hpp
+++ b/gui/rendering/Camera.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_CAMERA_H
-#define SPATIALMODELEDITOR_CAMERA_H
+#pragma once
 
 #include <math.h>
 
@@ -59,5 +58,3 @@ private:
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_CAMERA_H

--- a/gui/rendering/ObjectInfo.hpp
+++ b/gui/rendering/ObjectInfo.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_OBJECTINFO_H
-#define SPATIALMODELEDITOR_OBJECTINFO_H
+#pragma once
 
 #include <QVector4D>
 #include <QtOpenGL>
@@ -20,5 +19,3 @@ struct ObjectInfo {
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_OBJECTINFO_H

--- a/gui/rendering/ObjectLoader.hpp
+++ b/gui/rendering/ObjectLoader.hpp
@@ -2,17 +2,16 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_OBJECTLOADER_H
-#define SPATIALMODELEDITOR_OBJECTLOADER_H
+#pragma once
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh/Surface_mesh.h>
 
 #include <fstream>
 #include <iostream>
+#include <string>
 
 #include "ObjectInfo.hpp"
-#include <string>
 
 namespace rendering {
 
@@ -29,5 +28,3 @@ public:
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_OBJECTLOADER_H

--- a/gui/rendering/ShaderProgram.hpp
+++ b/gui/rendering/ShaderProgram.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_SHADERPROGRAM_H
-#define SPATIALMODELEDITOR_SHADERPROGRAM_H
+#pragma once
 
 #include <QtOpenGL>
 #include <string>
@@ -51,5 +50,3 @@ private:
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_SHADERPROGRAM_H

--- a/gui/rendering/Shaders/default/fragment.hpp
+++ b/gui/rendering/Shaders/default/fragment.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 8/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_FRAGMENT_H
-#define SPATIALMODELEDITOR_FRAGMENT_H
+#pragma once
 
 namespace rendering {
 
@@ -21,5 +20,3 @@ const char text_fragment[] =
     "//out_Color = vec4(1.0, 0.0, 0.0, 1.0);\n"
     "}\n";
 }
-
-#endif // SPATIALMODELEDITOR_FRAGMENT_H

--- a/gui/rendering/Shaders/default/vertex.hpp
+++ b/gui/rendering/Shaders/default/vertex.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 8/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_VERTEX_HPP
-#define SPATIALMODELEDITOR_VERTEX_HPP
+#pragma once
 
 namespace rendering {
 
@@ -88,5 +87,3 @@ const char text_vertex[] =
     "}\n";
 
 }
-
-#endif // SPATIALMODELEDITOR_VERTEX_HPP

--- a/gui/rendering/Utils.cpp
+++ b/gui/rendering/Utils.cpp
@@ -197,7 +197,7 @@ std::string rendering::Utils::Backtrace(const std::string &sectionName,
   return sectionName + trace_buf.str();
 }
 #else
-std::string Backtrace(int skip = 1) { return std::string(); }
+std::string Backtrace([[maybe_unused]] int skip = 1) { return std::string(); }
 #endif
 
 #ifdef QT_DEBUG
@@ -208,8 +208,10 @@ std::string GetCallstack(int skip) {
   return rendering::Utils::Backtrace("Callstack:\n", skip);
 }
 #else
-void CheckOpenGLError(std::string tag) {}
-std::string GetCallstack(int skip) { return std::string("Callstack:\n"); }
+void CheckOpenGLError([[maybe_unused]] std::string tag) {}
+std::string GetCallstack([[maybe_unused]] int skip) {
+  return std::string("Callstack:\n");
+}
 #endif
 
 std::string rendering::Utils::PrintGLErrorDescription(unsigned int glErr) {

--- a/gui/rendering/Utils.hpp
+++ b/gui/rendering/Utils.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_UTILS_H
-#define SPATIALMODELEDITOR_UTILS_H
+#pragma once
 
 #include <stdio.h>
 #include <string>
@@ -34,5 +33,3 @@ public:
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_UTILS_H

--- a/gui/rendering/WireframeObject.hpp
+++ b/gui/rendering/WireframeObject.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_WIREFRAMEOBJECT_H
-#define SPATIALMODELEDITOR_WIREFRAMEOBJECT_H
+#pragma once
 
 #include "ObjectInfo.hpp"
 #include "ObjectLoader.hpp"
@@ -73,5 +72,3 @@ private:
 };
 
 } // namespace rendering
-
-#endif // SPATIALMODELEDITOR_WIREFRAMEOBJECT_H

--- a/gui/rendering/rendering.hpp
+++ b/gui/rendering/rendering.hpp
@@ -2,8 +2,7 @@
 // Created by acaramizaru on 6/30/23.
 //
 
-#ifndef SPATIALMODELEDITOR_RENDERING_H
-#define SPATIALMODELEDITOR_RENDERING_H
+#pragma once
 
 #include "Camera.hpp"
 #include "ObjectInfo.hpp"
@@ -13,5 +12,3 @@
 #include "Shaders/default/vertex.hpp"
 #include "Utils.hpp"
 #include "WireframeObject.hpp"
-
-#endif // SPATIALMODELEDITOR_RENDERING_H

--- a/gui/widgets/qlabelmousetracker_t.cpp
+++ b/gui/widgets/qlabelmousetracker_t.cpp
@@ -9,18 +9,17 @@ static const char *tags{
 
 TEST_CASE("QLabelMouseTracker: single pixel, single colour image", tags) {
   QLabelMouseTracker mouseTracker;
-  QImage img(1, 1, QImage::Format_RGB32);
+  sme::common::ImageStack imgs{{QImage(1, 1, QImage::Format_RGB32)}};
   QRgb col{qRgb(12, 243, 154)};
-  img.setPixel(0, 0, col);
+  imgs[0].setPixel(0, 0, col);
   mouseTracker.show();
   mouseTracker.resize(100, 100);
   // NB: window managers might interfere with above resizing
   // so wait a bit until the size is correct and stable
   wait();
-  mouseTracker.setImage(img);
-  REQUIRE(mouseTracker.getImage().volume() ==
-          sme::common::Volume{img.size(), 1});
-  REQUIRE(mouseTracker.getImage()[0].pixel(0, 0) == img.pixel(0, 0));
+  mouseTracker.setImage(imgs);
+  REQUIRE(mouseTracker.getImage().volume() == imgs.volume());
+  REQUIRE(mouseTracker.getImage()[0].pixel(0, 0) == imgs[0].pixel(0, 0));
 
   std::vector<QRgb> clicks;
   QObject::connect(&mouseTracker, &QLabelMouseTracker::mouseClicked,
@@ -67,7 +66,7 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
   img.setPixel(0, 1, col3);
   img.setPixel(0, 2, col3);
   img.setPixel(1, 1, col4);
-  mouseTracker.setImage(img);
+  mouseTracker.setImage(sme::common::ImageStack({{img}}));
   mouseTracker.show();
   mouseTracker.resize(100, 100);
   wait();
@@ -225,21 +224,20 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
 
 TEST_CASE("QLabelMouseTracker: image and mask", tags) {
   QLabelMouseTracker mouseTracker;
-  QImage img(":/geometry/circle-100x100.png");
-  QImage mask(":/geometry/concave-cell-nucleus-100x100.png");
+  sme::common::ImageStack img{{QImage(":/geometry/circle-100x100.png")}};
+  sme::common::ImageStack mask{
+      {QImage(":/geometry/concave-cell-nucleus-100x100.png")}};
   mouseTracker.setImages({img, mask});
   mouseTracker.show();
   mouseTracker.resize(100, 100);
   wait();
 
-  REQUIRE(mouseTracker.getImage().volume() ==
-          sme::common::Volume{img.size(), 1});
-  REQUIRE(mouseTracker.getImage()[0].pixel(0, 0) == img.pixel(0, 0));
-  REQUIRE(mouseTracker.getImage()[0].pixel(2, 2) == img.pixel(2, 2));
-  REQUIRE(mouseTracker.getMaskImage().volume() ==
-          sme::common::Volume{mask.size(), 1});
-  REQUIRE(mouseTracker.getMaskImage()[0].pixel(0, 0) == mask.pixel(0, 0));
-  REQUIRE(mouseTracker.getMaskImage()[0].pixel(2, 2) == mask.pixel(2, 2));
+  REQUIRE(mouseTracker.getImage().volume() == img.volume());
+  REQUIRE(mouseTracker.getImage()[0].pixel(0, 0) == img[0].pixel(0, 0));
+  REQUIRE(mouseTracker.getImage()[0].pixel(2, 2) == img[0].pixel(2, 2));
+  REQUIRE(mouseTracker.getMaskImage().volume() == mask.volume());
+  REQUIRE(mouseTracker.getMaskImage()[0].pixel(0, 0) == mask[0].pixel(0, 0));
+  REQUIRE(mouseTracker.getMaskImage()[0].pixel(2, 2) == mask[0].pixel(2, 2));
 
   std::vector<QRgb> clicks;
   QObject::connect(&mouseTracker, &QLabelMouseTracker::mouseClicked,

--- a/gui/widgets/qopenglmousetracker.cpp
+++ b/gui/widgets/qopenglmousetracker.cpp
@@ -2,7 +2,7 @@
 // Created by acaramizaru on 7/25/23.
 //
 
-#include "qopenglmousetracker.h"
+#include "qopenglmousetracker.hpp"
 
 QOpenGLMouseTracker::QOpenGLMouseTracker(float lineWidth,
                                          float lineSelectPrecision,
@@ -221,10 +221,8 @@ QVector3D QOpenGLMouseTracker::GetCameraOrientation() const {
 void QOpenGLMouseTracker::addMesh(const rendering::SMesh &mesh, QColor color) {
   rendering::ObjectInfo objectInfo = rendering::ObjectLoader::Load(mesh);
 
-  m_meshSet.push_back(std::make_pair(
-      color,
-      std::unique_ptr<rendering::WireframeObject>(
-          new rendering::WireframeObject(objectInfo, color, mesh, this))));
+  m_meshSet.emplace_back(color, std::make_unique<rendering::WireframeObject>(
+                                    objectInfo, color, mesh, this));
 }
 
 void QOpenGLMouseTracker::setFPS(float frameRate) { m_frameRate = frameRate; }

--- a/gui/widgets/qopenglmousetracker.hpp
+++ b/gui/widgets/qopenglmousetracker.hpp
@@ -2,16 +2,14 @@
 // Created by acaramizaru on 7/25/23.
 //
 
-#ifndef SPATIALMODELEDITOR_QOPENGLMOUSETRACKER_H
-#define SPATIALMODELEDITOR_QOPENGLMOUSETRACKER_H
+#pragma once
 
 #include <QOpenGLWidget>
+#include <QTimer>
 #include <QWidget>
 #include <QtOpenGL>
 
 #include "rendering/rendering.hpp"
-
-#include <QTimer>
 
 class QOpenGLMouseTracker : public QOpenGLWidget {
   Q_OBJECT
@@ -87,5 +85,3 @@ protected:
 
   void wheelEvent(QWheelEvent *event) override;
 };
-
-#endif // SPATIALMODELEDITOR_QOPENGLMOUSETRACKER_H

--- a/gui/widgets/qopenglmousetracker_t.cpp
+++ b/gui/widgets/qopenglmousetracker_t.cpp
@@ -5,13 +5,11 @@
 #include "catch_wrapper.hpp"
 #include "qt_test_utils.hpp"
 
+#include "qopenglmousetracker.hpp"
 #include "rendering/rendering.hpp"
+#include "sme/logger.hpp"
 
 using namespace sme::test;
-
-#include "qopenglmousetracker.h"
-
-#include "sme/logger.hpp"
 
 static const char *tags{"[gui/widgets/QOpenGLMouseTracker][gui][opengl]"};
 

--- a/sme/CMakeLists.txt
+++ b/sme/CMakeLists.txt
@@ -9,9 +9,6 @@ target_sources(sme PRIVATE sme.cpp)
 target_include_directories(sme PRIVATE src)
 add_subdirectory(src)
 
-set_target_properties(sme PROPERTIES CXX_STANDARD 20)
-set_target_properties(sme PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
 # https://github.com/pybind/pybind11/issues/1818#issuecomment-506031452
 target_compile_options(sme
                        PUBLIC $<$<CXX_COMPILER_ID:Clang>:-fsized-deallocation>)

--- a/sme/src/sme_common.hpp
+++ b/sme/src/sme_common.hpp
@@ -36,9 +36,8 @@ T &findElem(std::vector<T> &v, typename std::vector<T>::difference_type i) {
 }
 
 template <typename T> T &findElem(std::vector<T> &v, const std::string &name) {
-  if (auto iter = std::find_if(
-          v.begin(), v.end(),
-          [&name](const auto &elem) { return elem.getName() == name; });
+  if (auto iter = std::ranges::find_if(
+          v, [&name](const auto &elem) { return elem.getName() == name; });
       iter != v.end()) {
     return *iter;
   }

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -193,6 +193,8 @@ def test_import_geometry_from_image():
     m = sme.open_example_model()
     comp_img_0 = m.compartment_image
     nucl_mask_0 = m.compartments["Nucleus"].geometry_mask
+    with pytest.raises(sme.InvalidArgument):
+        m.import_geometry_from_image("idontexist.tiff")
     m.import_geometry_from_image(imgfile_modified)
     comp_img_1 = m.compartment_image
     nucl_mask_1 = m.compartments["Nucleus"].geometry_mask

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(
   REQUIRED
   CONFIG
   COMPONENTS Test)
-set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
 add_library(testlib resources/test_resources.qrc)
 if(SME_QT_DISABLE_UNICODE)


### PR DESCRIPTION
- remove redundant `!=` operator definition as is now inferred from `==`
- use `contains` boolean member function of containers
- use `using enum`
- add `cxx_std_20` as a public compile feature of core
- use ranges
- resolves #913

Other code quality improvements (that don't require c++20)

- use `std::less<>` transparent comparator in sets/maps of strings
- remove convenience `ImageStack(const QImage &)` constructor and refactor test code accordingly
- add `ImageStack` constructor that takes a filename
  - refactor common code from sme_model.cpp and guiutils.cpp into this constructor
- use #pragma once for all headers
- use emplace make and make_unique
- remove no longer used `modelHasIndependentCompartments` from dune_converter_impl