### PR TITLE
Duneconverter: use model filename for gmsh filename

### DIFF
--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -20,9 +20,9 @@
 
 namespace sme::simulate {
 
-static void addGrid(IniFile &ini) {
+static void addGrid(IniFile &ini, const QString &filenameGrid) {
   ini.addSection("grid");
-  ini.addValue("path", "grid.msh");
+  ini.addValue("path", filenameGrid);
   ini.addValue("dimension", 2);
 }
 
@@ -295,10 +295,11 @@ DuneConverter::DuneConverter(
     }
   }
   auto filename{QString("%1.ini").arg(baseIniFile)};
+  auto filenameGrid{QString("%1.msh").arg(baseIniFile)};
   auto iniFilename{QDir(iniFileDir).filePath(filename)};
 
   IniFile iniCommon;
-  addGrid(iniCommon);
+  addGrid(iniCommon, filenameGrid);
   addModel(iniCommon);
   addTimeStepping(iniCommon, model.getSimulationSettings().options.dune,
                   doublePrecision);

--- a/core/simulate/src/duneconverter_t.cpp
+++ b/core/simulate/src/duneconverter_t.cpp
@@ -24,7 +24,7 @@ TEST_CASE("DUNE: DuneConverter",
     QStringList ini = dc.getIniFile().split("\n");
     auto line = ini.cbegin();
     REQUIRE(*line++ == "[grid]");
-    REQUIRE(*line++ == "path = grid.msh");
+    REQUIRE(*line++ == "path = dune.msh");
     REQUIRE(*line++ == "dimension = 2");
     line = find_line("[compartments]", ini);
     REQUIRE(*line++ == "[compartments]");

--- a/core/simulate/src/dunegrid_t.cpp
+++ b/core/simulate/src/dunegrid_t.cpp
@@ -41,7 +41,9 @@ TEST_CASE("DUNE: grid",
     CAPTURE(exampleModel);
     // load mesh from model
     auto m{getExampleModel(exampleModel)};
-    simulate::DuneConverter dc(m, {}, true);
+    auto filename =
+        QString("tmp_dunegrid_model_%1").arg(static_cast<int>(exampleModel));
+    simulate::DuneConverter dc(m, {}, true, filename + ".ini");
     auto config{getConfig(dc)};
     const auto *mesh{m.getGeometry().getMesh()};
 
@@ -49,7 +51,8 @@ TEST_CASE("DUNE: grid",
     auto [grid, hostGrid] = simulate::makeDuneGrid<HostGrid, MDGTraits>(*mesh);
 
     // generate dune grid with Dune::Copasi::make_multi_domain_grid
-    if (QFile f("grid.msh"); f.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    if (QFile f(filename + ".msh");
+        f.open(QIODevice::WriteOnly | QIODevice::Text)) {
       f.write(mesh->getGMSH().toUtf8());
       f.close();
     }


### PR DESCRIPTION
- generated ini file has name [model-filename].ini
- use [model-filename].msh for corresponding gmsh file (instead of grid.msh)
- resolves #939
