### PR TITLE
Improve use of Dune-copasi in sme

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux_x86_64:2024.02.20
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux_x86_64:2024.02.27
       CIBW_SKIP: '*-manylinux_i686 *-musllinux* pp*-*'
       CIBW_ENVIRONMENT: 'CMAKE_ARGS="-DSME_LOG_LEVEL=OFF -DSME_BUILD_CORE=off -DCMAKE_PREFIX_PATH=/opt/smelibs;/opt/smelibs/lib64/cmake"'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2024.02.01"
+SME_DEPS_VERSION="2024.02.27"
 OS=$1
 
 set -e -x

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -128,17 +128,6 @@ target_include_directories(core SYSTEM PRIVATE ${SYMENGINE_INCLUDE_DIRS})
 target_compile_definitions(
   core PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${SME_LOG_LEVEL})
 
-# provide METIS::METIS target expected by dune-copasi with scotchmetisv3
-# metis-compatible library
-add_library(
-  METIS::METIS
-  INTERFACE
-  IMPORTED)
-find_package(SCOTCH)
-target_link_libraries(
-  METIS::METIS
-  INTERFACE SCOTCH::scotchmetisv3
-  INTERFACE SCOTCH::scotcherr)
 find_package(dune-copasi REQUIRED)
 target_link_libraries(
   core

--- a/core/cmake/smeConfig.cmake.in
+++ b/core/cmake/smeConfig.cmake.in
@@ -2,8 +2,8 @@ get_filename_component(SME_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
 find_dependency(SymEngine REQUIRED)
-find_dependency(sbml-static)
-find_dependency(OpenCV REQUIRED COMPONENTS core imgproc) # core imgproc
+find_dependency(sbml-static REQUIRED)
+find_dependency(OpenCV REQUIRED COMPONENTS core imgproc)
 find_dependency(spdlog REQUIRED)
 find_dependency(TIFF REQUIRED)
 find_dependency(fmt REQUIRED)
@@ -12,23 +12,6 @@ find_dependency(cereal REQUIRED)
 find_dependency(Pagmo REQUIRED)
 find_dependency(TBB CONFIG REQUIRED)
 find_dependency(combine-static REQUIRED CONFIGS Combine-static-config.cmake)
-# provide METIS::METIS target expected by dune-copasi
-add_library(
-  METIS::METIS
-  INTERFACE
-  IMPORTED)
-find_dependency(SCOTCH REQUIRED)
-target_link_libraries(
-  METIS::METIS
-  INTERFACE SCOTCH::scotchmetisv3
-  INTERFACE SCOTCH::scotcherr)
-find_dependency(dune-common REQUIRED)
-find_dependency(dune-geometry REQUIRED)
-find_dependency(dune-uggrid REQUIRED)
-find_dependency(dune-grid REQUIRED)
-find_dependency(dune-istl REQUIRED)
-find_dependency(dune-localfunctions REQUIRED)
-find_dependency(dune-pdelab REQUIRED)
 find_dependency(dune-copasi REQUIRED)
 
 if(NOT TARGET sme::core)

--- a/core/resources/models/ABtoC.xml
+++ b/core/resources/models/ABtoC.xml
@@ -26,7 +26,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/brusselator-model.xml
+++ b/core/resources/models/brusselator-model.xml
@@ -26,7 +26,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/circadian-clock.xml
+++ b/core/resources/models/circadian-clock.xml
@@ -1765,7 +1765,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/gray-scott-3d.xml
+++ b/core/resources/models/gray-scott-3d.xml
@@ -30,8 +30,8 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
-                <linearSolver>CG</linearSolver>
+                <newtonAbsErr>0.0</newtonAbsErr>
+                <linearSolver>RestartedGMRes</linearSolver>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/gray-scott.xml
+++ b/core/resources/models/gray-scott.xml
@@ -30,7 +30,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/liver-cells.xml
+++ b/core/resources/models/liver-cells.xml
@@ -26,7 +26,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/liver-simplified.xml
+++ b/core/resources/models/liver-simplified.xml
@@ -40,7 +40,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/single-compartment-diffusion-3d.xml
+++ b/core/resources/models/single-compartment-diffusion-3d.xml
@@ -21,7 +21,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/single-compartment-diffusion.xml
+++ b/core/resources/models/single-compartment-diffusion.xml
@@ -26,7 +26,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/very-simple-model-3d.xml
+++ b/core/resources/models/very-simple-model-3d.xml
@@ -26,8 +26,8 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
-                <linearSolver>CG</linearSolver>
+                <newtonAbsErr>0.0</newtonAbsErr>
+                <linearSolver>RestartedGMRes</linearSolver>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/resources/models/very-simple-model.xml
+++ b/core/resources/models/very-simple-model.xml
@@ -26,7 +26,7 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
+                <newtonAbsErr>0.0</newtonAbsErr>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>

--- a/core/simulate/include/sme/simulate_options.hpp
+++ b/core/simulate/include/sme/simulate_options.hpp
@@ -32,8 +32,8 @@ struct DuneOptions {
   double decrease{0.5};
   bool writeVTKfiles{false};
   double newtonRelErr{1e-8};
-  double newtonAbsErr{1e-12};
-  std::string linearSolver{"CG"};
+  double newtonAbsErr{0.0};
+  std::string linearSolver{"RestartedGMRes"};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {

--- a/core/simulate/src/dunefunction_t.cpp
+++ b/core/simulate/src/dunefunction_t.cpp
@@ -16,14 +16,14 @@ using namespace sme;
 using namespace sme::test;
 
 using HostGrid2d = Dune::UGGrid<2>;
-using MDGTraits2d = Dune::mdgrid::DynamicSubDomainCountTraits<2, 10>;
+using MDGTraits2d = Dune::mdgrid::FewSubDomainsTraits<2, 64>;
 using Grid2d = Dune::mdgrid::MultiDomainGrid<HostGrid2d, MDGTraits2d>;
 using Model2d =
     Dune::Copasi::Model<Grid2d, Grid2d::SubDomainGrid::Traits::LeafGridView,
                         double, double>;
 
 using HostGrid3d = Dune::UGGrid<3>;
-using MDGTraits3d = Dune::mdgrid::DynamicSubDomainCountTraits<3, 10>;
+using MDGTraits3d = Dune::mdgrid::FewSubDomainsTraits<3, 64>;
 using Grid3d = Dune::mdgrid::MultiDomainGrid<HostGrid3d, MDGTraits3d>;
 using Model3d =
     Dune::Copasi::Model<Grid3d, Grid3d::SubDomainGrid::Traits::LeafGridView,
@@ -94,8 +94,9 @@ static std::vector<AvgDiff> getAvgDiffs2d(Mod exampleModel,
           dc, *grid));
 
   // create model using TIFF files for initial conditions
-  auto filename =
-      QString("tmp_gridfunction_model_%1").arg(static_cast<int>(exampleModel));
+  auto filename = QString("tmp_gridfunction_model_%1_maxtrianglearea_%2")
+                      .arg(static_cast<int>(exampleModel))
+                      .arg(maxTriangleArea);
   simulate::DuneConverter dcTiff(m, {}, true, filename + ".ini");
   auto configTiff = getConfig(dcTiff);
   auto parser_context_tiff{std::make_shared<Dune::Copasi::ParserContext>(

--- a/core/simulate/src/dunegrid_t.cpp
+++ b/core/simulate/src/dunegrid_t.cpp
@@ -20,11 +20,11 @@ static Dune::ParameterTree getConfig(const simulate::DuneConverter &dc) {
 }
 
 using HostGrid2d = Dune::UGGrid<2>;
-using MDGTraits2d = Dune::mdgrid::DynamicSubDomainCountTraits<2, 1>;
+using MDGTraits2d = Dune::mdgrid::FewSubDomainsTraits<2, 64>;
 using Grid2d = Dune::mdgrid::MultiDomainGrid<HostGrid2d, MDGTraits2d>;
 
 using HostGrid3d = Dune::UGGrid<3>;
-using MDGTraits3d = Dune::mdgrid::DynamicSubDomainCountTraits<3, 1>;
+using MDGTraits3d = Dune::mdgrid::FewSubDomainsTraits<3, 64>;
 using Grid3d = Dune::mdgrid::MultiDomainGrid<HostGrid3d, MDGTraits3d>;
 
 template <typename Grid>
@@ -66,7 +66,7 @@ TEST_CASE("DUNE grid",
       std::locale::global(userLocale);
 
       // compare grids
-      int nCompartments{grid->maxSubDomainIndex()};
+      auto nCompartments{grid->maxSubDomainIndex()};
       REQUIRE(gmshGrid->maxSubDomainIndex() == nCompartments);
       for (int compIndex = 0; compIndex < nCompartments; ++compIndex) {
         auto meshCoords = getAllElementCoordinates(grid.get(), compIndex);
@@ -107,7 +107,7 @@ TEST_CASE("DUNE grid",
       std::locale::global(userLocale);
 
       // compare grids
-      int nCompartments{grid->maxSubDomainIndex()};
+      auto nCompartments{grid->maxSubDomainIndex()};
       REQUIRE(gmshGrid->maxSubDomainIndex() == nCompartments);
       for (int compIndex = 0; compIndex < nCompartments; ++compIndex) {
         auto meshCoords = getAllElementCoordinates(grid.get(), compIndex);

--- a/core/simulate/src/dunesim_impl.hpp
+++ b/core/simulate/src/dunesim_impl.hpp
@@ -178,8 +178,7 @@ private:
 
   using HostGrid = Dune::UGGrid<DuneDimensions>;
   std::shared_ptr<HostGrid> hostGrid;
-  using MDGTraits =
-      Dune::mdgrid::DynamicSubDomainCountTraits<DuneDimensions, 10>;
+  using MDGTraits = Dune::mdgrid::FewSubDomainsTraits<DuneDimensions, 64>;
   using Grid = Dune::mdgrid::MultiDomainGrid<HostGrid, MDGTraits>;
   using GridView = typename Grid::LeafGridView;
   using SubGrid = typename Grid::SubDomainGrid;

--- a/test/resources/models/hollow-sphere-3d.xml
+++ b/test/resources/models/hollow-sphere-3d.xml
@@ -31,7 +31,7 @@
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
                 <newtonAbsErr>9.9999999999999998e-13</newtonAbsErr>
-                <linearSolver>CG</linearSolver>
+                <linearSolver>RestartedGMRes</linearSolver>
               </dune>
               <pixel>
                 <cereal_class_version>0</cereal_class_version>


### PR DESCRIPTION
- use 0 as default value for `duneOptions.newtonAbsErr`
  - this means by default only the relative error is used, which is less sensitive to absolute magnitude of model values / geometry
  - user can still optionally set a non-zero value if they know what they are doing
  - update existing example models to also use this value
  - explicitly add a non-zero for one test that didn't converge without it
  - resolves https://github.com/spatial-model-editor/spatial-model-editor/issues/956
- use `RestartedGMRes` as the default linear solver
  - `CG` is only valid for symmetric positive-definite systems
  - update existing models to use this solver
  - resolves https://github.com/spatial-model-editor/spatial-model-editor/issues/958
- remove no longer needed METIS and dune targets from CMake as they are now taken care of by find_package(dune-copasi)
- internal dune API change
  - `Dune::mdgrid::DynamicSubDomainCountTraits<ndim, 10>` -> `Dune::mdgrid::FewSubDomainsTraits<ndim, 64>`
- sme_deps -> 2024.02.27
- manylinux -> 2024.02.27