### PR TITLE
Add 3d volume rendering for voxel visualization using VTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Spatial Model Editor makes use of the following open source libraries:
 
 - [LibCombine](https://github.com/sbmlteam/libcombine) - license: [BSD](https://github.com/sbmlteam/libCombine/blob/master/LICENSE.md)
 
+- [VTK](https://vtk.org/) - license: [BSD](https://gitlab.kitware.com/vtk/vtk/-/blob/master/Copyright.txt)
+
 ## Licensing Note
 
 The source code in this repository is released under the MIT license, which is a permissive

--- a/app/spatial-model-editor.cpp
+++ b/app/spatial-model-editor.cpp
@@ -3,6 +3,7 @@
 #include "sme/version.hpp"
 #include <QApplication>
 #include <QIcon>
+#include <QVTKOpenGLNativeWidget.h>
 #include <QtGui>
 #include <fmt/core.h>
 #include <locale>
@@ -27,6 +28,9 @@ int main(int argc, char *argv[]) {
   // set to lowest level here to show everything
   // then disable lower levels at compile time
   spdlog::set_level(spdlog::level::trace);
+
+  // ensure our default opengl format is compatible with vtk
+  QSurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat());
 
   QApplication a(argc, argv);
   QApplication::setWindowIcon(QIcon(":/icon/icon.ico"));

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2023.11.21"
+SME_DEPS_VERSION="2023.12.12"
 OS=$1
 
 set -e -x

--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -24,6 +24,9 @@ cmake .. \
     -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib/cmake" \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DSME_LOG_LEVEL=OFF \
+    -DFREETYPE_LIBRARY_RELEASE=/opt/smelibs/lib/libQt6BundledFreetype.a \
+    -DFREETYPE_INCLUDE_DIR_freetype2=/opt/smelibs/include/QtFreetype \
+    -DFREETYPE_INCLUDE_DIR_ft2build=/opt/smelibs/include/QtFreetype \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="11"
 make -j3 VERBOSE=1
 ccache --show-stats

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -40,7 +40,10 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER \
     -DSME_QT_DISABLE_UNICODE=$SME_QT_DISABLE_UNICODE \
     -DSME_LOG_LEVEL=OFF \
-    -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS
+    -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
+    -DFREETYPE_LIBRARY_RELEASE=/c/smelibs/lib/libQt6BundledFreetype.a \
+    -DFREETYPE_INCLUDE_DIR_freetype2=/c/smelibs/include/QtFreetype \
+    -DFREETYPE_INCLUDE_DIR_ft2build=/c/smelibs/include/QtFreetype
 make -j2 VERBOSE=1
 
 ccache -s -v

--- a/core/common/include/sme/image_stack.hpp
+++ b/core/common/include/sme/image_stack.hpp
@@ -39,12 +39,12 @@ public:
   [[nodiscard]] inline const Volume &volume() const noexcept { return sz; }
   inline std::vector<QImage>::iterator begin() noexcept { return imgs.begin(); }
   [[nodiscard]] inline std::vector<QImage>::const_iterator
-  cbegin() const noexcept {
+  begin() const noexcept {
     return imgs.cbegin();
   }
   inline std::vector<QImage>::iterator end() noexcept { return imgs.end(); }
   [[nodiscard]] inline std::vector<QImage>::const_iterator
-  cend() const noexcept {
+  end() const noexcept {
     return imgs.cend();
   }
   void clear();

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -16,6 +16,26 @@ target_include_directories(gui PUBLIC .)
 find_package(qcustomplot)
 target_link_libraries(gui PUBLIC qcustomplot::qcustomplot)
 
+find_package(
+  VTK REQUIRED
+  COMPONENTS RenderingQt
+             GUISupportQt
+             CommonColor
+             CommonCore
+             CommonDataModel
+             FiltersCore
+             InteractionStyle
+             RenderingUI
+             RenderingContextOpenGL2
+             RenderingCore
+             RenderingFreeType
+             RenderingGL2PSOpenGL2
+             RenderingLOD
+             RenderingOpenGL2
+             RenderingVolume
+             RenderingVolumeOpenGL2)
+message(STATUS "VTK_LIBRARIES found: ${VTK_LIBRARIES}")
+
 if(BUILD_TESTING)
   target_sources(gui_tests PUBLIC mainwindow_t.cpp guiutils_t.cpp)
   target_link_libraries(gui_tests PUBLIC gui testlib)
@@ -32,4 +52,11 @@ target_link_libraries(
   PUBLIC Qt::Widgets
          sme::core
          Qt::OpenGLWidgets
-         Qt::OpenGL)
+         Qt::OpenGL
+         ${VTK_LIBRARIES})
+
+vtk_module_autoinit(
+  TARGETS
+  gui
+  MODULES
+  ${VTK_LIBRARIES})

--- a/gui/dialogs/dialogabout.cpp
+++ b/gui/dialogs/dialogabout.cpp
@@ -21,6 +21,7 @@
 #include <spdlog/version.h>
 #include <symengine/symengine_config.h>
 #include <tiffvers.h>
+#include <vtkVersion.h>
 #include <zlib.h>
 
 static QString dep(const QString &name, const QString &url,
@@ -101,6 +102,7 @@ DialogAbout::DialogAbout(QWidget *parent)
       dep("zipper", "https://github.com/fbergmann/zipper", "master"));
   libraries.append(dep("libCombine", "https://github.com/sbmlteam/libCombine",
                        libcombine::getLibCombineDottedVersion()));
+  libraries.append(dep("VTK", "https://vtk.org/", vtkVersion::GetVTKVersion()));
 
   libraries.append("</ul>");
   ui->lblLibraries->setText(libraries);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -127,14 +127,16 @@ MainWindow::MainWindow(const QString &filename, QWidget *parent)
 MainWindow::~MainWindow() = default;
 
 void MainWindow::setupTabs() {
-  tabGeometry =
-      new TabGeometry(model, ui->lblGeometry, statusBar(), ui->tabReactions);
+  tabGeometry = new TabGeometry(model, ui->lblGeometry, ui->voxGeometry,
+                                statusBar(), ui->tabReactions);
   ui->tabGeometry->layout()->addWidget(tabGeometry);
 
-  tabSpecies = new TabSpecies(model, ui->lblGeometry, ui->tabSpecies);
+  tabSpecies =
+      new TabSpecies(model, ui->lblGeometry, ui->voxGeometry, ui->tabSpecies);
   ui->tabSpecies->layout()->addWidget(tabSpecies);
 
-  tabReactions = new TabReactions(model, ui->lblGeometry, ui->tabReactions);
+  tabReactions = new TabReactions(model, ui->lblGeometry, ui->voxGeometry,
+                                  ui->tabReactions);
   ui->tabReactions->layout()->addWidget(tabReactions);
 
   tabFunctions = new TabFunctions(model, ui->tabFunctions);
@@ -146,7 +148,8 @@ void MainWindow::setupTabs() {
   tabEvents = new TabEvents(model, ui->tabEvents);
   ui->tabEvents->layout()->addWidget(tabEvents);
 
-  tabSimulate = new TabSimulate(model, ui->lblGeometry, ui->tabSimulate);
+  tabSimulate =
+      new TabSimulate(model, ui->lblGeometry, ui->voxGeometry, ui->tabSimulate);
   ui->tabSimulate->layout()->addWidget(tabSimulate);
 }
 
@@ -234,6 +237,9 @@ void MainWindow::setupConnections() {
 
   connect(ui->actionGeometry_scale, &QAction::triggered, this,
           &MainWindow::actionGeometry_scale_triggered);
+
+  connect(ui->action3d_render, &QAction::triggered, this,
+          &MainWindow::action3d_render_triggered);
 
   connect(ui->actionInvert_y_axis, &QAction::triggered, this,
           &MainWindow::actionInvert_y_axis_triggered);
@@ -628,6 +634,15 @@ void MainWindow::actionGeometry_scale_triggered(bool checked) {
   auto options{model.getDisplayOptions()};
   options.showGeometryScale = checked;
   model.setDisplayOptions(options);
+}
+
+void MainWindow::action3d_render_triggered(bool checked) {
+  if (checked) {
+    ui->stackGeometry->setCurrentIndex(1);
+    ui->voxGeometry->setImage(ui->lblGeometry->getImage());
+    return;
+  }
+  ui->stackGeometry->setCurrentIndex(0);
 }
 
 void MainWindow::actionInvert_y_axis_triggered(bool checked) {

--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -77,6 +77,7 @@ private:
   void actionGeometry_grid_triggered(bool checked);
   void actionGeometry_scale_triggered(bool checked);
   void actionInvert_y_axis_triggered(bool checked);
+  void action3d_render_triggered(bool checked);
 
   // Advanced menu actions
   void actionSimulation_options_triggered();

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -31,19 +31,22 @@
       </property>
       <widget class="QWidget" name="gridLayoutWidget">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="2">
-         <widget class="QLabel" name="lblGeometryZoomLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="0" column="1">
+         <widget class="QSlider" name="slideGeometryZIndex">
+          <property name="maximum">
+           <number>0</number>
           </property>
-          <property name="text">
-           <string>Zoom:</string>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="invertedControls">
+           <bool>false</bool>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::TicksBothSides</enum>
+          </property>
+          <property name="tickInterval">
+           <number>1</number>
           </property>
          </widget>
         </item>
@@ -61,36 +64,51 @@
          </widget>
         </item>
         <item row="1" column="0" colspan="4">
-         <widget class="QScrollArea" name="scrollGeometry">
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="scrollGeometryContents">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>752</width>
-             <height>572</height>
-            </rect>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <widget class="QStackedWidget" name="stackGeometry">
+          <widget class="QWidget" name="page1">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
-             <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <widget class="QScrollArea" name="scrollGeometry">
+              <property name="widgetResizable">
+               <bool>true</bool>
               </property>
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
+              <widget class="QWidget" name="scrollGeometryContents">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>740</width>
+                 <height>560</height>
+                </rect>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <item>
+                 <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
 &lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
-              </property>
-              <property name="text" stdset="0">
-               <string/>
-              </property>
+                  </property>
+                  <property name="text" stdset="0">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
              </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="page2">
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QVoxelRenderer" name="voxGeometry"/>
             </item>
            </layout>
           </widget>
@@ -109,22 +127,19 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QSlider" name="slideGeometryZIndex">
-          <property name="maximum">
-           <number>0</number>
+        <item row="0" column="2">
+         <widget class="QLabel" name="lblGeometryZoomLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+          <property name="text">
+           <string>Zoom:</string>
           </property>
-          <property name="invertedControls">
-           <bool>false</bool>
-          </property>
-          <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
-          </property>
-          <property name="tickInterval">
-           <number>1</number>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -316,6 +331,7 @@
     <addaction name="actionGeometry_grid"/>
     <addaction name="actionGeometry_scale"/>
     <addaction name="actionInvert_y_axis"/>
+    <addaction name="action3d_render"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuImport"/>
@@ -544,6 +560,9 @@
    <property name="checked">
     <bool>false</bool>
    </property>
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Geometry &amp;grid</string>
    </property>
@@ -585,6 +604,14 @@
     <string>&amp;single-compartment-diffusion-3d</string>
    </property>
   </action>
+  <action name="action3d_render">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>3d render</string>
+   </property>
+  </action>
   <actiongroup name="actionGroupSimType">
    <action name="actionSimTypeDUNE">
     <property name="checkable">
@@ -616,6 +643,11 @@
    <class>QLabelMouseTracker</class>
    <extends>QWidget</extends>
    <header>qlabelmousetracker.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>QVoxelRenderer</class>
+   <extends>QOpenGLWidget</extends>
+   <header>qvoxelrenderer.hpp</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -1,6 +1,7 @@
 #include "tabgeometry.hpp"
 #include "guiutils.hpp"
 #include "qlabelmousetracker.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/logger.hpp"
 #include "sme/mesh.hpp"
 #include "sme/model.hpp"
@@ -11,9 +12,11 @@
 #include <stdexcept>
 
 TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
-                         QStatusBar *statusBar, QWidget *parent)
+                         QVoxelRenderer *voxelRenderer, QStatusBar *statusBar,
+                         QWidget *parent)
     : QWidget(parent), ui{std::make_unique<Ui::TabGeometry>()}, model(m),
-      lblGeometry(mouseTracker), m_statusBar{statusBar} {
+      lblGeometry(mouseTracker), voxGeometry(voxelRenderer),
+      m_statusBar{statusBar} {
   ui->setupUi(this);
   ui->tabCompartmentGeometry->setCurrentIndex(0);
 
@@ -96,6 +99,7 @@ void TabGeometry::loadModelData(const QString &selection) {
     ui->btnChangeCompartment->setEnabled(true);
   }
   lblGeometry->setImage(model.getGeometry().getImages());
+  voxGeometry->setImage(model.getGeometry().getImages());
   lblGeometry->setPhysicalSize(model.getGeometry().getPhysicalSize(),
                                model.getUnits().getLength().name);
   enableTabs();

--- a/gui/tabs/tabgeometry.hpp
+++ b/gui/tabs/tabgeometry.hpp
@@ -9,6 +9,7 @@
 class QLabel;
 class QListWidgetItem;
 class QLabelMouseTracker;
+class QVoxelRenderer;
 class QStatusBar;
 
 namespace sme::model {
@@ -24,6 +25,7 @@ class TabGeometry : public QWidget {
 
 public:
   explicit TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
+                       QVoxelRenderer *voxelRenderer,
                        QStatusBar *statusBar = nullptr,
                        QWidget *parent = nullptr);
   ~TabGeometry() override;
@@ -39,6 +41,7 @@ private:
   std::unique_ptr<Ui::TabGeometry> ui;
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
+  QVoxelRenderer *voxGeometry;
   QStatusBar *m_statusBar{};
   bool waitingForCompartmentChoice{false};
   bool membraneSelected{false};

--- a/gui/tabs/tabgeometry_t.cpp
+++ b/gui/tabs/tabgeometry_t.cpp
@@ -2,6 +2,7 @@
 #include "model_test_utils.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/model.hpp"
 #include "tabgeometry.hpp"
 #include <QDoubleSpinBox>
@@ -17,10 +18,11 @@ TEST_CASE("TabGeometry",
           "[gui/tabs/geometry][gui/tabs][gui][geometry][serial]") {
   sme::model::Model model;
   QLabelMouseTracker mouseTracker;
+  QVoxelRenderer voxelRenderer;
   mouseTracker.show();
   waitFor(&mouseTracker);
   QLabel statusBarMsg;
-  auto tab = TabGeometry(model, &mouseTracker);
+  auto tab = TabGeometry(model, &mouseTracker, &voxelRenderer);
   tab.show();
   waitFor(&tab);
   ModalWidgetTimer mwt;

--- a/gui/tabs/tabreactions.hpp
+++ b/gui/tabs/tabreactions.hpp
@@ -17,6 +17,7 @@ class Model;
 }
 
 class QLabelMouseTracker;
+class QVoxelRenderer;
 class QTreeWidgetItem;
 
 class QDoubleSpinBoxNoScroll : public QDoubleSpinBox {
@@ -34,6 +35,7 @@ class TabReactions : public QWidget {
 
 public:
   explicit TabReactions(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
+                        QVoxelRenderer *voxelRenderer,
                         QWidget *parent = nullptr);
   ~TabReactions() override;
   void loadModelData(const QString &selection = {});
@@ -42,6 +44,7 @@ private:
   std::unique_ptr<Ui::TabReactions> ui;
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
+  QVoxelRenderer *voxGeometry;
   QString currentReacId{};
   QString invalidLocationLabel{"Invalid Location"};
   std::vector<sme::model::ReactionLocation> reactionLocations;

--- a/gui/tabs/tabreactions_t.cpp
+++ b/gui/tabs/tabreactions_t.cpp
@@ -3,6 +3,7 @@
 #include "qlabelmousetracker.hpp"
 #include "qplaintextmathedit.hpp"
 #include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/model.hpp"
 #include "tabreactions.hpp"
 #include <QComboBox>
@@ -17,7 +18,8 @@ using Catch::Matchers::ContainsSubstring;
 TEST_CASE("TabReactions", "[gui/tabs/reactions][gui/tabs][gui][reactions]") {
   sme::model::Model model;
   QLabelMouseTracker mouseTracker;
-  TabReactions tab(model, &mouseTracker);
+  QVoxelRenderer voxelRenderer;
+  TabReactions tab(model, &mouseTracker, &voxelRenderer);
   tab.show();
   waitFor(&tab);
   ModalWidgetTimer mwt;

--- a/gui/tabs/tabsimulate.cpp
+++ b/gui/tabs/tabsimulate.cpp
@@ -4,6 +4,7 @@
 #include "dialogimageslice.hpp"
 #include "guiutils.hpp"
 #include "qlabelmousetracker.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/logger.hpp"
 #include "sme/mesh.hpp"
 #include "sme/model.hpp"
@@ -17,9 +18,9 @@
 #include <future>
 
 TabSimulate::TabSimulate(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
-                         QWidget *parent)
+                         QVoxelRenderer *voxelRenderer, QWidget *parent)
     : QWidget(parent), ui{std::make_unique<Ui::TabSimulate>()}, model{m},
-      lblGeometry(mouseTracker),
+      lblGeometry{mouseTracker}, voxGeometry{voxelRenderer},
       plt{std::make_unique<PlotWrapper>("Average Concentration", this)} {
   ui->setupUi(this);
   ui->gridSimulate->addWidget(plt->plot, 1, 0, 1, 7);
@@ -342,6 +343,7 @@ void TabSimulate::updatePlotAndImages() {
       }
     }
     lblGeometry->setImage(images.back());
+    voxGeometry->setImage(images.back());
     plt->plot->rescaleAxes(true);
     plt->plot->replot(QCustomPlot::RefreshPriority::rpQueuedReplot);
   }
@@ -444,6 +446,7 @@ void TabSimulate::hslideTime_valueChanged(int value) {
     return;
   }
   lblGeometry->setImage(images[value]);
+  voxGeometry->setImage(images[value]);
   plt->setVerticalLine(time[value]);
   plt->plot->replot();
   ui->lblCurrentTime->setText(

--- a/gui/tabs/tabsimulate.hpp
+++ b/gui/tabs/tabsimulate.hpp
@@ -17,6 +17,7 @@ class QCPAbstractPlottable;
 class QCPItemStraightLine;
 class QCPTextElement;
 class QLabelMouseTracker;
+class QVoxelRenderer;
 namespace sme::model {
 class Model;
 } // namespace sme::model
@@ -27,6 +28,7 @@ class TabSimulate : public QWidget {
 
 public:
   explicit TabSimulate(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
+                       QVoxelRenderer *voxelRenderer,
                        QWidget *parent = nullptr);
   ~TabSimulate() override;
   void loadModelData();
@@ -41,6 +43,7 @@ private:
   std::unique_ptr<Ui::TabSimulate> ui;
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
+  QVoxelRenderer *voxGeometry;
   std::unique_ptr<PlotWrapper> plt;
   std::unique_ptr<sme::simulate::Simulation> sim;
   sme::model::DisplayOptions displayOptions;

--- a/gui/tabs/tabsimulate_t.cpp
+++ b/gui/tabs/tabsimulate_t.cpp
@@ -2,6 +2,7 @@
 #include "model_test_utils.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/model.hpp"
 #include "tabsimulate.hpp"
 #include <QLineEdit>
@@ -12,6 +13,7 @@ using namespace sme::test;
 
 TEST_CASE("TabSimulate", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   QLabelMouseTracker mouseTracker;
+  QVoxelRenderer voxelRenderer;
   SECTION("Many actions") {
     // load model & do initial simulation
     auto model{getExampleModel(Mod::ABtoC)};
@@ -19,7 +21,7 @@ TEST_CASE("TabSimulate", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
     sme::simulate::Simulation sim(model);
     sim.doMultipleTimesteps({{2, 0.01}, {1, 0.02}});
 
-    TabSimulate tab(model, &mouseTracker);
+    TabSimulate tab(model, &mouseTracker, &voxelRenderer);
     tab.show();
     waitFor(&tab);
     ModalWidgetTimer mwt;

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -3,6 +3,7 @@
 #include "dialogconcentrationimage.hpp"
 #include "guiutils.hpp"
 #include "qlabelmousetracker.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/logger.hpp"
 #include "sme/model.hpp"
 #include "ui_tabspecies.h"
@@ -11,9 +12,9 @@
 #include <QMessageBox>
 
 TabSpecies::TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
-                       QWidget *parent)
+                       QVoxelRenderer *voxelRenderer, QWidget *parent)
     : QWidget(parent), ui{std::make_unique<Ui::TabSpecies>()}, model(m),
-      lblGeometry(mouseTracker) {
+      lblGeometry(mouseTracker), voxGeometry(voxelRenderer) {
   ui->setupUi(this);
   connect(ui->listSpecies, &QTreeWidget::currentItemChanged, this,
           &TabSpecies::listSpecies_currentItemChanged);
@@ -131,6 +132,8 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
   ui->txtInitialConcentration->setText("");
   ui->lblInitialConcentrationUnits->setText("");
   lblGeometry->setImage(
+      model.getSpecies().getConcentrationImages(currentSpeciesId));
+  voxGeometry->setImage(
       model.getSpecies().getConcentrationImages(currentSpeciesId));
   auto concentrationType{
       model.getSpecies().getInitialConcentrationType(currentSpeciesId)};
@@ -279,6 +282,8 @@ void TabSpecies::btnEditAnalyticConcentration_clicked() {
     model.getSpecies().setAnalyticConcentration(currentSpeciesId, expr.c_str());
     lblGeometry->setImage(
         model.getSpecies().getConcentrationImages(currentSpeciesId));
+    voxGeometry->setImage(
+        model.getSpecies().getConcentrationImages(currentSpeciesId));
   }
 }
 
@@ -294,6 +299,8 @@ void TabSpecies::btnEditImageConcentration_clicked() {
     model.getSpecies().setSampledFieldConcentration(
         currentSpeciesId, dialog.getConcentrationArray());
     lblGeometry->setImage(
+        model.getSpecies().getConcentrationImages(currentSpeciesId));
+    voxGeometry->setImage(
         model.getSpecies().getConcentrationImages(currentSpeciesId));
   }
 }

--- a/gui/tabs/tabspecies.hpp
+++ b/gui/tabs/tabspecies.hpp
@@ -16,13 +16,14 @@ class Model;
 } // namespace sme::model
 
 class QLabelMouseTracker;
+class QVoxelRenderer;
 
 class TabSpecies : public QWidget {
   Q_OBJECT
 
 public:
   explicit TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
-                      QWidget *parent = nullptr);
+                      QVoxelRenderer *voxelRenderer, QWidget *parent = nullptr);
   ~TabSpecies() override;
   void loadModelData(const QString &selection = {});
 
@@ -30,6 +31,7 @@ private:
   std::unique_ptr<Ui::TabSpecies> ui;
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
+  QVoxelRenderer *voxGeometry;
   QPixmap lblSpeciesColourPixmap = QPixmap(1, 1);
   QString currentSpeciesId;
   void enableWidgets(bool enable);

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -2,6 +2,7 @@
 #include "model_test_utils.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
 #include "sme/model.hpp"
 #include "tabspecies.hpp"
 #include <QCheckBox>
@@ -16,7 +17,8 @@ using namespace sme::test;
 TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
   sme::model::Model model;
   QLabelMouseTracker mouseTracker;
-  TabSpecies tab(model, &mouseTracker);
+  QVoxelRenderer voxelRenderer;
+  TabSpecies tab(model, &mouseTracker, &voxelRenderer);
   tab.show();
   waitFor(&tab);
 

--- a/gui/widgets/CMakeLists.txt
+++ b/gui/widgets/CMakeLists.txt
@@ -4,7 +4,8 @@ target_sources(
           qlabelslice.cpp
           qlabelmousetracker.cpp
           qopenglmousetracker.cpp
-          qplaintextmathedit.cpp)
+          qplaintextmathedit.cpp
+          qvoxelrenderer.cpp)
 target_include_directories(gui PUBLIC .)
 
 if(BUILD_TESTING)
@@ -14,5 +15,6 @@ if(BUILD_TESTING)
            qlabelslice_t.cpp
            qlabelmousetracker_t.cpp
            qopenglmousetracker_t.cpp
-           qplaintextmathedit_t.cpp)
+           qplaintextmathedit_t.cpp
+           qvoxelrenderer_t.cpp)
 endif()

--- a/gui/widgets/qvoxelrenderer.cpp
+++ b/gui/widgets/qvoxelrenderer.cpp
@@ -1,0 +1,113 @@
+#include "qvoxelrenderer.hpp"
+#include "sme/logger.hpp"
+#include <QPainter>
+#include <vtkCamera.h>
+#include <vtkPointData.h>
+
+QVoxelRenderer::QVoxelRenderer(QWidget *parent)
+    : QVTKOpenGLNativeWidget(parent) {
+  setRenderWindow(renderWindow);
+  renderWindow->AddRenderer(renderer);
+  // piecewise opacity function, converts 0-255 input value to 0-1 opacity float
+  opacityTransferFunction->AddPoint(0, 0.0);
+  opacityTransferFunction->AddPoint(255, 0.8);
+  volumeProperty->SetScalarOpacity(opacityTransferFunction);
+  volumeProperty->ShadeOn();
+  // directly use first 3 components of data as RGB values
+  volumeProperty->IndependentComponentsOff();
+  // don't interpolate between voxels
+  volumeProperty->SetInterpolationTypeToNearest();
+  volume->SetMapper(volumeMapper);
+  volume->SetProperty(volumeProperty);
+  volumeMapper->SetInputData(imageData);
+  axesWidget->SetOrientationMarker(axesActor);
+  axesWidget->SetInteractor(renderWindow->GetInteractor());
+  // set relative size of axes widget
+  axesWidget->SetViewport(0.0, 0.0, 0.3, 0.3);
+  axesWidget->SetEnabled(1);
+  axesWidget->InteractiveOn();
+  // inherit widget background color
+  [this]() {
+    float r{0};
+    float g{0};
+    float b{0};
+    palette().color(QWidget::backgroundRole()).getRgbF(&r, &g, &b);
+    renderer->SetBackground(r, g, b);
+  }();
+  renderer->AddVolume(volume);
+  renderer->GetActiveCamera()->Azimuth(45);
+  renderer->GetActiveCamera()->Elevation(30);
+}
+
+static vtkNew<vtkUnsignedCharArray>
+imageStackToVtkArray(const sme::common::ImageStack &img,
+                     std::array<int, 3> &dims) {
+  vtkNew<vtkUnsignedCharArray> array;
+  array->SetNumberOfComponents(4);
+  dims[0] = img.volume().width();
+  dims[1] = img.volume().height();
+  dims[2] = static_cast<int>(img.volume().depth());
+  SPDLOG_TRACE("{} x {} x {} ImageStack", dims[0], dims[1], dims[2]);
+  auto nVoxels = static_cast<vtkIdType>(img.volume().nVoxels());
+  if (dims[2] == 1) {
+    SPDLOG_TRACE("  - single z-slice -> duplicating");
+    // vtk needs at least two values in each dimension to render,
+    // so if we only have a single z-slice in the stack we duplicate it to give
+    // two identical z-slices for display purposes.
+    dims[2] = 2;
+    nVoxels *= 2;
+  }
+  SPDLOG_TRACE("  - constructing array with {} tuples of 4 x uchar", nVoxels);
+  array->SetNumberOfTuples(nVoxels);
+  int i = 0;
+  for (std::size_t z = 0; z < static_cast<std::size_t>(dims[2]); ++z) {
+    auto z_index = std::min(z, img.volume().depth() - 1);
+    for (int y = 0; y < dims[1]; ++y) {
+      for (int x = 0; x < dims[0]; ++x) {
+        auto rgb = img[z_index].pixel(x, y);
+        // red 0-255
+        array->SetValue(i, static_cast<unsigned char>(qRed(rgb)));
+        ++i;
+        // green 0-255
+        array->SetValue(i, static_cast<unsigned char>(qGreen(rgb)));
+        ++i;
+        // blue 0-255
+        array->SetValue(i, static_cast<unsigned char>(qBlue(rgb)));
+        // use average of rgb values for input to opacity function
+        ++i;
+        int rgb_av = qRed(rgb) / 3 + qGreen(rgb) / 3 + qBlue(rgb) / 3;
+        array->SetValue(i, static_cast<unsigned char>(rgb_av));
+        ++i;
+      }
+    }
+  }
+  SPDLOG_TRACE("  - assigned {} of {} values", i, array->GetNumberOfValues());
+  return array;
+}
+
+void QVoxelRenderer::setImage(const sme::common::ImageStack &img) {
+  if (!isVisible()) {
+    return;
+  }
+  std::array<int, 3> dims{};
+  imageDataArray = imageStackToVtkArray(img, dims);
+  imageData->SetDimensions(dims.data());
+  imageData->SetSpacing(1.0, 1.0, 1.0);
+  imageData->SetOrigin(0.0, 0.0, 0.0);
+  imageData->GetPointData()->SetScalars(imageDataArray);
+  renderer->ResetCameraClippingRange();
+  renderer->ResetCamera();
+  renderWindow->Render();
+}
+
+void QVoxelRenderer::setPhysicalSize(const sme::common::VolumeF &size,
+                                     const QString &units) {
+  lengthUnits = units;
+  std::array<int, 3> dims{};
+  imageData->GetDimensions(dims.data());
+  imageData->SetSpacing(size.width() / dims[0], size.height() / dims[1],
+                        size.depth() / dims[2]);
+  renderer->ResetCameraClippingRange();
+  renderer->ResetCamera();
+  renderWindow->Render();
+}

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "sme/image_stack.hpp"
+#include <QLabel>
+#include <QMouseEvent>
+#include <QSlider>
+#include <QVTKOpenGLNativeWidget.h>
+#include <vtkAxesActor.h>
+#include <vtkGPUVolumeRayCastMapper.h>
+#include <vtkGenericOpenGLRenderWindow.h>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkOrientationMarkerWidget.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkRenderer.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkVolume.h>
+#include <vtkVolumeProperty.h>
+
+class QVoxelRenderer : public QVTKOpenGLNativeWidget {
+  Q_OBJECT
+public:
+  explicit QVoxelRenderer(QWidget *parent = nullptr);
+  void setImage(const sme::common::ImageStack &img);
+  void setPhysicalSize(const sme::common::VolumeF &size, const QString &units);
+
+private:
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  vtkNew<vtkRenderer> renderer;
+  vtkNew<vtkAxesActor> axesActor;
+  vtkNew<vtkOrientationMarkerWidget> axesWidget;
+  vtkNew<vtkVolume> volume;
+  vtkNew<vtkVolumeProperty> volumeProperty;
+  vtkNew<vtkGPUVolumeRayCastMapper> volumeMapper;
+  vtkNew<vtkPiecewiseFunction> opacityTransferFunction;
+  vtkNew<vtkImageData> imageData;
+  vtkNew<vtkUnsignedCharArray> imageDataArray;
+  QString lengthUnits{};
+};

--- a/gui/widgets/qvoxelrenderer_t.cpp
+++ b/gui/widgets/qvoxelrenderer_t.cpp
@@ -1,0 +1,66 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
+#include "sme/image_stack.hpp"
+
+using namespace sme::test;
+
+// set to e.g. 10000 to interactively inspect the rendering of each ImageStack
+constexpr int delay_ms{0};
+
+TEST_CASE("QVoxelRenderer",
+          "[qvoxelrenderer][gui/widgets/qvoxelrenderer][gui/widgets][gui]") {
+  QVoxelRenderer voxelRenderer;
+  voxelRenderer.show();
+  auto gray = qRgb(50, 50, 50);
+  auto red = qRgb(255, 0, 0);
+  auto green = qRgb(0, 255, 0);
+  auto blue = qRgb(0, 0, 255);
+  SECTION("20x47x10 geometry image with colors for each face") {
+    sme::common::Volume volume{20, 47, 10};
+    sme::common::ImageStack imageStack(volume, QImage::Format_RGB32);
+    REQUIRE(imageStack.volume() == volume);
+    wait(delay_ms);
+    // fill whole block with gray
+    imageStack.fill(gray);
+    voxelRenderer.setImage(imageStack);
+    wait(delay_ms);
+    // blue z=0 face
+    imageStack[0].fill(blue);
+    imageStack[1].fill(blue);
+    voxelRenderer.setImage(imageStack);
+    wait(delay_ms);
+    // green y=0 face
+    for (std::size_t z = 0; z < volume.depth(); ++z) {
+      for (int x = 0; x < volume.width(); ++x) {
+        imageStack[z].setPixel(x, 0, green);
+        imageStack[z].setPixel(x, 1, green);
+      }
+    }
+    voxelRenderer.setImage(imageStack);
+    wait(delay_ms);
+    // red x=0 face
+    for (std::size_t z = 0; z < volume.depth(); ++z) {
+      for (int y = 0; y < volume.height(); ++y) {
+        imageStack[z].setPixel(0, y, red);
+        imageStack[z].setPixel(1, y, red);
+      }
+    }
+    voxelRenderer.setImage(imageStack);
+    wait(delay_ms);
+    // set physical size that maintains existing cubic voxels
+    voxelRenderer.setPhysicalSize({20.0, 47.0, 10.0}, "units");
+    wait(delay_ms);
+    // set physical size that makes z-slices 5x thicker
+    voxelRenderer.setPhysicalSize({20.0, 47.0, 50.0}, "units");
+    wait(delay_ms);
+  }
+  SECTION("100x100x1 geometry image") {
+    auto model = sme::test::getExampleModel(Mod::VerySimpleModel);
+    auto imageStack = model.getGeometry().getImages();
+    REQUIRE(imageStack.volume() == sme::common::Volume{100, 100, 1});
+    voxelRenderer.setImage(imageStack);
+    wait(delay_ms);
+  }
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,10 +1,9 @@
 #include "catch_wrapper.hpp"
 #include "sme/logger.hpp"
 #include <QApplication>
+#include <QSurfaceFormat>
 #include <catch2/catch_session.hpp>
 #include <locale>
-
-#include <QSurfaceFormat>
 
 int main(int argc, char *argv[]) {
   Catch::StringMaker<double>::precision = 25;
@@ -12,7 +11,8 @@ int main(int argc, char *argv[]) {
 
 #ifdef SME_ENABLE_GUI_TESTS
   QSurfaceFormat format;
-  // This comment is a reminder for whenever we can test using a Mac machine.
+  // This comment is a reminder for whenever we can test using a Mac
+  // machine.
   //  format.setProfile(QSurfaceFormat::CoreProfile);
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
@@ -25,7 +25,8 @@ int main(int argc, char *argv[]) {
 
   format.setOption(QSurfaceFormat::DebugContext);
 
-  // This comment is a reminder for whenever we can test using a Mac machine.
+  // This comment is a reminder for whenever we can test using a Mac
+  // machine.
   //   format.setMajorVersion(4);
   //   format.setMinorVersion(1);
 

--- a/test/test_utils/catch_wrapper.cpp
+++ b/test/test_utils/catch_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "catch_wrapper.hpp"
 
+#include "sme/voxel.hpp"
 #include <QPoint>
 #include <QPointF>
 #include <QSize>
@@ -30,5 +31,10 @@ std::ostream &operator<<(std::ostream &os, QSizeF const &value) {
 std::ostream &operator<<(std::ostream &os,
                          std::pair<QPoint, QPoint> const &value) {
   os << '{' << value.first << ',' << value.second << '}';
+  return os;
+}
+std::ostream &operator<<(std::ostream &os, sme::common::Volume const &value) {
+  os << '{' << value.width() << " x " << value.height() << " x "
+     << value.depth() << '}';
   return os;
 }

--- a/test/test_utils/catch_wrapper.hpp
+++ b/test/test_utils/catch_wrapper.hpp
@@ -12,6 +12,10 @@ class QPointF;
 class QSize;
 class QSizeF;
 
+namespace sme::common {
+struct Volume;
+}
+
 std::ostream &operator<<(std::ostream &os, QString const &value);
 std::ostream &operator<<(std::ostream &os, QPoint const &value);
 std::ostream &operator<<(std::ostream &os, QPointF const &value);
@@ -19,6 +23,7 @@ std::ostream &operator<<(std::ostream &os, QSize const &value);
 std::ostream &operator<<(std::ostream &os, QSizeF const &value);
 std::ostream &operator<<(std::ostream &os,
                          std::pair<QPoint, QPoint> const &value);
+std::ostream &operator<<(std::ostream &os, sme::common::Volume const &value);
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
- add `VoxelRenderer` widget
  - 3d volume rendered analog of `QLabelMouseTracker`
  - inherits from `QVTKOpenGLNativeWidget`
    - which itself inherits from `QOpenGLWidget`
  - built-in user interactions to rotate & zoom camera
  - axes widget for orientation
  - `setImage()`
    - converts ImageStack to vtk data type with rgb + opacity values for each voxel, then render
  - `setPhysicalSize()` - sets the voxel size based on physical size and number of voxels, so that asymmetric voxels are rendered correctly
- MainWindow changes
  - add `View->3d render` menu option to use `VoxelRenderer` instead of `QLabelMouseTracker`
  - use `QStackWidget` to swap between `lblGeometry` and `voxGeometry` widgets for this
- Note `vtk_module_autoinit` in CMakeLists.txt is required for vtk to find its implementations at runtime
  - this needs to be done for any static lib or binary that (directly) uses VTK
- add VTK to dependencies
- sme_deps -> 2023.12.12 for VTK libraries
- resolves #923