### PR TITLE
Improve `fillMissingByDilation` behaviour for invalid inputs

### DIFF
--- a/core/model/src/CMakeLists.txt
+++ b/core/model/src/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
   core
   PRIVATE geometry.cpp
           geometry_analytic.cpp
+          geometry_impl.cpp
           geometry_sampled_field.cpp
           geometry_utils.cpp
           id.cpp
@@ -28,6 +29,7 @@ if(BUILD_TESTING)
     core_tests
     PUBLIC geometry_t.cpp
            geometry_analytic_t.cpp
+           geometry_impl_t.cpp
            geometry_utils_t.cpp
            id_t.cpp
            model_t.cpp

--- a/core/model/src/geometry_impl.cpp
+++ b/core/model/src/geometry_impl.cpp
@@ -1,0 +1,98 @@
+#include "geometry_impl.hpp"
+#include "sme/logger.hpp"
+#include <QImage>
+#include <QString>
+
+namespace sme::geometry {
+
+void fillMissingByDilation(std::vector<std::size_t> &arr, int nx, int ny,
+                           int nz, std::size_t invalidIndex) {
+  std::vector<std::size_t> arr_next{arr};
+  const int maxIter{nx + ny + nz};
+  std::size_t dx{1};
+  std::size_t dy{static_cast<std::size_t>(nx)};
+  std::size_t dz{dy * static_cast<std::size_t>(ny)};
+  for (int iter = 0; iter < maxIter; ++iter) {
+    bool finished{true};
+    bool iteration_changed_something{false};
+    for (int z = 0; z < nz; ++z) {
+      for (int y = 0; y < ny; ++y) {
+        for (int x = 0; x < nx; ++x) {
+          auto i{(static_cast<std::size_t>(x) +
+                  dy * static_cast<std::size_t>(y) +
+                  dz * static_cast<std::size_t>(z))};
+          if (arr[i] == invalidIndex) {
+            // replace negative voxel with any valid face-/6-connected neighbour
+            if (x > 0 && arr[i - dx] != invalidIndex) {
+              arr_next[i] = arr[i - dx];
+              iteration_changed_something = true;
+            } else if (x + 1 < nx && arr[i + 1] != invalidIndex) {
+              arr_next[i] = arr[i + dx];
+              iteration_changed_something = true;
+            } else if (y > 0 && arr[i - dy] != invalidIndex) {
+              arr_next[i] = arr[i - dy];
+              iteration_changed_something = true;
+            } else if (y + 1 < ny && arr[i + dy] != invalidIndex) {
+              arr_next[i] = arr[i + dy];
+              iteration_changed_something = true;
+            } else if (z > 0 && arr[i - dz] != invalidIndex) {
+              arr_next[i] = arr[i - dz];
+              iteration_changed_something = true;
+            } else if (z + 1 < nz && arr[i + dz] != invalidIndex) {
+              arr_next[i] = arr[i + dz];
+              iteration_changed_something = true;
+            } else {
+              // voxel has no valid neighbour: need another iteration
+              finished = false;
+            }
+          }
+        }
+      }
+    }
+    arr = arr_next;
+    if (finished) {
+      SPDLOG_DEBUG("Replaced all invalid indices after {} iterations", iter);
+      return;
+    }
+    if (!iteration_changed_something) {
+      SPDLOG_WARN("Last iteration {} did not modify any values - giving up",
+                  iter);
+      break;
+    }
+  }
+  // set any remaining invalid indices to just point to the first element
+  for (auto &a : arr) {
+    if (a == invalidIndex) {
+      SPDLOG_WARN("  - using 0 for invalid index");
+      a = 0;
+    }
+  }
+  SPDLOG_WARN("Failed to replace all invalid voxels");
+}
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
+void saveDebuggingIndicesImageXY(const std::vector<std::size_t> &arrayPoints,
+                                 int nx, int ny, int nz, std::size_t maxIndex,
+                                 const QString &filename) {
+  auto norm{static_cast<float>(maxIndex)};
+  for (int z = 0; z < nz; ++z) {
+    QImage img(nx, ny, QImage::Format_ARGB32_Premultiplied);
+    img.fill(qRgba(0, 0, 0, 0));
+    QColor c;
+    for (int x = 0; x < nx; ++x) {
+      for (int y = 0; y < ny; ++y) {
+        auto i = arrayPoints[static_cast<std::size_t>(x + nx * y) +
+                             static_cast<std::size_t>(nx * ny) * z];
+        if (i <= maxIndex) {
+          auto v{static_cast<float>(i) / norm};
+          c.setHslF(1.0f - v, 1.0, 0.5f * v);
+          img.setPixel(x, y, c.rgb());
+        }
+      }
+    }
+    img.save(filename + "XY_z" + QString::number(z) + ".png");
+  }
+}
+#endif
+
+} // namespace sme::geometry

--- a/core/model/src/geometry_impl.hpp
+++ b/core/model/src/geometry_impl.hpp
@@ -1,0 +1,14 @@
+#include <QString>
+#include <vector>
+
+namespace sme::geometry {
+
+void fillMissingByDilation(std::vector<std::size_t> &arr, int nx, int ny,
+                           int nz, std::size_t invalidIndex);
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
+void saveDebuggingIndicesImageXY(const std::vector<std::size_t> &arrayPoints,
+                                 int nx, int ny, int nz, std::size_t maxIndex,
+                                 const QString &filename);
+#endif
+} // namespace sme::geometry

--- a/core/model/src/geometry_impl_t.cpp
+++ b/core/model/src/geometry_impl_t.cpp
@@ -1,0 +1,33 @@
+#include "catch_wrapper.hpp"
+#include "geometry_impl.hpp"
+
+using namespace sme;
+
+TEST_CASE("fillMissingByDilation", "[core/model/geometry][core/"
+                                   "model][core][model][geometry]") {
+  int nx = 2;
+  int ny = 3;
+  int nz = 5;
+  std::vector<std::size_t> arr(static_cast<std::size_t>(nx * ny * nz), 6);
+  std::size_t invalidIndex = 6;
+  SECTION("empty array") {
+    std::vector<std::size_t> empty{};
+    geometry::fillMissingByDilation(empty, 0, 0, 0, invalidIndex);
+    REQUIRE(empty.empty());
+  }
+  SECTION("single valid voxel") {
+    arr[15] = 13;
+    geometry::fillMissingByDilation(arr, nx, ny, nz, invalidIndex);
+    for (auto a : arr) {
+      // every element contains the only valid index
+      REQUIRE(a == 13);
+    }
+  }
+  SECTION("no valid voxels") {
+    geometry::fillMissingByDilation(arr, nx, ny, nz, invalidIndex);
+    for (auto a : arr) {
+      // 0 used if no valid voxel is found
+      REQUIRE(a == 0);
+    }
+  }
+}


### PR DESCRIPTION
- stop early if no indices were modified by an entire iteration
- replace any remaining invalid indices with arbitrary valid index
- add some logging output
- add some 3d compartment geometry tests involving this function
- resolves #869
