### PR TITLE
Improve GUI tests

### DIFF
--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -32,7 +32,7 @@ make -j3 VERBOSE=1
 ccache --show-stats
 
 # run cpp tests
-time ./test/tests -as ~[gui]~[opengl] > tests.txt 2>&1 || (tail -n 10000 tests.txt && exit 1)
+time ./test/tests -as ~[gui] > tests.txt 2>&1 || (tail -n 10000 tests.txt && exit 1)
 tail -n 100 tests.txt
 
 # run python tests

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -439,29 +439,28 @@ TEST_CASE("SBML species",
     REQUIRE(common::average(s.getField("A_c1")->getConcentration()) ==
             dbl_approx(2.0));
   }
-}
-
-TEST_CASE("Analytic conc involving piecewise", "[Q]") {
-  auto m{getExampleModel(Mod::VerySimpleModel)};
-  auto &s{m.getSpecies()};
-  s.setAnalyticConcentration("A_c1", "piecewise(1,x<33,2,x>66,0)");
-  REQUIRE(s.getInitialConcentrationType("A_c1") ==
-          model::ConcentrationType::Analytic);
-  REQUIRE(s.getAnalyticConcentration("A_c1") ==
-          "piecewise(1, x < 33, 2, x > 66, 0)");
-  const auto &voxels{s.getField("A_c1")->getCompartment()->getVoxels()};
-  const auto &concentration{s.getField("A_c1")->getConcentration()};
-  REQUIRE(voxels.size() == concentration.size());
-  auto correct_conc = [&m](const common::Voxel &voxel) {
-    double x{m.getGeometry().getPhysicalPoint(voxel).p.x()};
-    if (x < 33) {
-      return 1;
-    } else if (x > 66) {
-      return 2;
+  SECTION("Analytic conc involving piecewise") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &s{m.getSpecies()};
+    s.setAnalyticConcentration("A_c1", "piecewise(1,x<33,2,x>66,0)");
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::ConcentrationType::Analytic);
+    REQUIRE(s.getAnalyticConcentration("A_c1") ==
+            "piecewise(1, x < 33, 2, x > 66, 0)");
+    const auto &voxels{s.getField("A_c1")->getCompartment()->getVoxels()};
+    const auto &concentration{s.getField("A_c1")->getConcentration()};
+    REQUIRE(voxels.size() == concentration.size());
+    auto correct_conc = [&m](const common::Voxel &voxel) {
+      double x{m.getGeometry().getPhysicalPoint(voxel).p.x()};
+      if (x < 33) {
+        return 1;
+      } else if (x > 66) {
+        return 2;
+      }
+      return 0;
+    };
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+      REQUIRE(concentration[i] == dbl_approx(correct_conc(voxels[i])));
     }
-    return 0;
-  };
-  for (std::size_t i = 0; i < voxels.size(); ++i) {
-    REQUIRE(concentration[i] == dbl_approx(correct_conc(voxels[i])));
   }
 }

--- a/gui/dialogs/dialogcoordinates_t.cpp
+++ b/gui/dialogs/dialogcoordinates_t.cpp
@@ -1,21 +1,32 @@
 #include "catch_wrapper.hpp"
 #include "dialogcoordinates.hpp"
 #include "qt_test_utils.hpp"
+#include <QLineEdit>
 
 using namespace sme::test;
