### PR TITLE
Update dependencies and add `linearSolver` to `DuneOptions`

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
           key: ccache-${{ github.job }}-${{ matrix.script }}-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       if: startsWith(github.event.ref, 'refs/tags/') == false
       run: ./ci/set-latest-version.sh ${GITHUB_SHA}
     - name: Cache ccache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
@@ -64,7 +64,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
@@ -97,9 +97,9 @@ jobs:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache make
+          install: mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ccache make
       - name: Install Mesa 3D to get OpenGL support on Windows without a GPU
         uses: ssciwr/setup-mesa-dist-win@v1
         with:
@@ -108,7 +108,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: C:\Users\runneradmin\AppData\Local\ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux_x86_64:2023.11.21
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux_x86_64:2024.01.23
       CIBW_SKIP: '*-manylinux_i686 *-musllinux* pp*-*'
       CIBW_ENVIRONMENT: 'CMAKE_ARGS="-DSME_BUILD_CORE=off -DCMAKE_PREFIX_PATH=/opt/smelibs;/opt/smelibs/lib64/cmake"'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'
@@ -37,7 +37,7 @@ jobs:
       if: startsWith(github.event.ref, 'refs/tags/') == false
       run: ./ci/set-latest-version.sh ${GITHUB_SHA}
     - name: Cache ccache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/ccache
         key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
