### PR TITLE
simplify `Symbolic` and dependent classes by removing pimpl idiom & explicit move-only constructors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     - id: nbstripout
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v17.0.4
+    rev: v17.0.5
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -38,7 +38,7 @@ repos:
       - id: beautysh
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.1
+    rev: 0.27.2
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/core/common/src/symbolic.cpp
+++ b/core/common/src/symbolic.cpp
@@ -1,41 +1,23 @@
 #include "sme/symbolic.hpp"
 #include "sme/logger.hpp"
-#include <llvm/Config/llvm-config.h>
 #include <map>
 #include <ranges>
-#include <symengine/basic.h>
-#include <symengine/llvm_double.h>
-#include <symengine/parser/sbml/sbml_parser.h>
-#include <symengine/symengine_rcp.h>
 
 namespace sme::common {
 
-using namespace SymEngine;
-
-struct Symbolic::SymEngineFunc {
+struct SymEngineFunc {
   std::string name{};
-  vec_basic args{};
-  RCP<const Basic> body{};
+  SymEngine::vec_basic args{};
+  SymEngine::RCP<const SymEngine::Basic> body{};
   SymEngineFunc() = default;
-  explicit SymEngineFunc(const SymbolicFunction &symbolicFunction);
-};
-
-Symbolic::SymEngineFunc::SymEngineFunc(const SymbolicFunction &symbolicFunction)
-    : name{symbolicFunction.name} {
-  SbmlParser parser;
-  for (const auto &arg : symbolicFunction.args) {
-    args.push_back(parser.parse(arg));
+  explicit SymEngineFunc(const SymbolicFunction &symbolicFunction)
+      : name{symbolicFunction.name} {
+    SymEngine::SbmlParser parser;
+    for (const auto &arg : symbolicFunction.args) {
+      args.push_back(parser.parse(arg));
+    }
+    body = parser.parse(symbolicFunction.body);
   }
-  body = parser.parse(symbolicFunction.body);
-}
-
-struct Symbolic::SymEngineWrapper {
-  LLVMDoubleVisitor lambdaLLVM{};
-  vec_basic exprInlined{};
-  vec_basic exprOriginal{};
-  vec_basic varVec{};
-  std::map<std::string, RCP<const Symbol>, std::less<>> symbols{};
-  std::string errorMessage{};
 };
 
 Symbolic::Symbolic() = default;
@@ -44,23 +26,39 @@ Symbolic::Symbolic(const std::vector<std::string> &expressions,
                    const std::vector<std::string> &variables,
                    const std::vector<std::pair<std::string, double>> &constants,
                    const std::vector<SymbolicFunction> &functions,
-                   bool allow_unknown_symbols)
-    : se{std::make_unique<SymEngineWrapper>()} {
+                   bool allow_unknown_symbols) {
+  parse(expressions, variables, constants, functions, allow_unknown_symbols);
+}
+
+Symbolic::Symbolic(const std::string &expression,
+                   const std::vector<std::string> &variables,
+                   const std::vector<std::pair<std::string, double>> &constants,
+                   const std::vector<SymbolicFunction> &functions,
+                   bool allow_unknown_symbols) {
+  parse(expression, variables, constants, functions, allow_unknown_symbols);
+}
+
+bool Symbolic::parse(
+    const std::vector<std::string> &expressions,
+    const std::vector<std::string> &variables,
+    const std::vector<std::pair<std::string, double>> &constants,
+    const std::vector<SymbolicFunction> &functions,
+    bool allow_unknown_symbols) {
+  clear();
   SPDLOG_DEBUG("parsing {} expressions", expressions.size());
   for (const auto &v : variables) {
     SPDLOG_DEBUG("  - variable {}", v);
-    se->symbols[v] = symbol(v);
-    se->varVec.push_back(se->symbols[v]);
+    symbols[v] = SymEngine::symbol(v);
+    varVec.push_back(symbols[v]);
   }
-  map_basic_basic d;
+  SymEngine::map_basic_basic d;
   for (const auto &[name, value] : constants) {
     SPDLOG_DEBUG("  - constant {} = {}", name, value);
-    d[symbol(name)] = real_double(value);
+    d[SymEngine::symbol(name)] = SymEngine::real_double(value);
   }
   // hack until https://github.com/symengine/symengine/issues/1566 is resolved:
   // (SymEngine parser relies on strtod and assumes C locale)
   std::locale userLocale{std::locale::global(std::locale::classic())};
-  SbmlParser parser;
   // map from function id to symengine expressions
   std::map<std::string, SymEngineFunc, std::less<>> symEngineFuncs;
   for (const auto &function : functions) {
@@ -68,7 +66,7 @@ Symbolic::Symbolic(const std::vector<std::string> &expressions,
     symEngineFuncs[function.id] = SymEngineFunc(function);
   }
   for (const auto &expression : expressions) {
-    map_basic_basic fns;
+    SymEngine::map_basic_basic fns;
     SPDLOG_DEBUG("expr {}", expression);
     // parse expression & substitute all supplied functions & numeric constants
     // todo: clean this up - see
@@ -76,28 +74,30 @@ Symbolic::Symbolic(const std::vector<std::string> &expressions,
     try {
       int remainingAllowedReplaceLoops{1024};
       auto e{parser.parse(expression)};
-      RCP<const Basic> ePrevious{zero};
-      se->exprOriginal.push_back(e);
+      SymEngine::RCP<const SymEngine::Basic> ePrevious{SymEngine::zero};
+      exprOriginal.push_back(e);
       auto remainingSymbols{function_symbols(*e)};
       while (!remainingSymbols.empty() && !eq(*e, *ePrevious) &&
              --remainingAllowedReplaceLoops > 0) {
         ePrevious = e;
         for (const auto &funcSymbol : remainingSymbols) {
           auto name =
-              rcp_dynamic_cast<const FunctionSymbol>(funcSymbol)->get_name();
+              rcp_dynamic_cast<const SymEngine::FunctionSymbol>(funcSymbol)
+                  ->get_name();
           if (auto iter{symEngineFuncs.find(name)};
               iter != symEngineFuncs.cend()) {
             const auto &f = iter->second;
             const auto &args = funcSymbol->get_args();
             if (args.size() != f.args.size()) {
-              se->errorMessage =
-                  fmt::format("Function '{}' requires {} argument(s), found {}",
-                              f.name, f.args.size(), args.size());
-              SPDLOG_WARN("{}", se->errorMessage);
+              errorMessage =
+                  fmt::format("Error parsing expression '{}': Function '{}' "
+                              "requires {} argument(s), found {}",
+                              expression, f.name, f.args.size(), args.size());
+              SPDLOG_WARN("{}", errorMessage);
               std::locale::global(userLocale);
-              return;
+              return false;
             }
-            map_basic_basic arg_map;
+            SymEngine::map_basic_basic arg_map;
             for (std::size_t i = 0; i < args.size(); ++i) {
               arg_map[f.args[i]] = args[i];
             }
@@ -113,126 +113,134 @@ Symbolic::Symbolic(const std::vector<std::string> &expressions,
         remainingSymbols = function_symbols(*e);
       }
       if (remainingAllowedReplaceLoops <= 0) {
-        se->errorMessage = "Recursive function calls not supported";
-        SPDLOG_WARN("{}", se->errorMessage);
+        errorMessage = fmt::format("Error parsing expression '{}': Recursive "
+                                   "function calls are not supported",
+                                   expression);
+        SPDLOG_WARN("{}", errorMessage);
         std::locale::global(userLocale);
-        return;
+        return false;
       }
-      se->exprInlined.push_back(e->subs(d));
-    } catch (const SymEngineException &e) {
+      exprInlined.push_back(e->subs(d));
+    } catch (const SymEngine::SymEngineException &e) {
       // if SymEngine failed to parse, capture error message
       SPDLOG_WARN("{}", e.what());
-      se->errorMessage = e.what();
+      errorMessage = fmt::format("Error parsing expression '{}': {}",
+                                 expression, e.what());
       std::locale::global(userLocale);
-      return;
+      return false;
     }
-    SPDLOG_DEBUG("  --> {}", sbml(*se->exprInlined.back()));
+    SPDLOG_DEBUG("  --> {}", sbml(*exprInlined.back()));
     if (!allow_unknown_symbols) {
       // check that all remaining symbols are in the variables vector
-      auto fs{free_symbols(*se->exprInlined.back())};
+      auto fs{free_symbols(*exprInlined.back())};
       if (auto iter = std::ranges::find_if(
               fs,
               [&v = variables](const auto &s) {
                 return std::ranges::find(v, sbml(*s)) == std::cend(v);
               });
           iter != std::cend(fs)) {
-        se->errorMessage = "Unknown symbol: " + sbml(*(*iter));
-        SPDLOG_WARN("{}", se->errorMessage);
+        errorMessage =
+            fmt::format("Error parsing expression '{}': Unknown symbol '{}'",
+                        expression, sbml(*(*iter)));
+        SPDLOG_WARN("{}", errorMessage);
         std::locale::global(userLocale);
-        return;
+        return false;
       }
     }
-    auto fn{function_symbols(*se->exprInlined.back())};
+    auto fn{function_symbols(*exprInlined.back())};
     if (!fn.empty()) {
-      se->errorMessage = "Unknown function: " + sbml(*(*fn.begin()));
-      SPDLOG_WARN("{}", se->errorMessage);
+      errorMessage =
+          fmt::format("Error parsing expression '{}': Unknown function '{}'",
+                      expression, sbml(*(*fn.begin())));
+      SPDLOG_WARN("{}", errorMessage);
       std::locale::global(userLocale);
-      return;
+      return false;
     }
   }
   valid = true;
   std::locale::global(userLocale);
+  return true;
 }
 
-Symbolic::~Symbolic() = default;
+bool Symbolic::parse(
+    const std::string &expression, const std::vector<std::string> &variables,
+    const std::vector<std::pair<std::string, double>> &constants,
+    const std::vector<SymbolicFunction> &functions,
+    bool allow_unknown_symbols) {
+  return parse(std::vector<std::string>{expression}, variables, constants,
+               functions, allow_unknown_symbols);
+}
 
-Symbolic::Symbolic(Symbolic &&) noexcept = default;
-
-Symbolic &Symbolic::operator=(Symbolic &&) noexcept = default;
-
-const char *Symbolic::getLLVMVersion() { return LLVM_VERSION_STRING; }
-
-void Symbolic::compile(bool doCSE, unsigned optLevel) {
+bool Symbolic::compile(bool doCSE, unsigned optLevel) {
+  lambdaLLVM = std::make_unique<SymEngine::LLVMDoubleVisitor>();
   if (!valid) {
-    return;
+    return false;
   }
   SPDLOG_DEBUG("compiling expression:");
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-  if (se->varVec.size() == se->exprInlined.size()) {
-    for (std::size_t i = 0; i < se->varVec.size(); ++i) {
-      SPDLOG_TRACE("  [{}] <- {}", sbml(*se->varVec[i]),
-                   sbml(*se->exprInlined[i]));
+  if (varVec.size() == exprInlined.size()) {
+    for (std::size_t i = 0; i < varVec.size(); ++i) {
+      SPDLOG_TRACE("  [{}] <- {}", sbml(*varVec[i]), sbml(*exprInlined[i]));
     }
   }
 #endif
   try {
-    se->lambdaLLVM.init(se->varVec, se->exprInlined, doCSE, optLevel);
+    lambdaLLVM->init(varVec, exprInlined, doCSE, optLevel);
   } catch (const std::exception &e) {
     // if SymEngine failed to compile, capture error message
     SPDLOG_WARN("{}", e.what());
     valid = false;
     compiled = false;
-    se->errorMessage = "Failed to compile expression: ";
-    se->errorMessage.append(e.what());
-    return;
+    errorMessage = fmt::format("Error compiling expression: {}", e.what());
+    return false;
   }
   compiled = true;
+  return true;
 }
 
 std::string Symbolic::expr(std::size_t i) const {
-  return sbml(*se->exprOriginal[i]);
+  return sbml(*exprOriginal[i]);
 }
 
 std::string Symbolic::inlinedExpr(std::size_t i) const {
-  return sbml(*se->exprInlined[i]);
+  return sbml(*exprInlined[i]);
 }
 
 std::string Symbolic::diff(const std::string &var, std::size_t i) const {
-  return sbml(*se->exprInlined[i]->diff(se->symbols.at(var)));
+  return sbml(*exprInlined[i]->diff(symbols.at(var)));
 }
 
 void Symbolic::relabel(const std::vector<std::string> &newVariables) {
-  if (se->varVec.size() != newVariables.size()) {
+  if (varVec.size() != newVariables.size()) {
     SPDLOG_WARN("cannot relabel variables: newVariables size {} "
                 "does not match number of existing variables {}",
-                newVariables.size(), se->varVec.size());
+                newVariables.size(), varVec.size());
     return;
   }
-  decltype(se->varVec) newVarVec;
-  decltype(se->symbols) newSymbols;
-  map_basic_basic d;
+  decltype(varVec) newVarVec;
+  decltype(symbols) newSymbols;
+  SymEngine::map_basic_basic d;
   for (std::size_t i = 0; i < newVariables.size(); ++i) {
     const auto &v = newVariables[i];
-    newSymbols[v] = symbol(v);
+    newSymbols[v] = SymEngine::symbol(v);
     newVarVec.push_back(newSymbols[v]);
-    d[se->varVec[i]] = newVarVec[i];
-    SPDLOG_DEBUG("relabeling {} -> {}", sbml(*se->varVec[i]),
-                 sbml(*newVarVec[i]));
+    d[varVec[i]] = newVarVec[i];
+    SPDLOG_DEBUG("relabeling {} -> {}", sbml(*varVec[i]), sbml(*newVarVec[i]));
   }
   // substitute new variables into all expressions
-  for (auto &e : se->exprInlined) {
+  for (auto &e : exprInlined) {
     SPDLOG_DEBUG("exprInlined '{}'", sbml(*e));
     e = e->subs(d);
     SPDLOG_DEBUG("  -> '{}'", sbml(*e));
   }
-  for (auto &e : se->exprOriginal) {
+  for (auto &e : exprOriginal) {
     SPDLOG_DEBUG("exprOriginal '{}'", sbml(*e));
     e = e->subs(d);
     SPDLOG_DEBUG("  -> '{}'", sbml(*e));
   }
   // replace old variables with new variables in vector & map
-  std::swap(se->varVec, newVarVec);
-  std::swap(se->symbols, newSymbols);
+  std::swap(varVec, newVarVec);
+  std::swap(symbols, newSymbols);
   if (compiled) {
     compile(true, 3);
   }
@@ -240,21 +248,21 @@ void Symbolic::relabel(const std::vector<std::string> &newVariables) {
 
 void Symbolic::rescale(double factor,
                        const std::vector<std::string> &exclusions) {
-  map_basic_basic d;
-  auto f = number(factor);
-  for (const auto &v : se->varVec) {
+  SymEngine::map_basic_basic d;
+  auto f = SymEngine::number(factor);
+  for (const auto &v : varVec) {
     if (std::ranges::find(exclusions, sbml(*v)) != std::cend(exclusions)) {
       d[v] = v;
     } else {
       d[v] = mul(v, f);
     }
   }
-  for (auto &e : se->exprInlined) {
+  for (auto &e : exprInlined) {
     SPDLOG_DEBUG("exprInlined '{}'", sbml(*e));
     e = e->subs(d);
     SPDLOG_DEBUG("  -> '{}'", sbml(*e));
   }
-  for (auto &e : se->exprOriginal) {
+  for (auto &e : exprOriginal) {
     SPDLOG_DEBUG("exprOriginal '{}'", sbml(*e));
     e = e->subs(d);
     SPDLOG_DEBUG("  -> '{}'", sbml(*e));
@@ -266,19 +274,27 @@ void Symbolic::rescale(double factor,
 
 void Symbolic::eval(std::vector<double> &results,
                     const std::vector<double> &vars) const {
-  se->lambdaLLVM.call(results.data(), vars.data());
+  lambdaLLVM->call(results.data(), vars.data());
 }
 
 void Symbolic::eval(double *results, const double *vars) const {
-  se->lambdaLLVM.call(results, vars);
+  lambdaLLVM->call(results, vars);
 }
 
 bool Symbolic::isValid() const { return valid; }
 
 bool Symbolic::isCompiled() const { return compiled; }
 
-const std::string &Symbolic::getErrorMessage() const {
-  return se->errorMessage;
-}
+const std::string &Symbolic::getErrorMessage() const { return errorMessage; }
 
+void Symbolic::clear() {
+  lambdaLLVM.reset();
+  exprInlined.clear();
+  exprOriginal.clear();
+  varVec.clear();
+  symbols.clear();
+  errorMessage.clear();
+  valid = false;
+  compiled = false;
+}
 } // namespace sme::common

--- a/core/simulate/include/sme/pde.hpp
+++ b/core/simulate/include/sme/pde.hpp
@@ -27,8 +27,7 @@ class Model;
 namespace simulate {
 
 class PdeError : public std::runtime_error {
-public:
-  explicit PdeError(const std::string &message) : std::runtime_error(message) {}
+  using std::runtime_error::runtime_error;
 };
 
 struct PdeScaleFactors {

--- a/core/simulate/src/pde_t.cpp
+++ b/core/simulate/src/pde_t.cpp
@@ -6,6 +6,7 @@
 
 using namespace sme;
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
   SECTION("ABtoC model") {
@@ -37,7 +38,7 @@ TEST_CASE("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     s.getReactions().setSpeciesStoichiometry("r3", "A", 1.0);
     std::vector<std::string> speciesIDs{"A", "B", "C"};
     REQUIRE_THROWS_WITH(simulate::Pde(&s, speciesIDs, {"r1", "r2", "r3"}),
-                        "Unknown symbol: idontexist");
+                        ContainsSubstring("Unknown symbol 'idontexist'"));
   }
   SECTION("simple model") {
     auto s{getTestModel("invalid-dune-names")};

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -27,6 +27,10 @@
 
 namespace sme::simulate {
 
+class PixelSimImplError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 template <typename Body>
 static void tbbParallelFor(std::size_t n, const Body &body) {
   constexpr std::size_t tbbGrainSize{64};
@@ -36,12 +40,12 @@ static void tbbParallelFor(std::size_t n, const Body &body) {
       partitioner);
 }
 
-ReacEval::ReacEval(
+ReacExpr::ReacExpr(
     const model::Model &doc, const std::vector<std::string> &speciesIDs,
     const std::vector<std::string> &reactionIDs, double reactionScaleFactor,
-    bool doCSE, unsigned optLevel, bool timeDependent, bool spaceDependent,
+    bool timeDependent, bool spaceDependent,
     const std::map<std::string, double, std::less<>> &substitutions) {
-  // construct reaction expressions and stoich matrix
+  // construct reaction expressions and variables
   PdeScaleFactors pdeScaleFactors;
   pdeScaleFactors.reaction = reactionScaleFactor;
   std::vector<std::string> extraVars{};
@@ -57,32 +61,16 @@ ReacEval::ReacEval(
   Pde pde(&doc, speciesIDs, reactionIDs, {}, pdeScaleFactors, extraVars, {},
           substitutions);
   // add dt/dt = 1 reaction term, and t,x,y "species"
-  auto sIds{speciesIDs};
-  sIds.insert(sIds.end(), extraVars.cbegin(), extraVars.cend());
-  auto rhs{pde.getRHS()};
+  variables = speciesIDs;
+  variables.insert(variables.end(), extraVars.cbegin(), extraVars.cend());
+  expressions = pde.getRHS();
   if (timeDependent) {
-    rhs.push_back("1"); // dt/dt = 1
+    expressions.emplace_back("1"); // dt/dt = 1
   }
   if (spaceDependent) {
-    rhs.push_back("0"); // dx/dt = 0
-    rhs.push_back("0"); // dy/dt = 0
+    expressions.emplace_back("0"); // dx/dt = 0
+    expressions.emplace_back("0"); // dy/dt = 0
   }
-  // compile all expressions with symengine
-  sym = common::Symbolic(rhs, sIds);
-  if (sym.isValid()) {
-    sym.compile(doCSE, optLevel);
-  }
-  if (!sym.isCompiled()) {
-    std::string msg{sym.getErrorMessage()};
-    msg.append("\nExpression: \"");
-    msg.append(sym.expr());
-    msg.append("\"");
-    throw ReacEvalError(msg);
-  }
-}
-
-void ReacEval::evaluate(double *output, const double *input) const {
-  sym.eval(output, input);
 }
 
 void SimCompartment::spatiallyAverageDcdt() {
@@ -143,8 +131,12 @@ SimCompartment::SimCompartment(
       !reacsInCompartment.isEmpty()) {
     reactionIDs = common::toStdString(reacsInCompartment);
   }
-  reacEval = ReacEval(doc, speciesIds, reactionIDs, 1.0, doCSE, optLevel,
-                      timeDependent, spaceDependent, substitutions);
+  ReacExpr reacExpr(doc, speciesIds, reactionIDs, 1.0, timeDependent,
+                    spaceDependent, substitutions);
+  if (!(sym.parse(reacExpr.expressions, reacExpr.variables) &&
+        sym.compile(doCSE, optLevel))) {
+    throw PixelSimImplError(sym.getErrorMessage());
+  }
   if (timeDependent) {
     speciesIds.push_back("time");
     diffConstants.push_back({0.0, 0.0, 0.0});
@@ -219,7 +211,7 @@ void SimCompartment::evaluateDiffusionOperator(std::size_t begin,
 
 void SimCompartment::evaluateReactions(std::size_t begin, std::size_t end) {
   for (std::size_t i = begin; i < end; ++i) {
-    reacEval.evaluate(dcdt.data() + i * nSpecies, conc.data() + i * nSpecies);
+    sym.eval(dcdt.data() + i * nSpecies, conc.data() + i * nSpecies);
   }
 }
 
@@ -513,8 +505,12 @@ SimMembrane::SimMembrane(
   // make vector of reaction IDs from membrane
   std::vector<std::string> reactionID =
       common::toStdString(doc.getReactions().getIds(membrane->getId().c_str()));
-  reacEval = ReacEval(doc, speciesIds, reactionID, volOverL3, doCSE, optLevel,
-                      timeDependent, spaceDependent, substitutions);
+  ReacExpr reacExpr(doc, speciesIds, reactionID, volOverL3, timeDependent,
+                    spaceDependent, substitutions);
+  if (!(sym.parse(reacExpr.expressions, reacExpr.variables) &&
+        sym.compile(doCSE, optLevel))) {
+    throw PixelSimImplError(sym.getErrorMessage());
+  }
 }
 
 void SimMembrane::evaluateReactions() {
@@ -556,7 +552,7 @@ void SimMembrane::evaluateReactions() {
       }
 
       // evaluate reaction terms
-      reacEval.evaluate(result.data(), species.data());
+      sym.eval(result.data(), species.data());
 
       // add results to dc/dt: first A, then B. divide by fluxLength to get
       // change in concentration for this voxel

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -1,5 +1,4 @@
 // Pixel simulator implementation
-//  - ReacEval: evaluates reaction terms at a single location
 //  - SimCompartment: evaluates reactions in a compartment
 //  - SimMembrane: evaluates reactions in a membrane
 
@@ -29,37 +28,20 @@ class Membrane;
 
 namespace simulate {
 
-class ReacEvalError : public std::runtime_error {
-public:
-  explicit ReacEvalError(const std::string &message)
-      : std::runtime_error(message) {}
-};
-
-class ReacEval {
-private:
-  // symengine reaction expression
-  common::Symbolic sym;
-
-public:
-  ReacEval() = default;
-  ReacEval(
+struct ReacExpr {
+  std::vector<std::string> expressions;
+  std::vector<std::string> variables;
+  ReacExpr(
       const model::Model &doc, const std::vector<std::string> &speciesID,
       const std::vector<std::string> &reactionID,
-      double reactionScaleFactor = 1.0, bool doCSE = true,
-      unsigned optLevel = 3, bool timeDependent = false,
+      double reactionScaleFactor = 1.0, bool timeDependent = false,
       bool spaceDependent = false,
       const std::map<std::string, double, std::less<>> &substitutions = {});
-  ReacEval(ReacEval &&) noexcept = default;
-  ReacEval(const ReacEval &) = delete;
-  ReacEval &operator=(ReacEval &&) noexcept = default;
-  ReacEval &operator=(const ReacEval &) = delete;
-  ~ReacEval() = default;
-  void evaluate(double *output, const double *input) const;
 };
 
 class SimCompartment {
 private:
-  ReacEval reacEval;
+  common::Symbolic sym;
   // species concentrations & corresponding dcdt values
   // ordering: ix, species
   std::vector<double> conc;
@@ -84,11 +66,6 @@ public:
       std::vector<std::string> sIds, bool doCSE = true, unsigned optLevel = 3,
       bool timeDependent = false, bool spaceDependent = false,
       const std::map<std::string, double, std::less<>> &substitutions = {});
-  SimCompartment(SimCompartment &&) noexcept = default;
-  SimCompartment(const SimCompartment &) = delete;
-  SimCompartment &operator=(SimCompartment &&) noexcept = default;
-  SimCompartment &operator=(const SimCompartment &) = delete;
-  ~SimCompartment() = default;
 
   // dcdt = result of applying diffusion operator to conc
   void evaluateDiffusionOperator(std::size_t begin, std::size_t end);
@@ -136,7 +113,7 @@ public:
 
 class SimMembrane {
 private:
-  ReacEval reacEval;
+  common::Symbolic sym;
   const geometry::Membrane *membrane;
   SimCompartment *compA;
   SimCompartment *compB;
@@ -150,11 +127,6 @@ public:
       unsigned optLevel = 3, bool timeDependent = false,
       bool spaceDependent = false,
       const std::map<std::string, double, std::less<>> &substitutions = {});
-  SimMembrane(SimMembrane &&) noexcept = default;
-  SimMembrane(const SimMembrane &) = delete;
-  SimMembrane &operator=(SimMembrane &&) noexcept = default;
-  SimMembrane &operator=(const SimMembrane &) = delete;
-  ~SimMembrane() = default;
   void evaluateReactions();
 };
 

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -14,6 +14,7 @@
 
 using namespace sme;
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("Simulate: very_simple_model, single pixel geometry",
           "[core/simulate/simulate][core/simulate][core][simulate][pixel]") {
@@ -2023,8 +2024,8 @@ TEST_CASE("pixel simulation with invalid reaction rate expression",
   m.getReactions().add("r2", "comp", "A * A / idontexist");
   m.getReactions().setSpeciesStoichiometry("r2", "A", 1.0);
   m.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
-  REQUIRE(simulate::Simulation(m).errorMessage() ==
-          "Unknown symbol: idontexist");
+  REQUIRE_THAT(simulate::Simulation(m).errorMessage(),
+               ContainsSubstring("Unknown symbol 'idontexist'"));
 }
 
 TEST_CASE("Fish model: simulation with piecewise function in reactions",

--- a/gui/dialogs/dialogabout.cpp
+++ b/gui/dialogs/dialogabout.cpp
@@ -10,6 +10,7 @@
 #include <expat.h>
 #include <fmt/core.h>
 #include <gmp.h>
+#include <llvm/Config/llvm-config.h>
 #include <mpfr.h>
 #include <omex/common/libcombine-version.h>
 #include <oneapi/tbb/version.h>
@@ -65,8 +66,7 @@ DialogAbout::DialogAbout(QWidget *parent)
                        FMT_VERSION % 100));
   libraries.append(dep("SymEngine", "https://github.com/symengine/symengine",
                        SYMENGINE_VERSION));
-  libraries.append(dep("LLVM core", "https://llvm.org",
-                       sme::common::Symbolic::getLLVMVersion()));
+  libraries.append(dep("LLVM core", "https://llvm.org", LLVM_VERSION_STRING));
   libraries.append(dep("GMP", "https://gmplib.org", __GNU_MP_VERSION,
                        __GNU_MP_VERSION_MINOR, __GNU_MP_VERSION_PATCHLEVEL));
   libraries.append(dep("MPFR", "https://www.mpfr.org/", MPFR_VERSION_MAJOR,

--- a/gui/tabs/tabevents_t.cpp
+++ b/gui/tabs/tabevents_t.cpp
@@ -11,6 +11,7 @@
 #include <QPushButton>
 
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("TabEvents", "[gui/tabs/events][gui/tabs][gui][events]") {
   sme::model::Model model;
@@ -129,7 +130,8 @@ TEST_CASE("TabEvents", "[gui/tabs/events][gui/tabs][gui][events]") {
     txtExpression->setFocus();
     sendKeyEvents(txtExpression, {"Delete", "Backspace", "Backspace"});
     REQUIRE(txtExpression->toPlainText() == "");
-    REQUIRE(lblExpressionStatus->text() == "Empty expression");
+    REQUIRE_THAT(lblExpressionStatus->text().toStdString(),
+                 ContainsSubstring("Empty expression"));
     // invalid expression so model expression unchanged
     REQUIRE(events.getExpression("p_") == "x");
     // expression -> "2"

--- a/gui/tabs/tabfunctions_t.cpp
+++ b/gui/tabs/tabfunctions_t.cpp
@@ -10,6 +10,7 @@
 #include <QPushButton>
 
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("TabFunctions", "[gui/tabs/functions][gui/tabs][gui][functions]") {
   sme::model::Model model;
@@ -178,12 +179,14 @@ TEST_CASE("TabFunctions", "[gui/tabs/functions][gui/tabs][gui][functions]") {
     // delete existing "0" to have empty expression
     sendKeyEvents(txtFunctionDef, {"Delete", "Backspace"});
     REQUIRE(txtFunctionDef->toPlainText() == "");
-    REQUIRE(lblFunctionDefStatus->text() == "Empty expression");
+    REQUIRE_THAT(lblFunctionDefStatus->text().toStdString(),
+                 ContainsSubstring("Empty expression"));
     // expression invalid so model not changed:
     REQUIRE(model.getFunctions().getExpression("func_1") == "0");
     sendKeyEvents(txtFunctionDef, {"x"});
     REQUIRE(txtFunctionDef->toPlainText() == "x");
-    REQUIRE(lblFunctionDefStatus->text() == "variable 'x' not found");
+    REQUIRE_THAT(lblFunctionDefStatus->text().toStdString(),
+                 ContainsSubstring("Variable 'x' not found"));
     // edit expression: x is not a parameter, model still not changed
     REQUIRE(model.getFunctions().getExpression("func_1") == "0");
     // edit expression: y is a parameter, so math is valid and model is updated

--- a/gui/tabs/tabreactions_t.cpp
+++ b/gui/tabs/tabreactions_t.cpp
@@ -12,6 +12,7 @@
 #include <QTreeWidget>
 
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("TabReactions", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
   sme::model::Model model;
@@ -159,7 +160,8 @@ TEST_CASE("TabReactions", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
     // edit reaction rate
     txtReactionRate->setFocus();
     sendKeyEvents(txtReactionRate, {"Backspace", "Delete", "2", "+"});
-    REQUIRE(lblReactionRateStatus->text() == "syntax error");
+    REQUIRE_THAT(lblReactionRateStatus->text().toStdString(),
+                 ContainsSubstring("syntax error"));
     sendKeyEvents(txtReactionRate, {"y"});
     REQUIRE(model.getReactions().getParameterName("reacQ", "y_") == "y");
     REQUIRE(lblReactionRateStatus->text() == "");

--- a/gui/widgets/qplaintextmathedit_t.cpp
+++ b/gui/widgets/qplaintextmathedit_t.cpp
@@ -5,14 +5,15 @@
 #include <QObject>
 
 using namespace sme::test;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
                                 "widgets][gui][qplaintextmathedit][symbolic]") {
   QPlainTextMathEdit mathEdit;
   struct Signal {
-    QString math;
-    QString error;
-    bool valid;
+    QString math{};
+    QString error{};
+    bool valid{false};
   };
   Signal signal;
   QObject::connect(
@@ -22,7 +23,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
       });
   REQUIRE(mathEdit.getMath() == "");
   REQUIRE(mathEdit.mathIsValid() == false);
-  REQUIRE(mathEdit.getErrorMessage() == "Empty expression");
+  REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+               ContainsSubstring("Empty expression"));
   SECTION("expression and/or variables") {
     mathEdit.show();
     // "1"
@@ -40,7 +42,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     sendKeyEvents(&mathEdit, {"*"});
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "syntax error");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("syntax error"));
     REQUIRE(signal.math == mathEdit.getMath());
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
@@ -61,7 +64,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     sendKeyEvents(&mathEdit, {"+", "q"});
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "variable 'q' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Variable 'q' not found"));
     REQUIRE(signal.math == mathEdit.getMath());
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
@@ -81,7 +85,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     mathEdit.removeVariable("q");
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "variable 'q' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Variable 'q' not found"));
     REQUIRE(signal.math == mathEdit.getMath());
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
@@ -115,7 +120,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     sendKeyEvents(&mathEdit, {"+"});
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "syntax error");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("syntax error"));
     REQUIRE(signal.math == mathEdit.getMath());
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
@@ -156,7 +162,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     REQUIRE(mathEdit.getVariables()[1] == "y");
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Empty expression");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Empty expression"));
     REQUIRE(mathEdit.compileMath() == false);
     // x+2*y
     sendKeyEvents(&mathEdit, {"x", "+", "2", "*", "y"});
@@ -185,11 +192,13 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     // "X + y_var"
     sendKeyEvents(&mathEdit, {"X", "+", "y", "_", "v", "a", "r"});
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Unknown symbol 'X'"));
     REQUIRE(mathEdit.compileMath() == false);
     mathEdit.addVariable("x", "X");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "variable 'y_var' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Variable 'y_var' not found"));
     REQUIRE(mathEdit.compileMath() == false);
     mathEdit.addVariable("y", "y_var");
     REQUIRE(mathEdit.getVariables().size() == 2);
@@ -205,12 +214,14 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     REQUIRE(mathEdit.compileMath() == true);
     mathEdit.removeVariable("y");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "variable 'y_var' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Variable 'y_var' not found"));
     REQUIRE(mathEdit.compileMath() == false);
     mathEdit.removeVariable("x");
     REQUIRE(mathEdit.getVariableMath().empty() == true);
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Unknown symbol 'X'"));
     REQUIRE(mathEdit.compileMath() == false);
   }
   SECTION("expression with quoted display names") {
@@ -231,7 +242,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     REQUIRE(mathEdit.compileMath() == true);
     mathEdit.removeVariable("x");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "variable 'X var!' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Variable 'X var!' not found"));
     REQUIRE(mathEdit.compileMath() == false);
   }
   SECTION("expression with user-defined function") {
@@ -243,7 +255,8 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     sendKeyEvents(&mathEdit, {"c", "s", "e", "(", "X", ")"});
     REQUIRE(signal.math == "");
     REQUIRE(mathEdit.getVariableMath().empty() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "function 'cse' not found");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Function 'cse' not found"));
     REQUIRE(mathEdit.mathIsValid() == false);
     REQUIRE(mathEdit.compileMath() == false);
     sme::common::SymbolicFunction f;
@@ -277,12 +290,14 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     sendKeyEvents(&mathEdit, {"/"});
     REQUIRE(mathEdit.getMath() == "");
     REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "syntax error");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("syntax error"));
     REQUIRE(signal.math == mathEdit.getMath());
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
     REQUIRE(mathEdit.compileMath() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "syntax error");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("syntax error"));
 
     // "1/0"
     sendKeyEvents(&mathEdit, {"0"});
@@ -293,7 +308,7 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     REQUIRE(signal.valid == mathEdit.mathIsValid());
     REQUIRE(signal.error == mathEdit.getErrorMessage());
     REQUIRE(mathEdit.compileMath() == false);
-    REQUIRE(mathEdit.getErrorMessage().left(30) ==
-            "Failed to compile expression: ");
+    REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
+                 ContainsSubstring("Error compiling expression"));
   }
 }


### PR DESCRIPTION
- this was only done to reduce compile dependencies
  - not worth complicating the code just to de-couple symengine headers
- `SymEngine::LLVMDoubleVisitor` still needs to be stored in a unique_ptr
  - init can only be called once so we need a new object each time
- add `parse` function to Symbolic
  - can re-use existing Symbolic object with a new expression
- add `clear` function to pair with above
- store and re-use instantiated `SymEngine::SBMLParser` within Symbolic
- add bool return values to `parse` and `compile` for composability
- add input expression to parse error messages
- replace ReacEval class with struct that provides expressions/variables for Symbolic
- use `ContainsSubstring` matchers in tests to make them more robust