+
+struct DialogCoordinatesWidgets {
+  explicit DialogCoordinatesWidgets(const DialogCoordinates *dialog) {
+    GET_DIALOG_WIDGET(QLineEdit, txtXName);
+    GET_DIALOG_WIDGET(QLineEdit, txtYName);
+    GET_DIALOG_WIDGET(QLineEdit, txtZName);
+  }
+  QLineEdit *txtXName;
+  QLineEdit *txtYName;
+  QLineEdit *txtZName;
+};
 
 TEST_CASE("DialogCoordinates",
           "[gui/dialogs/coordinates][gui/dialogs][gui][coordinates]") {
   DialogCoordinates dia("x", "y", "z");
+  dia.show();
+  DialogCoordinatesWidgets widgets(&dia);
   REQUIRE(dia.getXName() == "x");
   REQUIRE(dia.getYName() == "y");
   REQUIRE(dia.getZName() == "z");
-  ModalWidgetTimer mwt;
-  mwt.addUserAction({"Delete", "Backspace", "e", "x", "!", "Tab", "Delete",
-                     "Backspace", "y", "y", "Tab", "Delete", "Backspace", "h",
-                     ""});
-  mwt.start();
-  dia.exec();
+  sendKeyEvents(widgets.txtXName, {"Delete", "Backspace", "e", "x", "!"});
+  sendKeyEvents(widgets.txtYName, {"Delete", "Backspace", "y", "y"});
+  sendKeyEvents(widgets.txtZName, {"Delete", "Backspace", "h"});
   REQUIRE(dia.getXName() == "ex!");
   REQUIRE(dia.getYName() == "yy");
   REQUIRE(dia.getZName() == "h");

--- a/gui/dialogs/dialogeditunit.cpp
+++ b/gui/dialogs/dialogeditunit.cpp
@@ -11,7 +11,7 @@ DialogEditUnit::DialogEditUnit(const sme::model::Unit &unit,
     setWindowTitle(QString("Edit Unit of %1").arg(unitType));
   }
   ui->txtName->setText(u.name);
-  ui->txtMultipler->setText(QString::number(u.multiplier));
+  ui->txtMultiplier->setText(QString::number(u.multiplier));
   ui->txtScale->setText(QString::number(u.scale));
   ui->txtExponent->setText(QString::number(u.exponent));
 
@@ -21,7 +21,7 @@ DialogEditUnit::DialogEditUnit(const sme::model::Unit &unit,
           &DialogEditUnit::reject);
   connect(ui->txtName, &QLineEdit::textEdited, this,
           &DialogEditUnit::txtName_textEdited);
-  connect(ui->txtMultipler, &QLineEdit::textEdited, this,
+  connect(ui->txtMultiplier, &QLineEdit::textEdited, this,
           &DialogEditUnit::txtMultiplier_textEdited);
   connect(ui->txtScale, &QLineEdit::textEdited, this,
           &DialogEditUnit::txtScale_textEdited);
@@ -36,7 +36,7 @@ DialogEditUnit::~DialogEditUnit() = default;
 const sme::model::Unit &DialogEditUnit::getUnit() const { return u; }
 
 void DialogEditUnit::updateLblBaseUnits() {
-  if (validScale && validExponent && validMultipler) {
+  if (validScale && validExponent && validMultiplier) {
     ui->lblBaseUnits->setText(
         QString("1 %1 = %2").arg(u.name).arg(sme::model::unitInBaseUnits(u)));
   }
@@ -60,11 +60,11 @@ void DialogEditUnit::txtName_textEdited(const QString &text) {
 }
 
 void DialogEditUnit::txtMultiplier_textEdited(const QString &text) {
-  double newMultiplier = text.toDouble(&validMultipler);
-  if (validMultipler) {
+  double newMultiplier = text.toDouble(&validMultiplier);
+  if (validMultiplier) {
     u.multiplier = newMultiplier;
   }
-  setIsValidState(ui->txtMultipler, validMultipler,
+  setIsValidState(ui->txtMultiplier, validMultiplier,
                   "Invalid value: Multiplier must be a double");
   updateLblBaseUnits();
 }

--- a/gui/dialogs/dialogeditunit.hpp
+++ b/gui/dialogs/dialogeditunit.hpp
@@ -21,7 +21,7 @@ public:
 private:
   std::unique_ptr<Ui::DialogEditUnit> ui;
   sme::model::Unit u;
-  bool validMultipler{true};
+  bool validMultiplier{true};
   bool validScale{true};
   bool validExponent{true};
   void updateLblBaseUnits();

--- a/gui/dialogs/dialogeditunit.ui
+++ b/gui/dialogs/dialogeditunit.ui
@@ -65,7 +65,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="txtMultipler"/>
+      <widget class="QLineEdit" name="txtMultiplier"/>
      </item>
      <item row="4" column="1">
       <widget class="QLabel" name="lblBaseUnits">
@@ -97,7 +97,7 @@
  </widget>
  <tabstops>
   <tabstop>txtName</tabstop>
-  <tabstop>txtMultipler</tabstop>
+  <tabstop>txtMultiplier</tabstop>
   <tabstop>txtScale</tabstop>
   <tabstop>txtExponent</tabstop>
  </tabstops>

--- a/gui/dialogs/dialoggeometryimage_t.cpp
+++ b/gui/dialogs/dialoggeometryimage_t.cpp
@@ -4,16 +4,57 @@
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
 #include "sme/model.hpp"
+#include <QCheckBox>
+#include <QComboBox>
 #include <QDialogButtonBox>
+#include <QLineEdit>
 #include <QPushButton>
+#include <QSlider>
+#include <QSpinBox>
 
 using namespace sme::test;
+
+struct DialogGeometryImageWidgets {
+  explicit DialogGeometryImageWidgets(const DialogGeometryImage *dialog) {
+    GET_DIALOG_WIDGET(QLabel, lblImage);
+    GET_DIALOG_WIDGET(QSlider, slideZIndex);
+    GET_DIALOG_WIDGET(QLineEdit, txtImageWidth);
+    GET_DIALOG_WIDGET(QComboBox, cmbUnitsWidth);
+    GET_DIALOG_WIDGET(QLineEdit, txtImageHeight);
+    GET_DIALOG_WIDGET(QLineEdit, txtImageDepth);
+    GET_DIALOG_WIDGET(QCheckBox, chkKeepAspectRatio);
+    GET_DIALOG_WIDGET(QSpinBox, spinPixelsX);
+    GET_DIALOG_WIDGET(QSpinBox, spinPixelsY);
+    GET_DIALOG_WIDGET(QPushButton, btnResetPixels);
+    GET_DIALOG_WIDGET(QLabel, lblColours);
+    GET_DIALOG_WIDGET(QPushButton, btnSelectColours);
+    GET_DIALOG_WIDGET(QPushButton, btnApplyColours);
+    GET_DIALOG_WIDGET(QPushButton, btnResetColours);
+    GET_DIALOG_WIDGET(QLabel, lblPixelSize);
+    GET_DIALOG_WIDGET(QDialogButtonBox, buttonBox);
+  }
+  QLabel *lblImage;
+  QSlider *slideZIndex;
+  QLineEdit *txtImageWidth;
+  QComboBox *cmbUnitsWidth;
+  QLineEdit *txtImageHeight;
+  QLineEdit *txtImageDepth;
+  QCheckBox *chkKeepAspectRatio;
+  QSpinBox *spinPixelsX;
+  QSpinBox *spinPixelsY;
+  QPushButton *btnResetPixels;
+  QLabel *lblColours;
+  QPushButton *btnSelectColours;
+  QPushButton *btnApplyColours;
+  QPushButton *btnResetColours;
+  QLabel *lblPixelSize;
+  QDialogButtonBox *buttonBox;
+};
 
 TEST_CASE("DialogGeometryImage",
           "[gui/dialogs/geometryimage][gui/dialogs][gui][geometryimage]") {
   auto m{getExampleModel(Mod::ABtoC)};
   auto modelUnits = m.getUnits();
-  modelUnits.setLengthIndex(0);
   REQUIRE(modelUnits.getLengthUnits()[0].scale == 0);
   REQUIRE(modelUnits.getLengthUnits()[1].scale == -1);
   REQUIRE(modelUnits.getLengthUnits()[2].scale == -2);
@@ -24,225 +65,336 @@ TEST_CASE("DialogGeometryImage",
   img.fill(qRgb(255, 255, 255));
   img[0].setPixel(50, 25, qRgb(123, 123, 123));
   img[0].setPixel(55, 23, qRgba(123, 123, 101, 123));
-  DialogGeometryImage dim(img, {1.0, 1.0, 1.0}, modelUnits);
-  REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-  REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-  REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-  ModalWidgetTimer mwt;
-  auto *lblImage{dim.findChild<QLabelMouseTracker *>("lblImage")};
-  REQUIRE(lblImage != nullptr);
-  auto *okButton{dim.findChild<QDialogButtonBox *>("buttonBox")
-                     ->button(QDialogButtonBox::Ok)};
-  REQUIRE(okButton != nullptr);
-  auto *btnSelectColours{dim.findChild<QPushButton *>("btnSelectColours")};
-  REQUIRE(btnSelectColours != nullptr);
-  auto *btnApplyColours{dim.findChild<QPushButton *>("btnApplyColours")};
-  REQUIRE(btnApplyColours != nullptr);
-  auto *btnResetColours{dim.findChild<QPushButton *>("btnResetColours")};
-  REQUIRE(btnResetColours != nullptr);
-  SECTION("user sets width to 1, same units, width -> 0.01") {
-    mwt.addUserAction({"Tab", "1"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.01));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
+  SECTION("Use m for length units, initial voxel size 1^3") {
+    modelUnits.setLengthIndex(0);
+    REQUIRE(modelUnits.getLength().name == "m");
+    DialogGeometryImage dia(img, {1.0, 1.0, 1.0}, modelUnits);
+    dia.show();
+    waitFor(&dia);
+    DialogGeometryImageWidgets widgets(&dia);
+    REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+    REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+    REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+    SECTION("user sets image width to 1, same units, voxel width -> 0.01") {
+      sendKeyEvents(widgets.txtImageWidth,
+                    {"Backspace", "Backspace", "Backspace", "1", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(0.01));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets image width to 1e-8, voxel width -> 1e-10") {
+      sendKeyEvents(
+          widgets.txtImageWidth,
+          {"Backspace", "Backspace", "Backspace", "1", "e", "-", "8", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1e-10));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets image height to 10, voxel height -> 0.2") {
+      sendKeyEvents(widgets.txtImageHeight,
+                    {"Backspace", "Backspace", "Backspace", "1", "0", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.2));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets image height to 10, units to dm, voxel height -> 0.02, "
+            "others /=10") {
+      sendKeyEvents(widgets.txtImageHeight,
+                    {"Backspace", "Backspace", "Backspace", "1", "0", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.2));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      widgets.cmbUnitsWidth->setFocus();
+      sendKeyEvents(widgets.cmbUnitsWidth, {"Down"});
+      REQUIRE(widgets.cmbUnitsWidth->currentText() == "dm");
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(0.1));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.02));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(0.1));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets image height to 10, units to cm, voxel height -> 0.002, "
+            "others /=100") {
+      sendKeyEvents(widgets.txtImageHeight,
+                    {"Backspace", "Backspace", "Backspace", "1", "0", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.2));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      widgets.cmbUnitsWidth->setFocus();
+      sendKeyEvents(widgets.cmbUnitsWidth, {"Down", "Down"});
+      REQUIRE(widgets.cmbUnitsWidth->currentText() == "cm");
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(0.01));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.002));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(0.01));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets image width to 9 & units to dm, then image height 10, "
+            "units um") {
+      sendKeyEvents(widgets.txtImageWidth,
+                    {"Backspace", "Backspace", "Backspace", "9", "Enter"});
+      widgets.cmbUnitsWidth->setFocus();
+      sendKeyEvents(widgets.cmbUnitsWidth, {"Down", "Down", "Down", "Down"});
+      REQUIRE(widgets.cmbUnitsWidth->currentText() == "um");
+      sendKeyEvents(widgets.txtImageHeight,
+                    {"Backspace", "Backspace", "Backspace", "1", "0", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(0.09 * 1e-6));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(0.2 * 1e-6));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1e-6));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("user sets depth to 4, no change of units") {
+      sendKeyEvents(widgets.txtImageDepth,
+                    {"Backspace", "Backspace", "Backspace", "4", "Enter"});
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(4.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
+    SECTION("x pixels reduced from 100 to 98") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(widgets.spinPixelsX->value() == 100);
+      sendKeyEvents(widgets.spinPixelsX, {"Down", "Down"});
+      REQUIRE(widgets.spinPixelsX->value() == 98);
+      REQUIRE(dia.imageSizeAltered() == true);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 0.98));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0 / 0.98));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.getAlteredImage().volume().width() == 98);
+      REQUIRE(dia.getAlteredImage().volume().height() == 49);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+    }
+    SECTION("y pixels reduced from 50 to 5") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      widgets.spinPixelsY->setValue(5);
+      REQUIRE(widgets.spinPixelsY->value() == 5);
+      REQUIRE(dia.imageSizeAltered() == true);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.getAlteredImage().volume().width() == 10);
+      REQUIRE(dia.getAlteredImage().volume().height() == 5);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+    }
+    SECTION("x pixels reduced, y pixels reduced, reset pixels pressed") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(widgets.chkKeepAspectRatio->isChecked());
+      // 100->98 x pixels, implies 50->49 y pixels
+      REQUIRE(widgets.spinPixelsX->value() == 100);
+      widgets.spinPixelsX->setValue(98);
+      REQUIRE(widgets.spinPixelsX->value() == 98);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 0.98));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0 / 0.98));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 49);
+      // 98->99 x pixels, 49->50 y pixels
+      REQUIRE(widgets.spinPixelsX->value() == 98);
+      widgets.spinPixelsX->setValue(99);
+      REQUIRE(widgets.spinPixelsX->value() == 99);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 0.99));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      // 99->100 x pixels, 50->50 y pixels
+      REQUIRE(widgets.spinPixelsX->value() == 99);
+      widgets.spinPixelsX->setValue(100);
+      REQUIRE(widgets.spinPixelsX->value() == 100);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      widgets.spinPixelsY->setValue(5);
+      REQUIRE(widgets.spinPixelsY->value() == 5);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      sendMouseClick(widgets.btnResetPixels);
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+    }
+    SECTION("x pixels reduced, y pixels reduced, reset pixels pressed, "
+            "maintain aspect ratio off") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      sendMouseClick(widgets.chkKeepAspectRatio);
+      REQUIRE(widgets.chkKeepAspectRatio->isChecked() == false);
+      // 100->98 x pixels, y unchanged
+      REQUIRE(widgets.spinPixelsX->value() == 100);
+      widgets.spinPixelsX->setValue(98);
+      REQUIRE(widgets.spinPixelsX->value() == 98);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 0.98));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      // 98->99 x pixels, y unchanged
+      REQUIRE(widgets.spinPixelsX->value() == 98);
+      widgets.spinPixelsX->setValue(99);
+      REQUIRE(widgets.spinPixelsX->value() == 99);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 0.99));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      // 99->107 x pixels, y unchanged
+      REQUIRE(widgets.spinPixelsX->value() == 99);
+      widgets.spinPixelsX->setValue(107);
+      REQUIRE(widgets.spinPixelsX->value() == 107);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 1.07));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(widgets.spinPixelsY->value() == 50);
+      // 50 -> 5 y pixels, x unchanged
+      widgets.spinPixelsY->setValue(5);
+      REQUIRE(widgets.spinPixelsY->value() == 5);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0 / 1.07));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      sendMouseClick(widgets.btnResetPixels);
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+    }
+    SECTION("select colours pressed, then reset colours") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == true);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              true);
+      sendMouseClick(widgets.btnSelectColours);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == false);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              false);
+      sendMouseClick(widgets.btnResetColours);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == true);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              true);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+    }
+    SECTION("select colours pressed, then one chosen") {
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(dia.getAlteredImage()[0].colorCount() == 3);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == true);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              true);
+      REQUIRE(widgets.btnApplyColours->isEnabled() == false);
+      sendMouseClick(widgets.btnSelectColours);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == false);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              false);
+      REQUIRE(widgets.btnApplyColours->isEnabled() == false);
+      sendMouseClick(widgets.lblImage, QPoint(3, 3));
+      REQUIRE(widgets.btnApplyColours->isEnabled() == true);
+      sendMouseClick(widgets.btnApplyColours);
+      REQUIRE(widgets.txtImageWidth->isEnabled() == true);
+      REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+              true);
+      REQUIRE(widgets.btnApplyColours->isEnabled() == false);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(1.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == true);
+      REQUIRE(dia.getAlteredImage().volume().width() == 100);
+      REQUIRE(dia.getAlteredImage().volume().height() == 50);
+      REQUIRE(dia.getAlteredImage().volume().depth() == 1);
+      REQUIRE(dia.getAlteredImage()[0].colorCount() == 1);
+    }
   }