@@ -75,7 +75,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
@@ -108,14 +108,14 @@ jobs:
           submodules: 'true'
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache make
+          install: mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ccache make
       - name: Set "latest" version number unless commit is tagged
         if: startsWith(github.event.ref, 'refs/tags/') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: C:\Users\runneradmin\AppData\Local\ccache
           key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Spatial Model Editor makes use of the following open source libraries:
 
 - [VTK](https://vtk.org/) - license: [BSD](https://gitlab.kitware.com/vtk/vtk/-/blob/master/Copyright.txt)
 
+- [scotch](https://gitlab.inria.fr/scotch/scotch) - license: [CeCILL-C](https://gitlab.inria.fr/scotch/scotch/-/blob/master/doc/CeCILL-C_V1-en.txt?ref_type=heads)
+
 ## Licensing Note
 
 The source code in this repository is released under the MIT license, which is a permissive

--- a/ci/asan.sh
+++ b/ci/asan.sh
@@ -22,7 +22,7 @@ cmake .. \
     -DSME_LOG_LEVEL=TRACE
 # ignore any asan errors while building / collecting tests
 export ASAN_OPTIONS="halt_on_error=0"
-time make tests -j2
+time make tests -j4
 ccache --show-stats
 
 # various external libs "leak" memory, don't fail the build because of this

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -25,7 +25,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
     -DCMAKE_CXX_FLAGS="--coverage -D_GLIBCXX_USE_TBB_PAR_BACKEND=0"
-make -j2 VERBOSE=1
+make -j4 VERBOSE=1
 ccache --show-stats
 
 # start a window manager so the Qt GUI tests can have their focus set

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2023.12.12"
+SME_DEPS_VERSION="2024.01.23"
 OS=$1
 
 set -e -x

--- a/ci/linux-gui.sh
+++ b/ci/linux-gui.sh
@@ -32,7 +32,7 @@ cmake .. \
     -DSME_LOG_LEVEL=OFF \
     -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_TBB_PAR_BACKEND=0" \
     -DOpenGL_GL_PREFERENCE=LEGACY
-make -j2 VERBOSE=1
+make -j4 VERBOSE=1
 ccache --show-stats
 
 # start a window manager so the Qt GUI tests can have their focus set

--- a/ci/linux-install.sh
+++ b/ci/linux-install.sh
@@ -59,6 +59,10 @@ wget https://anaconda.org/conda-forge/ccache/4.3/download/linux-64/ccache-4.3-ha
 tar -xf ccache-4.3-haef5404_1.tar.bz2
 sudo cp bin/ccache /usr/bin/ccache
 
+# disable system blas/lapack to avoid them getting linked by accident
+sudo rm /usr/lib/x86_64-linux-gnu/libblas*
+sudo rm /usr/lib/x86_64-linux-gnu/liblapack*
+
 # check versions
 cmake --version
 g++ --version

--- a/ci/linux-wheels.sh
+++ b/ci/linux-wheels.sh
@@ -19,7 +19,7 @@ cmake .. \
     -DCMAKE_PREFIX_PATH="/opt/smelibs;/opt/smelibs/lib64/cmake" \
     -DSME_LOG_LEVEL=OFF \
     -DSME_BUILD_CORE=on
-make -j2 core tests
-ctest -j2 || ctest --rerun-failed --output-on-failure
+make -j4 core tests
+ctest -j4 || ctest --rerun-failed --output-on-failure
 make install
 cd ..

--- a/ci/sonar.sh
+++ b/ci/sonar.sh
@@ -29,7 +29,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
     -DCMAKE_CXX_FLAGS="--coverage -D_GLIBCXX_USE_TBB_PAR_BACKEND=0"
-build-wrapper-linux-x86-64 --out-dir bw-output make -j2
+build-wrapper-linux-x86-64 --out-dir bw-output make -j4
 ccache --show-stats
 
 # start a window manager so the Qt GUI tests can have their focus set

--- a/ci/tsan.sh
+++ b/ci/tsan.sh
@@ -25,7 +25,7 @@ cmake .. \
     -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
     -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wshadow -Wunused -Wconversion -Wsign-conversion -Wcast-align -fsanitize=thread -fno-omit-frame-pointer -D_GLIBCXX_USE_TBB_PAR_BACKEND=0"
 
-time make tests -j2
+time make tests -j4
 ccache --show-stats
 
 # start a window manager so the Qt GUI tests can have their focus set

--- a/ci/ubsan.sh
+++ b/ci/ubsan.sh
@@ -24,7 +24,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer" \
     -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wshadow -Wunused -Wconversion -Wsign-conversion -Wcast-align -fsanitize=undefined -fno-omit-frame-pointer -D_GLIBCXX_USE_TBB_PAR_BACKEND=0"
-time make tests -j2
+time make tests -j4
 ccache --show-stats
 
 # start a window manager so the Qt GUI tests can have their focus set

--- a/ci/windows-gui.sh
+++ b/ci/windows-gui.sh
@@ -44,7 +44,7 @@ cmake .. \
     -DFREETYPE_LIBRARY_RELEASE=/c/smelibs/lib/libQt6BundledFreetype.a \
     -DFREETYPE_INCLUDE_DIR_freetype2=/c/smelibs/include/QtFreetype \
     -DFREETYPE_INCLUDE_DIR_ft2build=/c/smelibs/include/QtFreetype
-make -j2 VERBOSE=1
+make -j4 VERBOSE=1
 
 ccache -s -v
 

--- a/ci/windows-wheels.sh
+++ b/ci/windows-wheels.sh
@@ -16,8 +16,6 @@ export SME_EXTRA_EXE_LIBS="-static;-static-libgcc;-static-libstdc++"
 # https://codereview.qt-project.org/c/qt/qtbase/+/350443
 export SME_QT_DISABLE_UNICODE=TRUE
 export SME_EXTRA_CORE_DEFS="_hypot=hypot;MS_WIN64"
-# disable this for now due to "terminate called after throwing an instance of 'core::Error'"
-#export CCACHE_NOHASHDIR="true"
 
 export CMAKE_ARGS="-DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DSME_BUILD_CORE=off -DSME_QT_DISABLE_UNICODE=$SME_QT_DISABLE_UNICODE -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER"
 pwd
@@ -28,7 +26,6 @@ cmake --version
 which python
 python --version
 
-# disable this for now due to "terminate called after throwing an instance of 'core::Error'"
 ccache -s
 
 # Remove CLI11 symlink to itself (causes recursive copying of folders on windows)
@@ -52,13 +49,12 @@ cmake .. \
     -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
     -DSME_LOG_LEVEL=OFF \
     -DSME_BUILD_CORE=on
-make -j2 core tests
-ctest -j2 --rerun-failed --output-on-failure
+make -j4 core tests
+ctest -j4 --rerun-failed --output-on-failure
 make install
 cd ..
 
 python -m pip install cibuildwheel==$CIBUILDWHEEL_VERSION
 python -m cibuildwheel --output-dir wheelhouse
 
-# disable this for now due to "terminate called after throwing an instance of 'core::Error'"
 ccache -s

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -122,6 +122,12 @@ target_compile_definitions(
   core PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${SME_LOG_LEVEL})
 
 find_package(dune-common REQUIRED)
+find_package(SCOTCH)
+target_link_libraries(
+  Dune::Common
+  INTERFACE SCOTCH::scotch
+            SCOTCH::scotcherr
+            SCOTCH::scotchmetisv3)
 find_package(dune-geometry REQUIRED)
 find_package(dune-uggrid REQUIRED)
 find_package(dune-grid REQUIRED)

--- a/core/resources/models/ABtoC.xml
+++ b/core/resources/models/ABtoC.xml
@@ -18,7 +18,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/brusselator-model.xml
+++ b/core/resources/models/brusselator-model.xml
@@ -18,7 +18,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/gray-scott.xml
+++ b/core/resources/models/gray-scott.xml
@@ -22,7 +22,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/liver-cells.xml
+++ b/core/resources/models/liver-cells.xml
@@ -18,7 +18,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/liver-simplified.xml
+++ b/core/resources/models/liver-simplified.xml
@@ -32,7 +32,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/single-compartment-diffusion-3d.xml
+++ b/core/resources/models/single-compartment-diffusion-3d.xml
@@ -13,7 +13,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/single-compartment-diffusion.xml
+++ b/core/resources/models/single-compartment-diffusion.xml
@@ -18,7 +18,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/resources/models/very-simple-model.xml
+++ b/core/resources/models/very-simple-model.xml
@@ -18,7 +18,7 @@
               <dune>
                 <cereal_class_version>0</cereal_class_version>
                 <discretization>0</discretization>
-                <integrator>alexander_2</integrator>
+                <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
                 <minDt>1e-10</minDt>
                 <maxDt>10000</maxDt>

--- a/core/simulate/include/sme/simulate_options.hpp
+++ b/core/simulate/include/sme/simulate_options.hpp
@@ -33,6 +33,7 @@ struct DuneOptions {
   bool writeVTKfiles{false};
   double newtonRelErr{1e-8};
   double newtonAbsErr{1e-12};
+  std::string linearSolver{"CG"};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -41,6 +42,12 @@ struct DuneOptions {
          CEREAL_NVP(minDt), CEREAL_NVP(maxDt), CEREAL_NVP(increase),
          CEREAL_NVP(decrease), CEREAL_NVP(writeVTKfiles),
          CEREAL_NVP(newtonRelErr), CEREAL_NVP(newtonAbsErr));
+    } else if (version == 1) {
+      ar(CEREAL_NVP(discretization), CEREAL_NVP(integrator), CEREAL_NVP(dt),
+         CEREAL_NVP(minDt), CEREAL_NVP(maxDt), CEREAL_NVP(increase),
+         CEREAL_NVP(decrease), CEREAL_NVP(writeVTKfiles),
+         CEREAL_NVP(newtonRelErr), CEREAL_NVP(newtonAbsErr),
+         CEREAL_NVP(linearSolver));
     }
   }
 };
