### PR TITLE
Add image file support to drag & drop

### DIFF
--- a/gui/guiutils.cpp
+++ b/gui/guiutils.cpp
@@ -47,15 +47,8 @@ void selectMatchingOrFirstChild(QTreeWidget *list, const QString &text) {
   selectFirstChild(list);
 }
 
-sme::common::ImageStack getImageFromUser(QWidget *parent,
-                                         const QString &title) {
-  QString filename = QFileDialog::getOpenFileName(
-      parent, title, "",
-      "Image Files (*.tif *.tiff *.gif *.jpg *.jpeg *.png *.bmp);; All files "
-      "(*.*)");
-  if (filename.isEmpty()) {
-    return {};
-  }
+sme::common::ImageStack getImageStackFromFilename(QWidget *parent,
+                                                  const QString &filename) {
   try {
     return sme::common::ImageStack(filename);
   } catch (const std::invalid_argument &e) {
@@ -66,6 +59,18 @@ sme::common::ImageStack getImageFromUser(QWidget *parent,
             .arg(e.what()));
   }
   return {};
+}
+
+sme::common::ImageStack getImageFromUser(QWidget *parent,
+                                         const QString &title) {
+  QString filename = QFileDialog::getOpenFileName(
+      parent, title, "",
+      "Image Files (*.tif *.tiff *.gif *.jpg *.jpeg *.png *.bmp);; All files "
+      "(*.*)");
+  if (filename.isEmpty()) {
+    return {};
+  }
+  return getImageStackFromFilename(parent, filename);
 }
 
 static QSize getZoomedInSize(const QSize &originalSize, int zoomFactor) {

--- a/gui/guiutils.hpp
+++ b/gui/guiutils.hpp
@@ -16,6 +16,9 @@ void selectFirstChild(QTreeWidget *tree);
 
 void selectMatchingOrFirstChild(QTreeWidget *list, const QString &text = {});
 
+sme::common::ImageStack getImageStackFromFilename(QWidget *parent,
+                                                  const QString &filename);
+
 sme::common::ImageStack getImageFromUser(QWidget *parent = nullptr,
                                          const QString &title = "Import image");
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -128,7 +128,7 @@ MainWindow::~MainWindow() = default;
 
 void MainWindow::setupTabs() {
   tabGeometry = new TabGeometry(model, ui->lblGeometry, ui->voxGeometry,
-                                statusBar(), ui->tabReactions);
+                                statusBar(), ui->tabGeometry);
   ui->tabGeometry->layout()->addWidget(tabGeometry);
 
   tabSpecies =
@@ -683,9 +683,16 @@ void MainWindow::dropEvent(QDropEvent *event) {
   if (!mimeData->hasUrls() || mimeData->urls().isEmpty()) {
     return;
   }
-  auto filename{getConvertedFilename(mimeData->urls().front().toLocalFile())};
-  model.importFile(filename.toStdString());
-  validateSBMLDoc(filename);
+  auto filename = getConvertedFilename(mimeData->urls().front().toLocalFile());
+  QStringList imgSuffixes{"bmp", "png", "jpg", "jpeg", "gif", "tif", "tiff"};
+  if (imgSuffixes.contains(QFileInfo(filename).suffix().toLower())) {
+    if (auto img{getImageStackFromFilename(this, filename)}; !img.empty()) {
+      importGeometryImage(img);
+    }
+  } else {
+    model.importFile(filename.toStdString());
+    validateSBMLDoc(filename);
+  }
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {

--- a/test/test_utils/qt_test_utils.cpp
+++ b/test/test_utils/qt_test_utils.cpp
@@ -2,6 +2,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QDialog>
+#include <QDrag>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTest>
@@ -78,6 +79,25 @@ QString sendKeyEventsToNextQDialog(const QStringList &keySeqStrings,
     wait(10);
   }
   return title;
+}
+
+void sendDropEvent(QWidget *widget, const QString &filename) {
+  QApplication::processEvents();
+  qDebug() << "sme::test::sendDropEvent :: sending" << filename << "to"
+           << widget;
+  QPoint pos(widget->width() / 2, widget->height() / 2);
+  auto data = new QMimeData();
+  auto drag = new QDrag(widget);
+  drag->setMimeData(data);
+  data->setUrls({QUrl::fromLocalFile(filename)});
+  auto dragEnterEvent =
+      new QDragEnterEvent(pos, Qt::DropAction::MoveAction, data, {}, {});
+  QApplication::postEvent(widget, dragEnterEvent);
+  QApplication::processEvents();
+  auto dropEvent =
+      new QDropEvent(pos, Qt::DropAction::MoveAction, data, {}, {});
+  QApplication::postEvent(widget, dropEvent);
+  QApplication::processEvents();
 }
 
 void sendMouseMove(QWidget *widget, const QPoint &pos, Qt::MouseButton button) {

--- a/test/test_utils/qt_test_utils.hpp
+++ b/test/test_utils/qt_test_utils.hpp
@@ -2,13 +2,16 @@
 
 #pragma once
 
+#include <QEvent>
 #include <QListWidgetItem>
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QTest>
 #include <QTimer>
 #include <QTreeWidgetItem>
 #include <QtCore>
+#include <concepts>
 #include <functional>
 #include <queue>
 #include <utility>
@@ -32,11 +35,19 @@ void wait(int milliseconds = 100);
 
 void waitFor(QWidget *widget);
 
+void waitFor(std::invocable auto condition) {
+  if (!QTest::qWaitFor(condition)) {
+    qDebug() << "sme::test::waitFor :: Timeout waiting for condition";
+  }
+}
+
 void sendKeyEvents(QObject *object, const QStringList &keySeqStrings,
                    bool sendReleaseEvents = true);
 
 QString sendKeyEventsToNextQDialog(const QStringList &keySeqStrings,
                                    bool sendReleaseEvents = true);
+
+void sendDropEvent(QWidget *object, const QString &filename);
 
 void sendMouseMove(QWidget *widget, const QPoint &pos = {},
                    Qt::MouseButton button = Qt::MouseButton::NoButton);


### PR DESCRIPTION
- if a file with a supported image extension is drag&dropped it is imported as a geometry image
- all other drag&dropped files are attempted to be imported as model files as before
- resolves #877