-  SECTION("user sets width to 1e-8, width -> 1e-10") {
-    mwt.addUserAction({"Tab", "1", "e", "-", "8"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1e-10));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("user sets height to 10, height -> 0.2") {
-    mwt.addUserAction({"Tab", "Tab", "Tab", "1", "0"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.2));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("user sets height to 10, units to dm, height -> 0.02, others /=10") {
-    mwt.addUserAction({"Tab", "Tab", "Down", "Tab", "1", "0"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.1));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.02));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(0.1));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION(
-      "user sets height to 10, units to cm, height -> 0.002, others /=100") {
-    mwt.addUserAction({"Tab", "Tab", "Down", "Down", "Tab", "1", "0"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.01));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.002));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(0.01));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("user sets width to 9 & units to dm, then height 10, units um") {
-    mwt.addUserAction({"Tab", "9", "Tab", "Down", "Tab", "1", "0", "Shift+Tab",
-                       "Down", "Down", "Down"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(0.09 * 1e-6));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(0.2 * 1e-6));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1e-6));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("user sets depth to 4, no change of units") {
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Backspace", "4"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(4.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("default units changed to mm, user sets width = 1, units = m") {
-    modelUnits.setLengthIndex(3); // mm
-    DialogGeometryImage dim2(img, {22.0, 22.0, 1.0}, modelUnits);
-    REQUIRE(dim2.getVoxelSize().width() == dbl_approx(22.0));
-    REQUIRE(dim2.getVoxelSize().height() == dbl_approx(22.0));
-    REQUIRE(dim2.getVoxelSize().depth() == dbl_approx(1.0));
-    mwt.addUserAction({"Tab", "1", "Tab", "Up", "Up", "Up", "Up", "Up", "Up"});
-    mwt.start();
-    dim2.exec();
-    REQUIRE(dim2.getVoxelSize().width() == dbl_approx(10.0));
-    REQUIRE(dim2.getVoxelSize().height() == dbl_approx(22e3));
-    REQUIRE(dim2.getVoxelSize().depth() == dbl_approx(1e3));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-  }
-  SECTION("x pixels reduced from 100 to 98") {
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    mwt.addUserAction(
-        {"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Down"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.imageSizeAltered() == true);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0 / 0.98));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0 / 0.98));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.getAlteredImage().volume().width() == 98);
-    REQUIRE(dim.getAlteredImage().volume().height() == 49);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-  }
-  SECTION("y pixels reduced from 50 to 5") {
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "5"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.imageSizeAltered() == true);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(10.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(10.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.getAlteredImage().volume().width() == 10);
-    REQUIRE(dim.getAlteredImage().volume().height() == 5);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-  }
-  SECTION("x pixels reduced, y pixels reduced, reset pixels pressed") {
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Down", "Tab", "5",
-                       "Tab", "Space", "Tab", "Tab", "Tab"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    // width/height both altered as aspect ratio changes slightly due to
-    // integer pixel count, so pixel width is not exactly preserved
-    REQUIRE(std::abs(dim.getVoxelSize().width() - 1.0) < 0.02);
-    REQUIRE(std::abs(dim.getVoxelSize().height() - 1.0) < 0.02);
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-  }
-  SECTION("select colours pressed, then reset colours") {
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab",
-                       "Space", "Space", "Tab"});
-    mwt.start();
-    dim.exec();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-  }
-  SECTION("select colours pressed, then one chosen") {
-    dim.show();
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == false);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    REQUIRE(dim.getAlteredImage()[0].colorCount() == 3);
-    REQUIRE(okButton->isEnabled() == true);
-    sendMouseClick(btnSelectColours);
-    // ok/cancel disabled while selecting colours
-    REQUIRE(okButton->isEnabled() == false);
-    sendMouseClick(lblImage, QPoint(3, 3));
-    REQUIRE(okButton->isEnabled() == false);
-    sendMouseClick(btnApplyColours);
-    REQUIRE(okButton->isEnabled() == true);
-    REQUIRE(dim.getVoxelSize().width() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().height() == dbl_approx(1.0));
-    REQUIRE(dim.getVoxelSize().depth() == dbl_approx(1.0));
-    REQUIRE(dim.imageSizeAltered() == false);
-    REQUIRE(dim.imageColoursAltered() == true);
-    REQUIRE(dim.getAlteredImage().volume().width() == 100);
-    REQUIRE(dim.getAlteredImage().volume().height() == 50);
-    REQUIRE(dim.getAlteredImage().volume().depth() == 1);
-    REQUIRE(dim.getAlteredImage()[0].colorCount() == 1);
+  SECTION("Use mm for length units, initial voxel size 22x22x1") {
+    modelUnits.setLengthIndex(3);
+    REQUIRE(modelUnits.getLength().name == "mm");
+    DialogGeometryImage dia(img, {22.0, 22.0, 1.0}, modelUnits);
+    dia.show();
+    waitFor(&dia);
+    DialogGeometryImageWidgets widgets(&dia);
+    REQUIRE(dia.getVoxelSize().width() == dbl_approx(22.0));
+    REQUIRE(dia.getVoxelSize().height() == dbl_approx(22.0));
+    REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+    SECTION("user sets image width = 1, units = m") {
+      widgets.txtImageWidth->setFocus();
+      widgets.txtImageWidth->clear();
+      sendKeyEvents(widgets.txtImageWidth, {"1", "Tab"});
+      REQUIRE(widgets.cmbUnitsWidth->currentText() == "mm");
+      wait(100);
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(0.01));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(22.0));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1.0));
+      widgets.cmbUnitsWidth->setFocus();
+      sendKeyEvents(widgets.cmbUnitsWidth, {"Up", "Up", "Up"});
+      REQUIRE(widgets.cmbUnitsWidth->currentText() == "m");
+      REQUIRE(dia.getVoxelSize().width() == dbl_approx(10.0));
+      REQUIRE(dia.getVoxelSize().height() == dbl_approx(22e3));
+      REQUIRE(dia.getVoxelSize().depth() == dbl_approx(1e3));
+      REQUIRE(dia.imageSizeAltered() == false);
+      REQUIRE(dia.imageColoursAltered() == false);
+    }
   }
 }

--- a/gui/dialogs/dialogimage_t.cpp
+++ b/gui/dialogs/dialogimage_t.cpp
@@ -1,16 +1,24 @@
 #include "catch_wrapper.hpp"
 #include "dialogimage.hpp"
+#include "qt_test_utils.hpp"
 #include <QLabel>
+
+struct DialogImageWidgets {
+  explicit DialogImageWidgets(const DialogImage *dialog) {
+    GET_DIALOG_WIDGET(QLabel, lblMessage);
+    GET_DIALOG_WIDGET(QLabel, lblImage);
+  }
+  QLabel *lblMessage;
+  QLabel *lblImage;
+};
 
 TEST_CASE("DialogImage", "[gui/dialogs/image][gui/dialogs][gui][image]") {
   sme::common::ImageStack imageStack{{QImage(":/icon/icon128.png")}};
   QString title("my title");
   QString message("see image below:");
   DialogImage dia(nullptr, title, message, imageStack);
-  auto *lblMessage{dia.findChild<QLabel *>("lblMessage")};
-  REQUIRE(lblMessage != nullptr);
-  auto *lblImage{dia.findChild<QLabel *>("lblImage")};
-  REQUIRE(lblImage != nullptr);
+  dia.show();
+  DialogImageWidgets widgets(&dia);
   REQUIRE(dia.windowTitle() == title);
-  REQUIRE(lblMessage->text() == message);
+  REQUIRE(widgets.lblMessage->text() == message);
 }

--- a/gui/dialogs/dialogmeshingoptions_t.cpp
+++ b/gui/dialogs/dialogmeshingoptions_t.cpp
@@ -1,23 +1,27 @@
 #include "catch_wrapper.hpp"
 #include "dialogmeshingoptions.hpp"
 #include "qt_test_utils.hpp"
+#include <QComboBox>
 
 using namespace sme::test;
+
+struct DialogMeshingOptionsWidgets {
+  explicit DialogMeshingOptionsWidgets(const DialogMeshingOptions *dialog) {
+    GET_DIALOG_WIDGET(QComboBox, cmbBoundarySimplificationType);
+  }
+  QComboBox *cmbBoundarySimplificationType;
+};
 
 TEST_CASE("DialogMeshingOptions", "[gui/dialogs/meshingoptions][gui/"
                                   "dialogs][gui][meshingoptions]") {
   DialogMeshingOptions dia(1);
-  ModalWidgetTimer mwt;
+  dia.show();
+  DialogMeshingOptionsWidgets widgets(&dia);
   SECTION("user does nothing: unchanged") {
-    mwt.addUserAction();
-    mwt.start();
-    dia.exec();
     REQUIRE(dia.getBoundarySimplificationType() == 1);
   }
   SECTION("user changes value") {
-    mwt.addUserAction({"Up"});
-    mwt.start();
-    dia.exec();
+    widgets.cmbBoundarySimplificationType->setCurrentIndex(0);
     REQUIRE(dia.getBoundarySimplificationType() == 0);
   }
 }

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -3,11 +3,31 @@
 #include "model_test_utils.hpp"
 #include "qt_test_utils.hpp"
 #include "sme/utils.hpp"
+#include <QComboBox>
 #include <QLineEdit>
 #include <QPushButton>
 
 using namespace sme;
 using namespace sme::test;
+
+struct DialogOptCostWidgets {
+  explicit DialogOptCostWidgets(const DialogOptCost *dialog) {
+    GET_DIALOG_WIDGET(QComboBox, cmbSpecies);
+    GET_DIALOG_WIDGET(QComboBox, cmbCostType);
+    GET_DIALOG_WIDGET(QLineEdit, txtSimulationTime);
+    GET_DIALOG_WIDGET(QPushButton, btnEditTargetValues);
+    GET_DIALOG_WIDGET(QComboBox, cmbDiffType);
+    GET_DIALOG_WIDGET(QLineEdit, txtWeight);
+    GET_DIALOG_WIDGET(QLineEdit, txtEpsilon);
+  }
+  QComboBox *cmbSpecies;
+  QComboBox *cmbCostType;
+  QLineEdit *txtSimulationTime;
+  QPushButton *btnEditTargetValues;
+  QComboBox *cmbDiffType;
+  QLineEdit *txtWeight;
+  QLineEdit *txtEpsilon;
+};
 
 TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
                            "dialogs][gui][optimize]") {
@@ -29,18 +49,13 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
                              simulate::OptCostDiffType::Relative, "cell/T0",
                              "T0", 19.0, 0.1, 0, 3, std::vector<double>{},
                              1e-13});
-  ModalWidgetTimer mwt;
   SECTION("no possible costs") {
     DialogOptCost dia(model, {});
-    mwt.addUserAction();
-    mwt.start();
-    dia.exec();
+    dia.show();
   }
   SECTION("no pre-selected cost: defaults to first one") {
     DialogOptCost dia(model, defaultOptCosts);
-    mwt.addUserAction();
-    mwt.start();
-    dia.exec();
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().id == "P0");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(12.0));
@@ -49,9 +64,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user does nothing: correct initial values") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
-    mwt.addUserAction();
-    mwt.start();
-    dia.exec();
+    dia.show();
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
@@ -70,9 +83,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes cost type") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
-    // get pointers to widgets within dialog
-    auto *txtEpsilon{dia.findChild<QLineEdit *>("txtEpsilon")};
-    REQUIRE(txtEpsilon != nullptr);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -84,10 +96,9 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    REQUIRE(txtEpsilon->isEnabled());
-    mwt.addUserAction({"Tab", "Down", "Tab", "Tab", "Tab", "Up"});
-    mwt.start();
-    dia.exec();
+    REQUIRE(widgets.txtEpsilon->isEnabled());
+    widgets.cmbCostType->setCurrentIndex(1);
+    widgets.cmbDiffType->setCurrentIndex(0);
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -99,10 +110,12 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::ConcentrationDcdt);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Absolute);
-    REQUIRE(txtEpsilon->isEnabled() == false);
+    REQUIRE(widgets.txtEpsilon->isEnabled() == false);
   }
   SECTION("user changes species") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -114,9 +127,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    mwt.addUserAction({"Down", "Down"});