@@ -108,7 +115,7 @@ bool operator==(const AvgMinMax &lhs, const AvgMinMax &rhs);
 } // namespace sme::simulate
 
 CEREAL_CLASS_VERSION(sme::simulate::Options, 0);
-CEREAL_CLASS_VERSION(sme::simulate::DuneOptions, 0);
+CEREAL_CLASS_VERSION(sme::simulate::DuneOptions, 1);
 CEREAL_CLASS_VERSION(sme::simulate::PixelIntegratorError, 0);
 CEREAL_CLASS_VERSION(sme::simulate::PixelOptions, 0);
 CEREAL_CLASS_VERSION(sme::simulate::AvgMinMax, 0);

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -46,7 +46,7 @@ static void addTimeStepping(IniFile &ini,
   ini.addValue("time_step_min", duneOptions.minDt, doublePrecision);
   ini.addValue("time_step_max", duneOptions.maxDt, doublePrecision);
   ini.addSection("model", "time_step_operator", "linear_solver");
-  ini.addValue("type", "CG");
+  ini.addValue("type", duneOptions.linearSolver.c_str());
   ini.addSection("model", "time_step_operator", "nonlinear_solver");
   ini.addValue("type", duneOptions.integrator.c_str());
   ini.addValue("convergence_condition.relative_tolerance",

--- a/core/simulate/src/dunesim.cpp
+++ b/core/simulate/src/dunesim.cpp
@@ -220,6 +220,7 @@ std::size_t DuneSim::run(double time, double timeout_ms,
   } catch (const Dune::Exception &e) {
     currentErrorMessage = e.what();
     SPDLOG_ERROR("{}", currentErrorMessage);
+    return 0;
   }
   if (stopRunningCallback && stopRunningCallback()) {
     SPDLOG_DEBUG("Simulation cancelled: requesting stop");

--- a/docs/reference/dune.rst
+++ b/docs/reference/dune.rst
@@ -48,5 +48,8 @@ The default settings should work well in most cases, but if desired they can be 
 * Newton absolute error
    * the absolute error where Newton iteration is considered to have converged
    * currently this may need to be altered depending on the units and geometry size (see `#315 <https://github.com/spatial-model-editor/spatial-model-editor/issues/315#issuecomment-760085781>`_)
+* Linear solver
+   * a variety of iterative and direct solvers are available
+   * the default is CG (Conjugate Gradient)
 
 For more information see the `dune-copasi documentation <https://dune-copasi.netlify.app/>`_.

--- a/gui/dialogs/dialogabout.cpp
+++ b/gui/dialogs/dialogabout.cpp
@@ -18,6 +18,7 @@
 #include <pagmo/config.hpp>
 #include <qcustomplot.h>
 #include <sbml/common/libsbml-version.h>
+#include <scotch.h>
 #include <spdlog/version.h>
 #include <symengine/symengine_config.h>
 #include <tiffvers.h>
@@ -103,7 +104,8 @@ DialogAbout::DialogAbout(QWidget *parent)
   libraries.append(dep("libCombine", "https://github.com/sbmlteam/libCombine",
                        libcombine::getLibCombineDottedVersion()));
   libraries.append(dep("VTK", "https://vtk.org/", vtkVersion::GetVTKVersion()));
-
+  libraries.append(dep("scotch", "https://gitlab.inria.fr/scotch/scotch",
+                       SCOTCH_VERSION, SCOTCH_RELEASE, SCOTCH_PATCHLEVEL));
   libraries.append("</ul>");
   ui->lblLibraries->setText(libraries);
 }

--- a/gui/dialogs/dialogimage.cpp
+++ b/gui/dialogs/dialogimage.cpp
@@ -11,8 +11,12 @@ DialogImage::DialogImage(QWidget *parent, const QString &title,
 
   setWindowTitle(title);
   ui->lblMessage->setText(message);
-  // todo: fix this to not hard code z=0 slice
-  ui->lblImage->setPixmap(QPixmap::fromImage(image[0]));
+  if (image.empty()) {
+    ui->lblImage->setVisible(false);
+  } else {
+    // todo: fix this to not hard code z=0 slice
+    ui->lblImage->setPixmap(QPixmap::fromImage(image[0]));
+  }
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
           &DialogImage::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this,

--- a/gui/dialogs/dialogimage_t.cpp
+++ b/gui/dialogs/dialogimage_t.cpp
@@ -13,12 +13,24 @@ struct DialogImageWidgets {
 };
 
 TEST_CASE("DialogImage", "[gui/dialogs/image][gui/dialogs][gui][image]") {
-  sme::common::ImageStack imageStack{{QImage(":/icon/icon128.png")}};
-  QString title("my title");
-  QString message("see image below:");
-  DialogImage dia(nullptr, title, message, imageStack);
-  dia.show();
-  DialogImageWidgets widgets(&dia);
-  REQUIRE(dia.windowTitle() == title);
-  REQUIRE(widgets.lblMessage->text() == message);
+  SECTION("Valid ImageStack") {
+    sme::common::ImageStack imageStack{{QImage(":/icon/icon128.png")}};
+    QString title("my title");
+    QString message("see image below:");
+    DialogImage dia(nullptr, title, message, imageStack);
+    dia.show();
+    DialogImageWidgets widgets(&dia);
+    REQUIRE(dia.windowTitle() == title);
+    REQUIRE(widgets.lblMessage->text() == message);
+  }
+  SECTION("Empty ImageStack") {
+    sme::common::ImageStack imageStack{};
+    QString title("my title");
+    QString message("see image below:");
+    DialogImage dia(nullptr, title, message, imageStack);
+    dia.show();
+    DialogImageWidgets widgets(&dia);
+    REQUIRE(dia.windowTitle() == title);
+    REQUIRE(widgets.lblMessage->text() == message);
+  }
 }

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -189,7 +189,13 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().targetValues.empty());
     // set conc from image in range [1,2]
     ModalWidgetTimer mwt;
-    mwt.addUserAction({"1", "Tab", "2"});
+    mwt.setIgnoredWidget(&dia);
+    mwt.addUserAction([](QWidget *dialog) {
+      sendKeyEventsToQLineEdit(dialog->findChild<QLineEdit *>("txtMinConc"),
+                               {"1", "Enter"});
+      sendKeyEventsToQLineEdit(dialog->findChild<QLineEdit *>("txtMaxConc"),
+                               {"2", "Enter"});
+    });
     mwt.start();
     sendMouseClick(widgets.btnEditTargetValues);
     REQUIRE(dia.getOptCost().name == "cell/Mt");
@@ -220,7 +226,12 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().targetValues.empty());
     // set conc dcdt from image in range [1.2,2]
     ModalWidgetTimer mwt;
-    mwt.addUserAction({"1", ".", "2", "Tab", "2"});
+    mwt.addUserAction([](QWidget *dialog) {
+      sendKeyEventsToQLineEdit(dialog->findChild<QLineEdit *>("txtMinConc"),
+                               {"1", ".", "2", "Enter"});
+      sendKeyEventsToQLineEdit(dialog->findChild<QLineEdit *>("txtMaxConc"),
+                               {"2", "Enter"});
+    });
     mwt.start();
     sendMouseClick(widgets.btnEditTargetValues);
     REQUIRE(dia.getOptCost().name == "cell/P0");

--- a/gui/dialogs/dialogoptsetup_t.cpp
+++ b/gui/dialogs/dialogoptsetup_t.cpp
@@ -3,6 +3,7 @@
 #include "model_test_utils.hpp"
 #include "qt_test_utils.hpp"
 #include <QComboBox>
+#include <QLineEdit>
 #include <QListWidget>
 #include <QListWidgetItem>
 #include <QPushButton>
@@ -93,8 +94,16 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(widgets.lstTargets->count() == 0);
       REQUIRE(dia.getOptimizeOptions().optCosts.empty());
       // click add target, change values, press ok
-      mwt.addUserAction({"Down", "Tab", "Down", "Tab", "4", "Tab", "Tab",
-                         "Down", "Tab", "2", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbSpecies")->setCurrentIndex(1);
+        dialog->findChild<QComboBox *>("cmbCostType")->setCurrentIndex(1);
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtSimulationTime"),
+            {"4", "Enter"});
+        dialog->findChild<QComboBox *>("cmbDiffType")->setCurrentIndex(1);
+        sendKeyEventsToQLineEdit(dialog->findChild<QLineEdit *>("txtWeight"),
+                                 {"2", "Enter"});
+      });
       mwt.start();
       sendMouseClick(widgets.btnAddTarget);
       REQUIRE(widgets.lstTargets->count() == 1);