-    mwt.start();
-    dia.exec();
+    widgets.cmbSpecies->setCurrentIndex(3);
     REQUIRE(dia.getOptCost().name == "cell/T0");
     REQUIRE(dia.getOptCost().id == "T0");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(19.0));
@@ -131,6 +142,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes simulation time") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -142,9 +155,10 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    mwt.addUserAction({"Tab", "Tab", "6", "2", ".", "8"});
-    mwt.start();
-    dia.exec();
+    sendKeyEvents(
+        widgets.txtSimulationTime,
+        {"Backspace", "Backspace", "Backspace", "6", "2", ".", "8", "Enter"});
+    CAPTURE(widgets.txtSimulationTime->text().toStdString());
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(62.8));
@@ -159,9 +173,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes target conc values") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
-    auto *btnEditTargetValues{
-        dia.findChild<QPushButton *>("btnEditTargetValues")};
-    REQUIRE(btnEditTargetValues != nullptr);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -175,9 +188,10 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostDiffType::Relative);
     REQUIRE(dia.getOptCost().targetValues.empty());
     // set conc from image in range [1,2]
+    ModalWidgetTimer mwt;
     mwt.addUserAction({"1", "Tab", "2"});
     mwt.start();
-    sendMouseClick(btnEditTargetValues);
+    sendMouseClick(widgets.btnEditTargetValues);
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -198,17 +212,17 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes target dcdt values") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[0]);
-    auto *btnEditTargetValues{
-        dia.findChild<QPushButton *>("btnEditTargetValues")};
-    REQUIRE(btnEditTargetValues != nullptr);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::ConcentrationDcdt);
     REQUIRE(dia.getOptCost().targetValues.empty());
     // set conc dcdt from image in range [1.2,2]
+    ModalWidgetTimer mwt;
     mwt.addUserAction({"1", ".", "2", "Tab", "2"});
     mwt.start();
-    sendMouseClick(btnEditTargetValues);
+    sendMouseClick(widgets.btnEditTargetValues);
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::ConcentrationDcdt);
@@ -220,6 +234,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes scale factor") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -231,9 +247,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "6", "2", ".", "8"});
-    mwt.start();
-    dia.exec();
+    sendKeyEvents(widgets.txtWeight, {"Backspace", "Backspace", "Backspace",
+                                      "6", "2", ".", "8", "Enter"});
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -248,6 +263,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
   }
   SECTION("user changes epsilon") {
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
@@ -259,10 +276,9 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    mwt.addUserAction(
-        {"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "1", "e", "-", "1", "7"});
-    mwt.start();
-    dia.exec();
+    sendKeyEvents(widgets.txtEpsilon,
+                  {"Backspace", "Backspace", "Backspace", "Backspace",
+                   "Backspace", "1", "e", "-", "1", "7", "Enter"});
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -2,13 +2,25 @@
 #include "dialogoptimize.hpp"
 #include "model_test_utils.hpp"
 #include "qt_test_utils.hpp"
+#include <QComboBox>
 #include <QPushButton>
 
 using namespace sme;
 using namespace sme::test;
 
+struct DialogOptimizeWidgets {
+  explicit DialogOptimizeWidgets(const DialogOptimize *dialog) {
+    GET_DIALOG_WIDGET(QComboBox, cmbTarget);
+    GET_DIALOG_WIDGET(QPushButton, btnSetup);
+    GET_DIALOG_WIDGET(QPushButton, btnStartStop);
+  }
+  QComboBox *cmbTarget;
+  QPushButton *btnSetup;
+  QPushButton *btnStartStop;
+};
+
 TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
-                            "dialogs][gui][optimize][Q]") {
+                            "dialogs][gui][optimize]") {
   auto model{getExampleModel(Mod::ABtoC)};
   model.getSimulationSettings().simulatorType =
       sme::simulate::SimulatorType::Pixel;
@@ -28,37 +40,30 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
                                       0,
                                       {}});
   model.getOptimizeOptions() = optimizeOptions;
-  ModalWidgetTimer mwt;
   SECTION("no optimizeOptions") {
     model.getOptimizeOptions() = {};
     DialogOptimize dia(model);
-    // get pointers to widgets within dialog
-    auto *btnStartStop{dia.findChild<QPushButton *>("btnStartStop")};
-    REQUIRE(btnStartStop != nullptr);
-    auto *btnSetup{dia.findChild<QPushButton *>("btnSetup")};
-    REQUIRE(btnSetup != nullptr);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
     // no valid initial optimize options
-    REQUIRE(btnStartStop->text() == "Start");
-    REQUIRE(btnStartStop->isEnabled() == false);
-    REQUIRE(btnSetup->isEnabled() == true);
+    REQUIRE(widgets.btnStartStop->text() == "Start");
+    REQUIRE(widgets.btnStartStop->isEnabled() == false);
+    REQUIRE(widgets.btnSetup->isEnabled() == true);
     REQUIRE(dia.getParametersString().isEmpty());
   }
   SECTION("existing optimizeOptions") {
     DialogOptimize dia(model);
-    // get pointers to widgets within dialog
-    auto *btnStartStop{dia.findChild<QPushButton *>("btnStartStop")};
-    REQUIRE(btnStartStop != nullptr);
-    auto *btnSetup{dia.findChild<QPushButton *>("btnSetup")};
-    REQUIRE(btnSetup != nullptr);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
     // valid initial optimize options
-    REQUIRE(btnStartStop->isEnabled() == true);
-    REQUIRE(btnSetup->isEnabled() == true);
+    REQUIRE(widgets.btnStartStop->isEnabled() == true);
+    REQUIRE(widgets.btnSetup->isEnabled() == true);
     // no initial parameters
     REQUIRE(dia.getParametersString().isEmpty());
     // evolve params for 3secs
-    sendMouseClick(btnStartStop);
+    sendMouseClick(widgets.btnStartStop);
     wait(3000);
-    sendMouseClick(btnStartStop);
+    sendMouseClick(widgets.btnStartStop);
     auto lines{dia.getParametersString().split("\n")};
     REQUIRE(lines.size() == 1);
   }

--- a/gui/dialogs/dialogoptsetup_t.cpp
+++ b/gui/dialogs/dialogoptsetup_t.cpp
@@ -11,6 +11,33 @@
 using namespace sme;
 using namespace sme::test;
 
+struct DialogOptSetupWidgets {
+  explicit DialogOptSetupWidgets(const DialogOptSetup *dialog) {
+    GET_DIALOG_WIDGET(QComboBox, cmbAlgorithm);
+    GET_DIALOG_WIDGET(QSpinBox, spinIslands);
+    GET_DIALOG_WIDGET(QSpinBox, spinPopulation);
+    GET_DIALOG_WIDGET(QListWidget, lstTargets);
+    GET_DIALOG_WIDGET(QPushButton, btnAddTarget);
+    GET_DIALOG_WIDGET(QPushButton, btnEditTarget);
+    GET_DIALOG_WIDGET(QPushButton, btnRemoveTarget);
+    GET_DIALOG_WIDGET(QListWidget, lstParameters);
+    GET_DIALOG_WIDGET(QPushButton, btnAddParameter);
+    GET_DIALOG_WIDGET(QPushButton, btnEditParameter);
+    GET_DIALOG_WIDGET(QPushButton, btnRemoveParameter);
+  }
+  QComboBox *cmbAlgorithm;
+  QSpinBox *spinIslands;
+  QSpinBox *spinPopulation;
+  QListWidget *lstTargets;
+  QPushButton *btnAddTarget;
+  QPushButton *btnEditTarget;
+  QPushButton *btnRemoveTarget;
+  QListWidget *lstParameters;
+  QPushButton *btnAddParameter;
+  QPushButton *btnEditParameter;
+  QPushButton *btnRemoveParameter;
+};
+
 TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
                             "dialogs][gui][optimize]") {
   auto model{getExampleModel(Mod::CircadianClock)};
@@ -18,40 +45,18 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       sme::simulate::SimulatorType::Pixel;
   SECTION("No initial OptimizeOptions") {
     DialogOptSetup dia(model);
-    // get pointers to widgets within dialog
-    auto *cmbAlgorithm{dia.findChild<QComboBox *>("cmbAlgorithm")};
-    REQUIRE(cmbAlgorithm != nullptr);
-    auto *spinIslands{dia.findChild<QSpinBox *>("spinIslands")};
-    REQUIRE(spinIslands != nullptr);
-    auto *spinPopulation{dia.findChild<QSpinBox *>("spinPopulation")};
-    REQUIRE(spinPopulation != nullptr);
-    auto *lstTargets{dia.findChild<QListWidget *>("lstTargets")};
-    REQUIRE(lstTargets != nullptr);
-    auto *lstParameters{dia.findChild<QListWidget *>("lstParameters")};
-    REQUIRE(lstParameters != nullptr);
-    auto *btnAddTarget{dia.findChild<QPushButton *>("btnAddTarget")};
-    REQUIRE(btnAddTarget != nullptr);
-    auto *btnEditTarget{dia.findChild<QPushButton *>("btnEditTarget")};
-    REQUIRE(btnEditTarget != nullptr);
-    auto *btnRemoveTarget{dia.findChild<QPushButton *>("btnRemoveTarget")};
-    REQUIRE(btnRemoveTarget != nullptr);
-    auto *btnAddParameter{dia.findChild<QPushButton *>("btnAddParameter")};
-    REQUIRE(btnAddParameter != nullptr);
-    auto *btnEditParameter{dia.findChild<QPushButton *>("btnEditParameter")};
-    REQUIRE(btnEditParameter != nullptr);
-    auto *btnRemoveParameter{
-        dia.findChild<QPushButton *>("btnRemoveParameter")};
-    REQUIRE(btnRemoveParameter != nullptr);
+    DialogOptSetupWidgets widgets(&dia);
+    dia.show();
     ModalWidgetTimer mwt;
     SECTION("user does nothing") {
-      REQUIRE(lstTargets->count() == 0);
-      REQUIRE(btnAddTarget->isEnabled());
-      REQUIRE(btnEditTarget->isEnabled() == false);
-      REQUIRE(btnRemoveTarget->isEnabled() == false);
-      REQUIRE(lstParameters->count() == 0);
-      REQUIRE(btnAddParameter->isEnabled());
-      REQUIRE(btnEditParameter->isEnabled() == false);
-      REQUIRE(btnRemoveParameter->isEnabled() == false);
+      REQUIRE(widgets.lstTargets->count() == 0);
+      REQUIRE(widgets.btnAddTarget->isEnabled());
+      REQUIRE(widgets.btnEditTarget->isEnabled() == false);
+      REQUIRE(widgets.btnRemoveTarget->isEnabled() == false);
+      REQUIRE(widgets.lstParameters->count() == 0);
+      REQUIRE(widgets.btnAddParameter->isEnabled());
+      REQUIRE(widgets.btnEditParameter->isEnabled() == false);
+      REQUIRE(widgets.btnRemoveParameter->isEnabled() == false);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.optAlgorithmType ==
               simulate::OptAlgorithmType::PSO);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 1);
@@ -64,35 +69,36 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
               simulate::OptAlgorithmType::PSO);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 1);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.population == 2);
-      sendKeyEvents(cmbAlgorithm, {"Down"});
-      sendKeyEvents(spinIslands, {"Delete", "Backspace", "1", "5", "Enter"});
+      widgets.cmbAlgorithm->setCurrentIndex(1);
+      sendKeyEvents(widgets.spinIslands,
+                    {"Delete", "Backspace", "1", "5", "Enter"});
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.optAlgorithmType ==
               simulate::OptAlgorithmType::GPSO);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 15);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.population == 2);
-      sendKeyEvents(spinPopulation, {"Delete", "Backspace", "3", "2", "Enter"});
+      sendKeyEvents(widgets.spinPopulation,
+                    {"Delete", "Backspace", "3", "2", "Enter"});
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.optAlgorithmType ==
               simulate::OptAlgorithmType::GPSO);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 15);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.population == 32);
     }
     SECTION("user adds targets") {
-      dia.show();
-      REQUIRE(lstTargets->count() == 0);
+      REQUIRE(widgets.lstTargets->count() == 0);
       REQUIRE(dia.getOptimizeOptions().optCosts.empty());
       // click add target, then cancel: no-op
       mwt.addUserAction({"Esc"}, false);
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 0);
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 0);
       REQUIRE(dia.getOptimizeOptions().optCosts.empty());
       // click add target, change values, press ok
       mwt.addUserAction({"Down", "Tab", "Down", "Tab", "4", "Tab", "Tab",
                          "Down", "Tab", "2", "Enter"});
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 1);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 1);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mt [Rate of change of concentration at t=4, relative "
               "difference]");
       const auto &optCosts{dia.getOptimizeOptions().optCosts};
@@ -108,12 +114,12 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // add another target with default values
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mt [Rate of change of concentration at t=4, relative "
               "difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 2);
       REQUIRE(optCosts[0].optCostDiffType ==
@@ -130,16 +136,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].compartmentIndex == 0);
       REQUIRE(optCosts[1].speciesIndex == 0);
       // user edits first target, but clicks cancel
-      sendKeyEvents(lstTargets, {"Up"});
-      REQUIRE(lstTargets->currentRow() == 0);
+      sendKeyEvents(widgets.lstTargets, {"Up"});
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Down", "Down", "Escape"}, false);
       mwt.start();
-      sendMouseClick(btnEditTarget);
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnEditTarget);
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mt [Rate of change of concentration at t=4, relative "
               "difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 2);
       REQUIRE(optCosts[0].optCostDiffType ==
@@ -157,14 +163,14 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].speciesIndex == 0);
       // user edits first target & changes target species (other target values
       // get reset to defaults)
-      REQUIRE(lstTargets->currentRow() == 0);
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Down", "Enter"});
       mwt.start();
-      sendMouseClick(btnEditTarget);
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnEditTarget);
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mp [Concentration at t=100, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 2);
       REQUIRE(optCosts[0].optCostDiffType ==
@@ -180,16 +186,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].compartmentIndex == 0);
       REQUIRE(optCosts[1].speciesIndex == 0);
       // user edits first target by double-clicking on it, changes opt cost type
-      REQUIRE(lstTargets->currentRow() == 0);
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Tab", "Down"});
       mwt.start();
-      sendMouseDoubleClick(lstTargets->item(0));
+      sendMouseDoubleClick(widgets.lstTargets->item(0));
       REQUIRE(mwt.getResult() == "Edit Optimization Target");
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mp [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 2);
       REQUIRE(optCosts[0].optCostDiffType ==
@@ -206,11 +212,11 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].compartmentIndex == 0);
       REQUIRE(optCosts[1].speciesIndex == 0);
       // user deletes first target, but clicks cancel
-      REQUIRE(lstTargets->currentRow() == 0);
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Escape"}, false);
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 2);
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 2);
       REQUIRE(optCosts.size() == 2);
       REQUIRE(optCosts[0].optCostDiffType ==
               simulate::OptCostDiffType::Absolute);
@@ -228,9 +234,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes first target
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 1);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 1);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 1);
       REQUIRE(optCosts[0].optCostDiffType ==
@@ -242,27 +248,27 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes remaining target
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 0);
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 0);
       REQUIRE(optCosts.empty());
     }
     SECTION("user adds parameters") {
-      REQUIRE(lstParameters->count() == 0);
+      REQUIRE(widgets.lstParameters->count() == 0);
       const auto &optParams{dia.getOptimizeOptions().optParams};
       REQUIRE(optParams.empty());
       // click add parameter, then cancel: no-op
       mwt.addUserAction({"Esc"}, false);
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 0);
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 0);
       REQUIRE(optParams.empty());
       // click add parameter, change values, press ok
       mwt.addUserAction(
           {"Down", "Down", "Tab", "2", "Tab", "5", "Tab", "Enter"});
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 1);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 1);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
       REQUIRE(optParams.size() == 1);
       REQUIRE(optParams[0].optParamType ==
@@ -275,11 +281,12 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // add another parameter with default values
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(1)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -296,15 +303,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].lowerBound == dbl_approx(0.9));
       REQUIRE(optParams[1].upperBound == dbl_approx(0.9));
       // user edits first parameter, but clicks cancel
-      sendKeyEvents(lstParameters, {"Up"});
-      REQUIRE(lstParameters->currentRow() == 0);
+      sendKeyEvents(widgets.lstParameters, {"Up"});
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Down", "Down", "Escape"}, false);
       mwt.start();
-      sendMouseClick(btnEditParameter);
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnEditParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(1)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -322,14 +330,15 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].upperBound == dbl_approx(0.9));
       // user edits first parameter & changes parameter (lower/upper bounds get
       // reset to default for this param)
-      REQUIRE(lstParameters->currentRow() == 0);
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Down", "Enter"});
       mwt.start();
-      sendMouseClick(btnEditParameter);
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnEditParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / n [4, 4]");
-      REQUIRE(lstParameters->item(1)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -346,14 +355,15 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].lowerBound == dbl_approx(0.9));
       REQUIRE(optParams[1].upperBound == dbl_approx(0.9));
       // user edits first parameter by doubleclick & changes bound
-      REQUIRE(lstParameters->currentRow() == 0);
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Tab", "1", "Tab", "2", "Enter"});
       mwt.start();
-      sendMouseDoubleClick(lstParameters->item(0));
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseDoubleClick(widgets.lstParameters->item(0));
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / n [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -370,11 +380,11 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].lowerBound == dbl_approx(0.9));
       REQUIRE(optParams[1].upperBound == dbl_approx(0.9));
       // user deletes first parameter, but clicks cancel
-      REQUIRE(lstParameters->currentRow() == 0);
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Escape"}, false);
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 2);
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -393,9 +403,10 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes first parameter
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 1);
-      REQUIRE(lstParameters->item(0)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 1);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 1);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -407,8 +418,8 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes remaining parameter
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 0);
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 0);
       REQUIRE(optParams.empty());
     }
   }
@@ -444,32 +455,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
     optCost1.targetValues = {};
     model.getOptimizeOptions() = optimizeOptions;
     DialogOptSetup dia(model);
+    DialogOptSetupWidgets widgets(&dia);
+    dia.show();
     const auto &optParams{dia.getOptimizeOptions().optParams};
     const auto &optCosts{dia.getOptimizeOptions().optCosts};
-    // get pointers to widgets within tab
-    auto *lstTargets{dia.findChild<QListWidget *>("lstTargets")};
-    REQUIRE(lstTargets != nullptr);
-    auto *lstParameters{dia.findChild<QListWidget *>("lstParameters")};
-    REQUIRE(lstParameters != nullptr);
-    auto *btnAddTarget{dia.findChild<QPushButton *>("btnAddTarget")};
-    REQUIRE(btnAddTarget != nullptr);
-    auto *btnEditTarget{dia.findChild<QPushButton *>("btnEditTarget")};
-    REQUIRE(btnEditTarget != nullptr);
-    auto *btnRemoveTarget{dia.findChild<QPushButton *>("btnRemoveTarget")};
-    REQUIRE(btnRemoveTarget != nullptr);
-    auto *btnAddParameter{dia.findChild<QPushButton *>("btnAddParameter")};
-    REQUIRE(btnAddParameter != nullptr);
-    auto *btnEditParameter{dia.findChild<QPushButton *>("btnEditParameter")};
-    REQUIRE(btnEditParameter != nullptr);
-    auto *btnRemoveParameter{
-        dia.findChild<QPushButton *>("btnRemoveParameter")};
-    REQUIRE(btnRemoveParameter != nullptr);
     ModalWidgetTimer mwt;
     SECTION("user does nothing") {
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
       REQUIRE(optCosts.size() == 2);
@@ -490,12 +485,13 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].id == "T0");
       REQUIRE(optCosts[1].compartmentIndex == 0);
       REQUIRE(optCosts[1].speciesIndex == 3);
-      REQUIRE(btnAddTarget->isEnabled());
-      REQUIRE(btnEditTarget->isEnabled() == false);
-      REQUIRE(btnRemoveTarget->isEnabled() == false);
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      REQUIRE(widgets.btnAddTarget->isEnabled());
+      REQUIRE(widgets.btnEditTarget->isEnabled() == false);
+      REQUIRE(widgets.btnRemoveTarget->isEnabled() == false);
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
@@ -512,19 +508,19 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].name == "Mp_transcription_n");
       REQUIRE(optParams[1].lowerBound == 0.2);
       REQUIRE(optParams[1].upperBound == 0.4);