@@ -164,7 +173,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user edits first target & changes target species (other target values
       // get reset to defaults)
       REQUIRE(widgets.lstTargets->currentRow() == 0);
-      mwt.addUserAction({"Down", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbSpecies")->setCurrentIndex(2);
+      });
       mwt.start();
       sendMouseClick(widgets.btnEditTarget);
       REQUIRE(widgets.lstTargets->count() == 2);
@@ -187,7 +198,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].speciesIndex == 0);
       // user edits first target by double-clicking on it, changes opt cost type
       REQUIRE(widgets.lstTargets->currentRow() == 0);
-      mwt.addUserAction({"Tab", "Down"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbCostType")->setCurrentIndex(1);
+      });
       mwt.start();
       sendMouseDoubleClick(widgets.lstTargets->item(0));
       REQUIRE(mwt.getResult() == "Edit Optimization Target");
@@ -263,8 +276,13 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(widgets.lstParameters->count() == 0);
       REQUIRE(optParams.empty());
       // click add parameter, change values, press ok
-      mwt.addUserAction(
-          {"Down", "Down", "Tab", "2", "Tab", "5", "Tab", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbParameter")->setCurrentIndex(2);
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtLowerBound"), {"2", "Enter"});
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtUpperBound"), {"5", "Enter"});
+      });
       mwt.start();
       sendMouseClick(widgets.btnAddParameter);
       REQUIRE(widgets.lstParameters->count() == 1);