-      REQUIRE(btnAddParameter->isEnabled());
-      REQUIRE(btnEditParameter->isEnabled() == false);
-      REQUIRE(btnRemoveParameter->isEnabled() == false);
+      REQUIRE(widgets.btnAddParameter->isEnabled());
+      REQUIRE(widgets.btnEditParameter->isEnabled() == false);
+      REQUIRE(widgets.btnRemoveParameter->isEnabled() == false);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.optAlgorithmType ==
               simulate::OptAlgorithmType::PSO);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 5);
       REQUIRE(dia.getOptimizeOptions().optAlgorithm.population == 17);
     }
     SECTION("user adds targets") {
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
       REQUIRE(optCosts.size() == 2);
@@ -546,11 +542,11 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // click add target, then cancel: no-op
       mwt.addUserAction({"Esc"}, false);
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 2);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 2);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
       REQUIRE(optCosts.size() == 2);
@@ -572,14 +568,14 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // click add target, change values, press ok
       mwt.addUserAction({"Down", "Tab", "Down", "Tab", "Enter"});
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 3);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 3);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
       REQUIRE(optCosts.size() == 3);
@@ -608,17 +604,17 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // add another target with default values
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnAddTarget);
-      REQUIRE(lstTargets->count() == 4);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnAddTarget);
+      REQUIRE(widgets.lstTargets->count() == 4);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(3)->text() ==
+      REQUIRE(widgets.lstTargets->item(3)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 4);
       REQUIRE(optCosts[0].optCostType == simulate::OptCostType::Concentration);
@@ -650,21 +646,21 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[3].compartmentIndex == 0);
       REQUIRE(optCosts[3].speciesIndex == 0);
       // user edits first target, but clicks cancel
-      sendKeyEvents(lstTargets, {"Up"});
-      REQUIRE(lstTargets->currentRow() == 0);
+      sendKeyEvents(widgets.lstTargets, {"Up"});
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Down", "Down", "Escape"}, false);
       mwt.start();
-      sendMouseClick(btnEditTarget);
-      REQUIRE(lstTargets->count() == 4);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnEditTarget);
+      REQUIRE(widgets.lstTargets->count() == 4);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/P0 [Concentration at t=18, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(3)->text() ==
+      REQUIRE(widgets.lstTargets->item(3)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 4);
       REQUIRE(optCosts[0].optCostType == simulate::OptCostType::Concentration);
@@ -697,20 +693,20 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[3].speciesIndex == 0);
       // user edits first target & changes target species (other target values
       // get reset to defaults)
-      REQUIRE(lstTargets->currentRow() == 0);
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Down", "Enter"});
       mwt.start();
-      sendMouseClick(btnEditTarget);
-      REQUIRE(lstTargets->count() == 4);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnEditTarget);
+      REQUIRE(widgets.lstTargets->count() == 4);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mt [Concentration at t=100, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(3)->text() ==
+      REQUIRE(widgets.lstTargets->item(3)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 4);
       REQUIRE(optCosts[0].optCostType == simulate::OptCostType::Concentration);
@@ -746,20 +742,20 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[3].compartmentIndex == 0);
       REQUIRE(optCosts[3].speciesIndex == 0);
       // user deletes first target, but clicks cancel
-      REQUIRE(lstTargets->currentRow() == 0);
+      REQUIRE(widgets.lstTargets->currentRow() == 0);
       mwt.addUserAction({"Escape"}, false);
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 4);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 4);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/Mt [Concentration at t=100, absolute difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(3)->text() ==
+      REQUIRE(widgets.lstTargets->item(3)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 4);
       REQUIRE(optCosts[0].optCostType == simulate::OptCostType::Concentration);
@@ -797,15 +793,15 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes first target
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 3);
-      REQUIRE(lstTargets->item(0)->text() ==
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 3);
+      REQUIRE(widgets.lstTargets->item(0)->text() ==
               "cell/T0 [Rate of change of concentration at t=9, relative "
               "difference]");
-      REQUIRE(lstTargets->item(1)->text() ==
+      REQUIRE(widgets.lstTargets->item(1)->text() ==
               "cell/Mt [Rate of change of concentration at t=100, absolute "
               "difference]");
-      REQUIRE(lstTargets->item(2)->text() ==
+      REQUIRE(widgets.lstTargets->item(2)->text() ==
               "cell/P0 [Concentration at t=100, absolute difference]");
       REQUIRE(optCosts.size() == 3);
       REQUIRE(optCosts[0].optCostType ==
@@ -835,20 +831,21 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes remaining targets
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
+      sendMouseClick(widgets.btnRemoveTarget);
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
+      sendMouseClick(widgets.btnRemoveTarget);
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveTarget);
-      REQUIRE(lstTargets->count() == 0);
+      sendMouseClick(widgets.btnRemoveTarget);
+      REQUIRE(widgets.lstTargets->count() == 0);
       REQUIRE(optCosts.empty());
     }
     SECTION("user adds parameters") {
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
@@ -868,10 +865,11 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // click add parameter, then cancel: no-op
       mwt.addUserAction({"Esc"}, false);
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 2);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
       REQUIRE(optParams.size() == 2);
       REQUIRE(optParams[0].optParamType ==
@@ -892,12 +890,13 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       mwt.addUserAction(
           {"Down", "Down", "Tab", "2", "Tab", "5", "Tab", "Enter"});
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 3);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 3);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(2)->text() ==
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
       REQUIRE(optParams.size() == 3);
       REQUIRE(optParams[0].optParamType ==
@@ -924,14 +923,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // add another parameter with default values
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnAddParameter);
-      REQUIRE(lstParameters->count() == 4);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      sendMouseClick(widgets.btnAddParameter);
+      REQUIRE(widgets.lstParameters->count() == 4);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(2)->text() ==
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(3)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(3)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 4);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -962,18 +963,20 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[3].lowerBound == dbl_approx(0.9));
       REQUIRE(optParams[3].upperBound == dbl_approx(0.9));
       // user edits first parameter, but clicks cancel
-      sendKeyEvents(lstParameters, {"Up"});
-      REQUIRE(lstParameters->currentRow() == 0);
+      sendKeyEvents(widgets.lstParameters, {"Up"});
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Down", "Down", "Escape"}, false);
       mwt.start();
-      sendMouseClick(btnEditParameter);
-      REQUIRE(lstParameters->count() == 4);
-      REQUIRE(lstParameters->item(0)->text() == "Mp_transcription_K [1, 2]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      sendMouseClick(widgets.btnEditParameter);
+      REQUIRE(widgets.lstParameters->count() == 4);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
+              "Mp_transcription_K [1, 2]");
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(2)->text() ==
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(3)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(3)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 4);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -1005,18 +1008,19 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[3].upperBound == dbl_approx(0.9));
       // user edits first parameter & changes parameter (lower/upper bounds get
       // reset to default for this param)
-      REQUIRE(lstParameters->currentRow() == 0);
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Down", "Enter"});
       mwt.start();
-      sendMouseClick(btnEditParameter);
-      REQUIRE(lstParameters->count() == 4);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnEditParameter);
+      REQUIRE(widgets.lstParameters->count() == 4);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / n [4, 4]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(2)->text() ==
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(3)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(3)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 4);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -1047,18 +1051,19 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[3].lowerBound == dbl_approx(0.9));
       REQUIRE(optParams[3].upperBound == dbl_approx(0.9));
       // user deletes first parameter, but clicks cancel
-      REQUIRE(lstParameters->currentRow() == 0);
+      REQUIRE(widgets.lstParameters->currentRow() == 0);
       mwt.addUserAction({"Escape"}, false);
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 4);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 4);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Reaction 'Mp transcription' / n [4, 4]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(2)->text() ==
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(3)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(3)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 4);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -1091,13 +1096,14 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes first parameter
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 3);
-      REQUIRE(lstParameters->item(0)->text() ==
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 3);
+      REQUIRE(widgets.lstParameters->item(0)->text() ==
               "Mp_transcription_n [0.2, 0.4]");
-      REQUIRE(lstParameters->item(1)->text() ==
+      REQUIRE(widgets.lstParameters->item(1)->text() ==
               "Reaction 'Mp transcription' / K [2, 5]");
-      REQUIRE(lstParameters->item(2)->text() == "Reaction 'sP' / k [0.9, 0.9]");
+      REQUIRE(widgets.lstParameters->item(2)->text() ==
+              "Reaction 'sP' / k [0.9, 0.9]");
       REQUIRE(optParams.size() == 3);
       REQUIRE(optParams[0].optParamType ==
               simulate::OptParamType::ReactionParameter);
@@ -1123,18 +1129,18 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user deletes remaining parameters
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 2);
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 2);
       REQUIRE(optParams.size() == 2);
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 1);
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 1);
       REQUIRE(optParams.size() == 1);
       mwt.addUserAction({"Enter"});
       mwt.start();
-      sendMouseClick(btnRemoveParameter);
-      REQUIRE(lstParameters->count() == 0);
+      sendMouseClick(widgets.btnRemoveParameter);
+      REQUIRE(widgets.lstParameters->count() == 0);
       REQUIRE(optParams.empty());
     }
   }
@@ -1144,10 +1150,10 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
         sme::simulate::SimulatorType::DUNE;
     model.getOptimizeOptions().optAlgorithm.islands = 4;
     DialogOptSetup dia(model);
-    auto *spinIslands{dia.findChild<QSpinBox *>("spinIslands")};
-    REQUIRE(spinIslands != nullptr);
-    REQUIRE(spinIslands->value() == 1);
-    REQUIRE(spinIslands->maximum() == 1);
+    DialogOptSetupWidgets widgets(&dia);
+    dia.show();
+    REQUIRE(widgets.spinIslands->value() == 1);
+    REQUIRE(widgets.spinIslands->maximum() == 1);
     REQUIRE(dia.getOptimizeOptions().optAlgorithm.islands == 1);
   }
 }

--- a/gui/dialogs/dialogsimulationoptions_t.cpp
+++ b/gui/dialogs/dialogsimulationoptions_t.cpp
@@ -2,8 +2,66 @@
 #include "dialogsimulationoptions.hpp"
 #include "qt_test_utils.hpp"
 #include "sme/simulate.hpp"
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTabWidget>
 
 using namespace sme::test;
+
+struct DialogSimulationOptionsWidgets {
+  explicit DialogSimulationOptionsWidgets(
+      const DialogSimulationOptions *dialog) {
+    GET_DIALOG_WIDGET(QTabWidget, tabSimulator);
+    // DUNE tab
+    GET_DIALOG_WIDGET(QComboBox, cmbDuneDiscretization);
+    GET_DIALOG_WIDGET(QComboBox, cmbDuneIntegrator);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneDt);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneMinDt);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneMaxDt);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneIncrease);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneDecrease);
+    GET_DIALOG_WIDGET(QCheckBox, chkDuneVTK);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneNewtonRel);
+    GET_DIALOG_WIDGET(QLineEdit, txtDuneNewtonAbs);
+    GET_DIALOG_WIDGET(QPushButton, btnDuneReset);
+    // Pixel tab
+    GET_DIALOG_WIDGET(QComboBox, cmbPixelIntegrator);
+    GET_DIALOG_WIDGET(QLineEdit, txtPixelRelErr);
+    GET_DIALOG_WIDGET(QLineEdit, txtPixelAbsErr);
+    GET_DIALOG_WIDGET(QLineEdit, txtPixelDt);
+    GET_DIALOG_WIDGET(QCheckBox, chkPixelMultithread);
+    GET_DIALOG_WIDGET(QSpinBox, spnPixelThreads);
+    GET_DIALOG_WIDGET(QCheckBox, chkPixelCSE);
+    GET_DIALOG_WIDGET(QSpinBox, spnPixelOptLevel);
+    GET_DIALOG_WIDGET(QPushButton, btnPixelReset);
+  }
+  QTabWidget *tabSimulator;
+  // DUNE tab
+  QComboBox *cmbDuneDiscretization;
+  QComboBox *cmbDuneIntegrator;
+  QLineEdit *txtDuneDt;
+  QLineEdit *txtDuneMinDt;
+  QLineEdit *txtDuneMaxDt;
+  QLineEdit *txtDuneIncrease;
+  QLineEdit *txtDuneDecrease;
+  QCheckBox *chkDuneVTK;
+  QLineEdit *txtDuneNewtonRel;
+  QLineEdit *txtDuneNewtonAbs;
+  QPushButton *btnDuneReset;
+  // Pixel tab
+  QComboBox *cmbPixelIntegrator;
+  QLineEdit *txtPixelRelErr;
+  QLineEdit *txtPixelAbsErr;
+  QLineEdit *txtPixelDt;
+  QCheckBox *chkPixelMultithread;
+  QSpinBox *spnPixelThreads;
+  QCheckBox *chkPixelCSE;
+  QSpinBox *spnPixelOptLevel;
+  QPushButton *btnPixelReset;
+};
 
 TEST_CASE("DialogSimulationOptions", "[gui/dialogs/simulationoptions][gui/"
                                      "dialogs][gui][simulationoptions]") {
@@ -25,11 +83,10 @@ TEST_CASE("DialogSimulationOptions", "[gui/dialogs/simulationoptions][gui/"
   options.pixel.doCSE = true;
   options.pixel.optLevel = 3;
   DialogSimulationOptions dia(options);
+  DialogSimulationOptionsWidgets widgets(&dia);
+  dia.show();
   ModalWidgetTimer mwt;
   SECTION("user does nothing: unchanged") {
-    mwt.addUserAction();
-    mwt.start();
-    dia.exec();
     auto opt = dia.getOptions();
     REQUIRE(options.dune.integrator == "ExplicitEuler");
     REQUIRE(options.dune.dt == dbl_approx(0.123));
@@ -49,14 +106,24 @@ TEST_CASE("DialogSimulationOptions", "[gui/dialogs/simulationoptions][gui/"
     REQUIRE(opt.pixel.doCSE == true);
     REQUIRE(opt.pixel.optLevel == 3);
   }
-  SECTION("user changes Dune values") {
-    mwt.addUserAction({"Tab", "Tab", "Down", "Down", "9", "Tab", ".",
-                       "4",   "Tab", "1",    "e",    "-", "1",   "2",
-                       "Tab", "9",   "Tab",  "1",    ".", "2",   "Tab",
-                       "0",   ".",   "7",    "Tab",  " ", "Tab", "1",
-                       "e",   "-",   "7",    "Tab",  "0"});
-    mwt.start();
-    dia.exec();
+  SECTION("user changes Dune values, then resets to defaults") {
+    widgets.tabSimulator->setCurrentIndex(0);
+    widgets.cmbDuneIntegrator->setCurrentIndex(2);
+    widgets.txtDuneDt->clear();
+    sendKeyEvents(widgets.txtDuneDt, {"0", ".", "4", "Enter"});
+    widgets.txtDuneMinDt->clear();
+    sendKeyEvents(widgets.txtDuneMinDt, {"1", "e", "-", "1", "2", "Enter"});
+    widgets.txtDuneMaxDt->clear();
+    sendKeyEvents(widgets.txtDuneMaxDt, {"9", "Enter"});
+    widgets.txtDuneIncrease->clear();
+    sendKeyEvents(widgets.txtDuneIncrease, {"1", ".", "2", "Enter"});
+    widgets.txtDuneDecrease->clear();
+    sendKeyEvents(widgets.txtDuneDecrease, {"0", ".", "7", "Enter"});
+    widgets.chkDuneVTK->setChecked(false);
+    widgets.txtDuneNewtonRel->clear();
+    sendKeyEvents(widgets.txtDuneNewtonRel, {"1", "e", "-", "7", "Enter"});
+    widgets.txtDuneNewtonAbs->clear();
+    sendKeyEvents(widgets.txtDuneNewtonAbs, {"0", "Enter"});
     auto opt = dia.getOptions();
     REQUIRE(opt.dune.integrator == "Heun");
     REQUIRE(opt.dune.dt == dbl_approx(0.4));
@@ -67,14 +134,9 @@ TEST_CASE("DialogSimulationOptions", "[gui/dialogs/simulationoptions][gui/"
     REQUIRE(opt.dune.writeVTKfiles == false);
     REQUIRE(opt.dune.newtonRelErr == dbl_approx(1e-7));
     REQUIRE(opt.dune.newtonAbsErr == dbl_approx(0));
-  }
-  SECTION("user resets to Dune defaults") {
-    mwt.addUserAction({"Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab",
-                       "Tab", "Tab", "Tab", " "});
-    mwt.start();
-    dia.exec();
+    sendMouseClick(widgets.btnDuneReset);
     sme::simulate::DuneOptions defaultOpts{};
-    auto opt = dia.getOptions();
+    opt = dia.getOptions();
     REQUIRE(opt.dune.integrator == defaultOpts.integrator);
     REQUIRE(opt.dune.dt == dbl_approx(defaultOpts.dt));
     REQUIRE(opt.dune.minDt == dbl_approx(defaultOpts.minDt));
@@ -83,34 +145,38 @@ TEST_CASE("DialogSimulationOptions", "[gui/dialogs/simulationoptions][gui/"
     REQUIRE(opt.dune.decrease == defaultOpts.decrease);
     REQUIRE(opt.dune.writeVTKfiles == defaultOpts.writeVTKfiles);
   }
-  SECTION("user changes Pixel values") {
-    mwt.addUserAction({"Right", "Tab", "Up",  "Up",  "Tab",   "7",   "Tab",
-                       "9",     "9",   "Tab", "0",   ".",     "5",   "Tab",
-                       "Space", "Tab", "1",   "Tab", "Space", "Tab", "1"});
-    mwt.start();
-    dia.exec();
+  SECTION("user changes Pixel values, then resets to defaults") {
+    widgets.tabSimulator->setCurrentIndex(0);
+    widgets.cmbPixelIntegrator->setCurrentIndex(2);
+    widgets.txtPixelRelErr->clear();
+    sendKeyEvents(widgets.txtPixelRelErr, {"0", ".", "4", "Enter"});
+    widgets.txtPixelAbsErr->clear();
+    sendKeyEvents(widgets.txtPixelAbsErr, {"2", ".", "7", "Enter"});
+    widgets.txtPixelDt->clear();
+    sendKeyEvents(widgets.txtPixelDt, {"0", ".", "0", "1", "8", "Enter"});
+    widgets.chkPixelMultithread->setChecked(true);
+    widgets.spnPixelThreads->setValue(1);
+    widgets.chkPixelCSE->setChecked(false);
+    widgets.spnPixelOptLevel->setValue(1);
     auto opt = dia.getOptions();
-    REQUIRE(opt.pixel.integrator == sme::simulate::PixelIntegratorType::RK212);
-    REQUIRE(opt.pixel.maxErr.rel == dbl_approx(7));
-    REQUIRE(opt.pixel.maxErr.abs == dbl_approx(99));
-    REQUIRE(opt.pixel.maxTimestep == dbl_approx(0.5));
+    REQUIRE(opt.pixel.integrator == sme::simulate::PixelIntegratorType::RK323);
+    REQUIRE(opt.pixel.maxErr.rel == dbl_approx(0.4));
+    REQUIRE(opt.pixel.maxErr.abs == dbl_approx(2.7));
+    REQUIRE(opt.pixel.maxTimestep == dbl_approx(0.018));
     REQUIRE(opt.pixel.enableMultiThreading == true);
     REQUIRE(opt.pixel.maxThreads == 1);
     REQUIRE(opt.pixel.doCSE == false);
     REQUIRE(opt.pixel.optLevel == 1);
-  }
-  SECTION("user resets to pixel defaults") {
-    mwt.addUserAction(
-        {"Right", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", "Tab", " "});
-    mwt.start();
-    dia.exec();
+    sendMouseClick(widgets.btnPixelReset);
     sme::simulate::PixelOptions defaultOpts{};
-    auto opt = dia.getOptions();
+    opt = dia.getOptions();
     REQUIRE(opt.pixel.integrator == defaultOpts.integrator);
     REQUIRE(opt.pixel.maxErr.rel == dbl_approx(defaultOpts.maxErr.rel));
     REQUIRE(opt.pixel.maxErr.abs == dbl_approx(defaultOpts.maxErr.abs));
     REQUIRE(opt.pixel.maxTimestep == dbl_approx(defaultOpts.maxTimestep));
     REQUIRE(opt.pixel.enableMultiThreading == defaultOpts.enableMultiThreading);
     REQUIRE(opt.pixel.maxThreads == defaultOpts.maxThreads);
+    REQUIRE(opt.pixel.doCSE == defaultOpts.doCSE);
+    REQUIRE(opt.pixel.optLevel == defaultOpts.optLevel);
   }
 }

--- a/gui/dialogs/dialogunits_t.cpp
+++ b/gui/dialogs/dialogunits_t.cpp
@@ -3,75 +3,63 @@
 #include "model_test_utils.hpp"
 #include "qt_test_utils.hpp"
 #include "sme/model.hpp"
+#include <QComboBox>
+#include <QPushButton>
 
 using namespace sme::test;
 
+struct DialogUnitsWidgets {
+  explicit DialogUnitsWidgets(const DialogUnits *dialog) {
+    GET_DIALOG_WIDGET(QComboBox, cmbTime);
+    GET_DIALOG_WIDGET(QComboBox, cmbLength);
+    GET_DIALOG_WIDGET(QComboBox, cmbVolume);
+    GET_DIALOG_WIDGET(QComboBox, cmbAmount);
+    GET_DIALOG_WIDGET(QPushButton, btnEditTime);
+    GET_DIALOG_WIDGET(QPushButton, btnEditLength);
+    GET_DIALOG_WIDGET(QPushButton, btnEditVolume);
+    GET_DIALOG_WIDGET(QPushButton, btnEditAmount);
+  }
+  QComboBox *cmbTime;
+  QComboBox *cmbLength;
+  QComboBox *cmbVolume;
+  QComboBox *cmbAmount;
+  QPushButton *btnEditTime;
+  QPushButton *btnEditLength;
+  QPushButton *btnEditVolume;
+  QPushButton *btnEditAmount;
+};
+
 TEST_CASE("DialogUnits", "[gui/dialogs/units][gui/dialogs][gui][units]") {
   auto m{getExampleModel(Mod::ABtoC)};
-  SECTION("no default units") {
-    auto units = m.getUnits();
-    units.setTimeIndex(0);
-    units.setLengthIndex(0);
-    units.setVolumeIndex(0);
-    units.setAmountIndex(0);
-    DialogUnits dia(units);
-    REQUIRE(dia.getTimeUnitIndex() == 0);
-    REQUIRE(dia.getLengthUnitIndex() == 0);
-    REQUIRE(dia.getVolumeUnitIndex() == 0);
-    REQUIRE(dia.getAmountUnitIndex() == 0);
-    ModalWidgetTimer mwt;
-    SECTION("user presses down key on each") {
-      mwt.addUserAction({"Down", "Tab", "Down", "Tab", "Down", "Tab", "Down"});
-      mwt.start();
-      dia.exec();
-      REQUIRE(dia.getTimeUnitIndex() == 1);
-      REQUIRE(dia.getLengthUnitIndex() == 1);
-      REQUIRE(dia.getVolumeUnitIndex() == 1);
-      REQUIRE(dia.getAmountUnitIndex() == 1);
-    }
-  }
-  SECTION("default units") {
-    auto units = m.getUnits();
-    units.setTimeIndex(0);
-    units.setLengthIndex(3);
-    units.setVolumeIndex(2);
-    units.setAmountIndex(1);
-    DialogUnits dia(units);
-    REQUIRE(dia.getTimeUnitIndex() == 0);
-    REQUIRE(dia.getLengthUnitIndex() == 3);
-    REQUIRE(dia.getVolumeUnitIndex() == 2);
-    REQUIRE(dia.getAmountUnitIndex() == 1);
-    ModalWidgetTimer mwt;
-    SECTION("user changes selection") {
-      mwt.addUserAction({"Down", "Tab", "Up", "Tab", "Up", "Tab", "Down"});
-      mwt.start();
-      dia.exec();
-      REQUIRE(dia.getTimeUnitIndex() == 1);
-      REQUIRE(dia.getLengthUnitIndex() == 2);
-      REQUIRE(dia.getVolumeUnitIndex() == 1);
-      REQUIRE(dia.getAmountUnitIndex() == 2);
-    }
-    SECTION("user presses up a lot for all") {
-      mwt.addUserAction({"Up", "Up", "Tab", "Up", "Up", "Up", "Tab", "Up", "Up",
-                         "Tab", "Up", "Up", "Up"});
-      mwt.start();
-      dia.exec();
-      REQUIRE(dia.getTimeUnitIndex() == 0);
-      REQUIRE(dia.getLengthUnitIndex() == 0);
-      REQUIRE(dia.getVolumeUnitIndex() == 0);
-      REQUIRE(dia.getAmountUnitIndex() == 0);
-    }
-    SECTION("user presses down a lot for all") {
-      mwt.addUserAction({"Down", "Down", "Down", "Down", "Down", "Down", "Tab",
-                         "Down", "Down", "Down", "Down", "Down", "Down", "Tab",
-                         "Down", "Down", "Down", "Down", "Down", "Down", "Tab",
-                         "Down", "Down", "Down", "Down", "Down", "Down"});
-      mwt.start();
-      dia.exec();
-      REQUIRE(dia.getTimeUnitIndex() == units.getTimeUnits().size() - 1);
-      REQUIRE(dia.getLengthUnitIndex() == units.getLengthUnits().size() - 1);
-      REQUIRE(dia.getVolumeUnitIndex() == units.getVolumeUnits().size() - 1);
-      REQUIRE(dia.getAmountUnitIndex() == units.getAmountUnits().size() - 1);
-    }
-  }
+  auto units = m.getUnits();
+  units.setTimeIndex(0);
+  units.setLengthIndex(3);
+  units.setVolumeIndex(2);
+  units.setAmountIndex(1);
+  DialogUnits dia(units);
+  dia.show();
+  DialogUnitsWidgets widgets(&dia);
+  // initial units
+  REQUIRE(dia.getTimeUnitIndex() == 0);
+  REQUIRE(dia.getLengthUnitIndex() == 3);
+  REQUIRE(dia.getVolumeUnitIndex() == 2);
+  REQUIRE(dia.getAmountUnitIndex() == 1);
+  // select 2nd unit for each
+  widgets.cmbTime->setCurrentIndex(1);
+  widgets.cmbLength->setCurrentIndex(1);
+  widgets.cmbVolume->setCurrentIndex(1);
+  widgets.cmbAmount->setCurrentIndex(1);
+  REQUIRE(dia.getTimeUnitIndex() == 1);
+  REQUIRE(dia.getLengthUnitIndex() == 1);
+  REQUIRE(dia.getVolumeUnitIndex() == 1);
+  REQUIRE(dia.getAmountUnitIndex() == 1);
+  // select last unit for each
+  widgets.cmbTime->setCurrentIndex(widgets.cmbTime->count() - 1);
+  widgets.cmbLength->setCurrentIndex(widgets.cmbLength->count() - 1);
+  widgets.cmbVolume->setCurrentIndex(widgets.cmbVolume->count() - 1);
+  widgets.cmbAmount->setCurrentIndex(widgets.cmbAmount->count() - 1);
+  REQUIRE(dia.getTimeUnitIndex() == units.getTimeUnits().size() - 1);
+  REQUIRE(dia.getLengthUnitIndex() == units.getLengthUnits().size() - 1);
+  REQUIRE(dia.getVolumeUnitIndex() == units.getVolumeUnits().size() - 1);
+  REQUIRE(dia.getAmountUnitIndex() == units.getAmountUnits().size() - 1);
 }

--- a/test/test_utils/qt_test_utils.hpp
+++ b/test/test_utils/qt_test_utils.hpp
@@ -7,11 +7,21 @@
 #include <QString>
 #include <QStringList>
 #include <QTimer>
+#include <QTreeWidgetItem>
 #include <QtCore>
+#include <functional>
 #include <queue>
 #include <utility>
 
 namespace sme::test {
+
+// macro to find widget in dialog and assign to variable of same name, which
+// throws if not found
+#define GET_DIALOG_WIDGET(WTYPE, WNAME)                                        \
+  WNAME = dialog->findChild<WTYPE *>(#WNAME);                                  \
+  if (WNAME == nullptr) {                                                      \
+    throw std::runtime_error(#WTYPE " '" #WNAME "' not found");                \
+  }
 
 // delay in ms to insert between key events
 constexpr int keyDelay{0};
@@ -47,6 +57,9 @@ void sendMouseClick(QWidget *widget, const QPoint &pos = {},
 void sendMouseClick(QListWidgetItem *item,
                     Qt::MouseButton button = Qt::MouseButton::LeftButton);
 
+void sendMouseClick(QTreeWidgetItem *item,
+                    Qt::MouseButton button = Qt::MouseButton::LeftButton);
+
 void sendMouseDoubleClick(QWidget *widget, const QPoint &pos = {},
                           Qt::MouseButton button = Qt::MouseButton::LeftButton);
 
@@ -68,6 +81,8 @@ void sendMouseDrag(QWidget *widget, const QPoint &startPos,
 //       - so the newly started one can deal with & close the new modal widget
 //       - once closed, execution returns to the current ModalWidgetTimer
 //    - sends KeyEvents for the keys specified in UserAction to the modal widget
+//    - or alternatively calls user-provided callback, passing in the modal
+//    widget
 //    - optionally calls accept (i.e. press OK) on the modal widget
 // default timing:
 //    - check for a modal widget every 0.1s
@@ -77,7 +92,10 @@ class ModalWidgetTimer : public QObject {
   Q_OBJECT
 public:
   explicit ModalWidgetTimer(int timerInterval = 100, int timeout = 30000);
-  void addUserAction(QStringList &&keySeqStrings = {},
+  void addUserAction(const QStringList &keySeqStrings = {},
+                     bool callAcceptOnDialog = true,
+                     ModalWidgetTimer *otherMwtToStart = nullptr);
+  void addUserAction(std::function<void(QWidget *)> callback,
                      bool callAcceptOnDialog = true,
                      ModalWidgetTimer *otherMwtToStart = nullptr);
   void setIgnoredWidget(QWidget *widgetToIgnore);
@@ -86,10 +104,8 @@ public:
 
 private:
   struct UserAction {
-    explicit UserAction(QStringList &&keys = {}, bool accept = true,
-                        ModalWidgetTimer *mwt = nullptr)
-        : keySeqStrings(std::move(keys)), callAccept(accept), mwtToStart(mwt) {}
-    QStringList keySeqStrings;
+    QStringList keySeqStrings{};
+    std::function<void(QWidget *)> callbackFunction{};
     bool callAccept = true;
     ModalWidgetTimer *mwtToStart = nullptr;
     QWidget *widgetToIgnore = nullptr;


### PR DESCRIPTION
- add callback action as alternative to keypress action in `ModalWidgetTimer`
  - callback is passed a pointer to the Modal Widget
  - can then use `findChild` inside the callback to write tests that are easier to understand and maintain
  - much better than a list of "Tab" keystrokes that need updating if a new widget is added to the dialog
  - resolves #895
- add helper macro `GET_DIALOG_WIDGET` to find a dialog child widget and throw if not found
  - use this to create a struct of child widgets in tests of a given dialog
  - re-use this struct in the tests to avoid duplicating `findChild` calls and nullptr checks
- reduce use of `ModalWidgetTimer` in test code
  - prefer `show()` and `sendKeyEvents()` over `exec()` and `ModalWidgetTimer`