@@ -331,7 +349,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user edits first parameter & changes parameter (lower/upper bounds get
       // reset to default for this param)
       REQUIRE(widgets.lstParameters->currentRow() == 0);
-      mwt.addUserAction({"Down", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbParameter")->setCurrentIndex(3);
+      });
       mwt.start();
       sendMouseClick(widgets.btnEditParameter);
       REQUIRE(widgets.lstParameters->count() == 2);
@@ -356,7 +376,12 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].upperBound == dbl_approx(0.9));
       // user edits first parameter by doubleclick & changes bound
       REQUIRE(widgets.lstParameters->currentRow() == 0);
-      mwt.addUserAction({"Tab", "1", "Tab", "2", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtLowerBound"), {"1", "Enter"});
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtUpperBound"), {"2", "Enter"});
+      });
       mwt.start();
       sendMouseDoubleClick(widgets.lstParameters->item(0));
       REQUIRE(widgets.lstParameters->count() == 2);
@@ -566,7 +591,10 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optCosts[1].compartmentIndex == 0);
       REQUIRE(optCosts[1].speciesIndex == 3);
       // click add target, change values, press ok
-      mwt.addUserAction({"Down", "Tab", "Down", "Tab", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbSpecies")->setCurrentIndex(1);
+        dialog->findChild<QComboBox *>("cmbCostType")->setCurrentIndex(1);
+      });
       mwt.start();
       sendMouseClick(widgets.btnAddTarget);
       REQUIRE(widgets.lstTargets->count() == 3);
@@ -694,7 +722,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user edits first target & changes target species (other target values
       // get reset to defaults)
       REQUIRE(widgets.lstTargets->currentRow() == 0);
-      mwt.addUserAction({"Down", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbSpecies")->setCurrentIndex(1);
+      });
       mwt.start();
       sendMouseClick(widgets.btnEditTarget);
       REQUIRE(widgets.lstTargets->count() == 4);
@@ -887,8 +917,13 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       REQUIRE(optParams[1].lowerBound == 0.2);
       REQUIRE(optParams[1].upperBound == 0.4);
       // click add parameter, change values, press ok
-      mwt.addUserAction(
-          {"Down", "Down", "Tab", "2", "Tab", "5", "Tab", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbParameter")->setCurrentIndex(2);
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtLowerBound"), {"2", "Enter"});
+        sendKeyEventsToQLineEdit(
+            dialog->findChild<QLineEdit *>("txtUpperBound"), {"5", "Enter"});
+      });
       mwt.start();
       sendMouseClick(widgets.btnAddParameter);
       REQUIRE(widgets.lstParameters->count() == 3);
@@ -1009,7 +1044,9 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
       // user edits first parameter & changes parameter (lower/upper bounds get
       // reset to default for this param)
       REQUIRE(widgets.lstParameters->currentRow() == 0);
-      mwt.addUserAction({"Down", "Enter"});
+      mwt.addUserAction([](QWidget *dialog) {
+        dialog->findChild<QComboBox *>("cmbParameter")->setCurrentIndex(3);
+      });
       mwt.start();
       sendMouseClick(widgets.btnEditParameter);
       REQUIRE(widgets.lstParameters->count() == 4);

--- a/gui/dialogs/dialogsimulationoptions.cpp
+++ b/gui/dialogs/dialogsimulationoptions.cpp
@@ -1,4 +1,5 @@
 #include "dialogsimulationoptions.hpp"
+#include "guiutils.hpp"
 #include "sme/logger.hpp"
 #include "sme/utils.hpp"
 #include "ui_dialogsimulationoptions.h"
@@ -80,6 +81,9 @@ void DialogSimulationOptions::setupConnections() {
           &DialogSimulationOptions::txtDuneNewtonRel_editingFinished);
   connect(ui->txtDuneNewtonAbs, &QLineEdit::editingFinished, this,
           &DialogSimulationOptions::txtDuneNewtonAbs_editingFinished);
+  connect(ui->cmbDuneLinearSolver,
+          qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &DialogSimulationOptions::cmbDuneLinearSolver_currentIndexChanged);
   connect(ui->btnDuneReset, &QPushButton::clicked, this,
           &DialogSimulationOptions::resetDuneToDefaults);
   // Pixel tab
@@ -105,15 +109,8 @@ void DialogSimulationOptions::setupConnections() {
 }
 
 void DialogSimulationOptions::loadDuneOpts() {
-  int i = ui->cmbDuneIntegrator->findText(opt.dune.integrator.c_str());
-  if (i >= 0 && i < ui->cmbDuneIntegrator->count()) {
-    ui->cmbDuneIntegrator->setCurrentIndex(i);
-  } else {
-    ui->cmbDuneIntegrator->setCurrentIndex(0);
-    SPDLOG_WARN("Invalid integrator '{}' - using '{}' instead",
-                opt.dune.integrator,
-                ui->cmbDuneIntegrator->currentText().toStdString());
-  }
+  selectMatchingOrFirstItem(ui->cmbDuneIntegrator, opt.dune.integrator.c_str());
+  opt.dune.integrator = ui->cmbDuneIntegrator->currentText().toStdString();
   ui->txtDuneDt->setText(dblToQString(opt.dune.dt));
   ui->txtDuneMinDt->setText(dblToQString(opt.dune.minDt));
   ui->txtDuneMaxDt->setText(dblToQString(opt.dune.maxDt));
@@ -122,6 +119,9 @@ void DialogSimulationOptions::loadDuneOpts() {
   ui->chkDuneVTK->setChecked(opt.dune.writeVTKfiles);
   ui->txtDuneNewtonRel->setText(dblToQString(opt.dune.newtonRelErr));
   ui->txtDuneNewtonAbs->setText(dblToQString(opt.dune.newtonAbsErr));
+  selectMatchingOrFirstItem(ui->cmbDuneLinearSolver,
+                            opt.dune.linearSolver.c_str());
+  opt.dune.linearSolver = ui->cmbDuneLinearSolver->currentText().toStdString();
 }
 
 void DialogSimulationOptions::cmbDuneIntegrator_currentIndexChanged(
@@ -166,6 +166,11 @@ void DialogSimulationOptions::txtDuneNewtonRel_editingFinished() {
 void DialogSimulationOptions::txtDuneNewtonAbs_editingFinished() {
   opt.dune.newtonAbsErr = ui->txtDuneNewtonAbs->text().toDouble();
   loadDuneOpts();
+}
+
+void DialogSimulationOptions::cmbDuneLinearSolver_currentIndexChanged(
+    [[maybe_unused]] int index) {
+  opt.dune.linearSolver = ui->cmbDuneLinearSolver->currentText().toStdString();
 }
 
 void DialogSimulationOptions::resetDuneToDefaults() {

--- a/gui/dialogs/dialogsimulationoptions.hpp
+++ b/gui/dialogs/dialogsimulationoptions.hpp
@@ -28,6 +28,7 @@ private:
   void chkDuneVTK_stateChanged();
   void txtDuneNewtonRel_editingFinished();
   void txtDuneNewtonAbs_editingFinished();
+  void cmbDuneLinearSolver_currentIndexChanged(int index);
   void resetDuneToDefaults();
   void loadPixelOpts();
   void cmbPixelIntegrator_currentIndexChanged(int index);

--- a/gui/dialogs/dialogsimulationoptions.ui
+++ b/gui/dialogs/dialogsimulationoptions.ui
@@ -38,39 +38,54 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
+         <item row="4" column="1">
+          <widget class="QLineEdit" name="txtDuneMaxDt">
+           <property name="toolTip">
+            <string>The maximum allowed timestep</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="lblOutputFiles">
+           <property name="text">
+            <string>Output files</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblDuneDiscretization">
+           <property name="text">
+            <string>Discretization</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="lblDuneMaxDt">
+           <property name="text">
+            <string>Max timestep</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="txtDuneMinDt">
+           <property name="toolTip">
+            <string>The minimum allowed timestep</string>
+           </property>
+          </widget>
+         </item>
          <item row="6" column="0">
           <widget class="QLabel" name="lblDuneDecrease">
            <property name="text">
             <string>Decrease factor</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="lblDuneNewtonRel">
-           <property name="text">
-            <string>Newton relative error</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbDuneDiscretization">
-           <item>
-            <property name="text">
-             <string>1st order FEM</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lblDuneIncrease">
-           <property name="text">
-            <string>Increase factor</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -87,13 +102,6 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="0" colspan="2">
-          <widget class="QPushButton" name="btnDuneReset">
-           <property name="text">
-            <string>Reset to default values</string>
-           </property>
-          </widget>
-         </item>
          <item row="7" column="1">
           <widget class="QCheckBox" name="chkDuneVTK">
            <property name="toolTip">
@@ -101,6 +109,63 @@
            </property>
            <property name="text">
             <string>VTK (ParaView)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="lblDuneIncrease">
+           <property name="text">
+            <string>Increase factor</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLineEdit" name="txtDuneDecrease">
+           <property name="toolTip">
+            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDuneDiscretization">
+           <item>
+            <property name="text">
+             <string>1st order FEM</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblDuneIntegrator">
+           <property name="text">
+            <string>Integrator</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="txtDuneDt">
+           <property name="toolTip">
+            <string>The initial timestep to use at the start of the simulation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0" colspan="2">
+          <widget class="QPushButton" name="btnDuneReset">
+           <property name="text">
+            <string>Reset to default values</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLineEdit" name="txtDuneIncrease">
+           <property name="toolTip">
+            <string>The factor by which the timestep is increased after a successful integration step</string>
            </property>
           </widget>
          </item>
@@ -151,101 +216,6 @@
            </item>
           </widget>
          </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="lblOutputFiles">
-           <property name="text">
-            <string>Output files</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QLineEdit" name="txtDuneIncrease">
-           <property name="toolTip">
-            <string>The factor by which the timestep is increased after a successful integration step</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QLineEdit" name="txtDuneDecrease">
-           <property name="toolTip">
-            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="0" colspan="2">
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="8" column="1">
-          <widget class="QLineEdit" name="txtDuneNewtonRel">
-           <property name="toolTip">
-            <string>The relative (to initial) size of defect at which the Newton iteration is considered to have converged</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLineEdit" name="txtDuneMaxDt">
-           <property name="toolTip">
-            <string>The maximum allowed timestep</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblDuneDiscretization">
-           <property name="text">
-            <string>Discretization</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lblDuneIntegrator">
-           <property name="text">
-            <string>Integrator</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="txtDuneDt">
-           <property name="toolTip">
-            <string>The initial timestep to use at the start of the simulation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="lblDuneMaxDt">
-           <property name="text">
-            <string>Max timestep</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLineEdit" name="txtDuneMinDt">
-           <property name="toolTip">
-            <string>The minimum allowed timestep</string>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="0">
           <widget class="QLabel" name="lblDuneMinDt">
            <property name="text">
@@ -253,6 +223,23 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="lblDuneNewtonRel">
+           <property name="text">
+            <string>Newton relative error</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLineEdit" name="txtDuneNewtonRel">
+           <property name="toolTip">
+            <string>The relative (to initial) size of defect at which the Newton iteration is considered to have converged</string>
            </property>
           </widget>
          </item>
@@ -272,6 +259,61 @@
             <string>The absolute size of defect at which the Newton iteration is considered to have converged</string>
            </property>
           </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="lblDuneLinearSolver">
+           <property name="text">
+            <string>Linear solver</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QComboBox" name="cmbDuneLinearSolver">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Linear solver to use&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>BiCGSTAB</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>CG</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>RestartedGMRes</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>UMFPack</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>SuperLU</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="11" column="0" rowspan="2" colspan="2">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -505,6 +547,7 @@
   <tabstop>chkDuneVTK</tabstop>
   <tabstop>txtDuneNewtonRel</tabstop>
   <tabstop>txtDuneNewtonAbs</tabstop>
+  <tabstop>cmbDuneLinearSolver</tabstop>
   <tabstop>btnDuneReset</tabstop>
   <tabstop>cmbPixelIntegrator</tabstop>
   <tabstop>txtPixelRelErr</tabstop>

--- a/gui/guiutils.cpp
+++ b/gui/guiutils.cpp
@@ -1,6 +1,7 @@
 #include "guiutils.hpp"
 #include "sme/logger.hpp"
 #include "sme/tiff.hpp"
+#include <QComboBox>
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QListWidget>
@@ -10,6 +11,18 @@
 #include <QString>
 #include <QTreeWidget>
 #include <QWidget>
+
+void selectMatchingOrFirstItem(QComboBox *comboBox, const QString &text) {
+  if (comboBox->count() == 0) {
+    return;
+  }
+  int i = comboBox->findText(text);
+  if (i >= 0 && i < comboBox->count()) {
+    comboBox->setCurrentIndex(i);
+  } else {
+    comboBox->setCurrentIndex(0);
+  }
+}
 
 void selectMatchingOrFirstItem(QListWidget *list, const QString &text) {
   if (list->count() == 0) {

--- a/gui/guiutils.hpp
+++ b/gui/guiutils.hpp
@@ -9,6 +9,9 @@ class QMessageBox;
 class QListWidget;
 class QTreeWidget;
 class QScrollArea;
+class QComboBox;
+
+void selectMatchingOrFirstItem(QComboBox *comboBox, const QString &text = {});
 
 void selectMatchingOrFirstItem(QListWidget *list, const QString &text = {});
 

--- a/test/test_utils/qt_test_utils.cpp
+++ b/test/test_utils/qt_test_utils.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QDialog>
 #include <QFileDialog>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QTest>
 #include <QTreeWidgetItem>
@@ -48,6 +49,13 @@ void sendKeyEvents(QObject *object, const QStringList &keySeqStrings,
     }
     wait(keyDelay);
   }
+}
+
+void sendKeyEventsToQLineEdit(QLineEdit *lineEdit,
+                              const QStringList &keySeqStrings) {
+  lineEdit->clear();
+  lineEdit->setFocus();
+  sendKeyEvents(lineEdit, keySeqStrings);
 }
 
 static QDialog *getNextQDialog() {

--- a/test/test_utils/qt_test_utils.hpp
+++ b/test/test_utils/qt_test_utils.hpp
@@ -35,6 +35,9 @@ void waitFor(QWidget *widget);
 void sendKeyEvents(QObject *object, const QStringList &keySeqStrings,
                    bool sendReleaseEvents = true);
 
+void sendKeyEventsToQLineEdit(QLineEdit *lineEdit,
+                              const QStringList &keySeqStrings);
+
 QString sendKeyEventsToNextQDialog(const QStringList &keySeqStrings,
                                    bool sendReleaseEvents = true);
 


### PR DESCRIPTION
- add linearSolver with default value "BiCGSTAB" to DuneOptions
- add scotch to README and about dialog
- add scotch target to dune common in our CMake now that dune-copasi is linked against it in sme_deps
- use UCRT64 environment in msys2 instead of MING64
  - this links to the Universal C Runtime UCRT instead of the legacy MSVCRT
  - this is what Visual Studio does by default
- sme_deps -> 2024.01.23
- manylinux -> 2024.01.23
- use 4 cores when building on linux/windows CI
