### PR TITLE
glLineWidth reimplementation

### DIFF
--- a/core/mesh/include/sme/mesh3d.hpp
+++ b/core/mesh/include/sme/mesh3d.hpp
@@ -132,6 +132,13 @@ public:
   [[nodiscard]] std::vector<uint32_t>
   getMeshSegmentsIndicesAsFlatArray(std::size_t compartmentIndex) const;
   /**
+   * A flat array of triangle indices for a particular compartment
+   *
+   * Used by the rendering system.
+   */
+  [[nodiscard]] std::vector<uint32_t>
+  getMeshTrianglesIndicesAsFlatArray(std::size_t compartmentIndex) const;
+  /**
    * @brief The mesh tetrahedron indices
    *
    * The indices of the vertices of each tetrahedron used in the mesh for each

--- a/core/mesh/src/mesh3d.cpp
+++ b/core/mesh/src/mesh3d.cpp
@@ -321,11 +321,31 @@ Mesh3d::getMeshSegmentsIndicesAsFlatArray(std::size_t compartmentIndex) const {
   const auto &indices = tetrahedronVertexIndices_[compartmentIndex];
   out.reserve(indices.size() * 6);
   for (const auto &t : indices) {
-    for (uint32_t i = 0; i < t.size() - 1; i++) {
+    for (uint32_t i = 0; i < t.size(); i++) {
       for (uint32_t j = i + 1; j < t.size(); j++) {
         out.push_back(static_cast<uint32_t>(t[i]));
         out.push_back(static_cast<uint32_t>(t[j]));
       }
+    }
+  }
+  return out;
+}
+
+std::vector<uint32_t>
+Mesh3d::getMeshTrianglesIndicesAsFlatArray(std::size_t compartmentIndex) const {
+  assert(compartmentIndex < tetrahedronVertexIndices_.size());
+
+  std::vector<uint32_t> out;
+  const auto &indices = tetrahedronVertexIndices_[compartmentIndex];
+  out.reserve(indices.size() * 4 * 3);
+  for (const auto &t : indices) {
+    for (uint32_t i = 0; i < t.size(); i++) {
+      for (uint32_t j = i + 1; j < t.size(); j++)
+        for (uint32_t k = j + 1; k < t.size(); k++) {
+          out.push_back(static_cast<uint32_t>(t[i]));
+          out.push_back(static_cast<uint32_t>(t[j]));
+          out.push_back(static_cast<uint32_t>(t[k]));
+        }
     }
   }
   return out;

--- a/gui/rendering/ShaderProgram.hpp
+++ b/gui/rendering/ShaderProgram.hpp
@@ -16,12 +16,16 @@ protected:
 
 public:
   explicit ShaderProgram(const std::string &vertexShaderFileName,
+                         const std::string &geometryShaderFileName,
                          const std::string &fragmentShaderFileName);
   ShaderProgram(const ShaderProgram &) = delete;
-  ShaderProgram(const char *vertexProgram, const char *fragmentProgram);
+  ShaderProgram(const char *vertexProgram, const char *geometryProgram,
+                const char *fragmentProgram);
   ~ShaderProgram();
 
   ShaderProgram &operator=(ShaderProgram other) = delete;
+
+  GLuint createShader(GLenum type, const std::string &src);
 
   void Use();
 
@@ -35,12 +39,16 @@ public:
   void SetColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
 
   void SetMeshTranslationOffset(GLfloat x, GLfloat y, GLfloat z);
+  void SetThickness(GLfloat thickness);
+  void SetBackgroundColor(GLfloat r, GLfloat g, GLfloat b);
 
 private:
   std::string m_vertexShaderText;
+  std::string m_geometryShaderText;
   std::string m_fragmentShaderText;
 
   GLuint m_vertexShaderId;
+  GLuint m_geometryShaderId;
   GLuint m_fragmentShaderId;
   GLuint m_programId;
 
@@ -54,6 +62,8 @@ private:
   GLint m_color;
 
   GLint m_meshTranslationOffsetLocation;
+  GLint m_thickness;
+  GLint m_background_color;
 };
 
 } // namespace rendering

--- a/gui/rendering/Shaders/colorAsUniform/colorAsUniformVertex.hpp
+++ b/gui/rendering/Shaders/colorAsUniform/colorAsUniformVertex.hpp
@@ -6,11 +6,12 @@
 #define SPATIALMODELEDITOR_COLORASUNIFORMVERTEX_H
 
 namespace rendering {
+namespace shader {
+namespace colorAsUniform {
 
 const char text_vertex_color_as_uniform[] =
-    "#version 140\n"
+    "#version 150\n"
     "#extension GL_ARB_explicit_attrib_location : enable\n"
-    "#extension GL_ARB_explicit_attrib_location: enable\n"
     "#define PI 3.14159265359\n"
     "layout(location=0) in vec4 in_Position;\n"
     "//layout(location=1) in vec4 in_Color;\n"
@@ -24,7 +25,7 @@ const char text_vertex_color_as_uniform[] =
     "\n"
     "uniform vec3 viewPosition;\n"
     "uniform vec3 viewRotation;\n"
-    "out vec4 ex_Color;\n"
+    "//out vec4 out_vert_Color;\n"
     "\n"
     "mat4 scaling( in float dx, in float dy, in float dz ) {\n"
     "return mat4(\n"
@@ -88,9 +89,11 @@ const char text_vertex_color_as_uniform[] =
     "mat4 offset = translation(\n"
     "translationOffset.x, translationOffset.y, translationOffset.z);\n"
     "gl_Position = in_Position * offset * MVP;\n"
-    "ex_Color = in_Color;\n"
+    "//out_vert_Color = in_Color;\n"
     "}\n";
 
 }
+} // namespace shader
+} // namespace rendering
 
 #endif // SPATIALMODELEDITOR_COLORASUNIFORMVERTEX_H

--- a/gui/rendering/Shaders/default/fragment.hpp
+++ b/gui/rendering/Shaders/default/fragment.hpp
@@ -5,18 +5,37 @@
 #pragma once
 
 namespace rendering {
+namespace shader {
+namespace default_ {
 
 const char text_fragment[] =
-    "#version 140\n"
+    "#version 150\n"
     "\n"
     "#extension GL_ARB_explicit_attrib_location : enable\n"
-    "#extension GL_ARB_explicit_attrib_location: enable\n"
-    "in vec4 ex_Color;\n"
-    "out vec4 out_Color;\n"
+    "uniform vec4 in_Color;\n"
+    "//in vec4 out_geo_Color;\n"
+    "out vec4 frag_Color;\n"
+    "in vec3 barycentric_coord;\n"
+    "in vec3 distance;\n"
+    "uniform float thickness;\n"
+    "uniform vec3 background_color;\n"
     "\n"
     "void main(void)\n"
     "{\n"
-    "out_Color = ex_Color;\n"
-    "//out_Color = vec4(1.0, 0.0, 0.0, 1.0);\n"
+    "   float barycentric_distance = min(barycentric_coord.x, "
+    "min(barycentric_coord.y, barycentric_coord.z));\n"
+    "   float dist = min(distance.x, min(distance.y, distance.z));\n"
+    "   float derivative = fwidth(barycentric_distance);\n"
+    "   float alpha = smoothstep(thickness, thickness+derivative, "
+    "barycentric_distance); // calculate alpha\n"
+    "   //float alpha = exp2(-2.0*barycentric_distance*barycentric_distance);\n"
+    "   if(alpha > 0.5) { discard; }\n"
+    "   ////if(dist > 0.1) { discard; }\n"
+    "   frag_Color = vec4((1-alpha)*in_Color.xyz + (alpha)*background_color, "
+    "1.0);\n"
+    "   //frag_Color = in_Color;\n"
+    "   //frag_Color = vec4(1.0, 0.0, 0.0, 0.5);\n"
     "}\n";
 }
+} // namespace shader
+} // namespace rendering

--- a/gui/rendering/Shaders/default/geometry.hpp
+++ b/gui/rendering/Shaders/default/geometry.hpp
@@ -1,0 +1,77 @@
+//
+// Created by hcaramizaru on 3/7/24.
+//
+
+#ifndef SPATIALMODELEDITOR_GEOMETRY_HPP
+#define SPATIALMODELEDITOR_GEOMETRY_HPP
+
+namespace rendering {
+namespace shader {
+namespace default_ {
+
+const char text_geometry[] =
+    "#version 150 core\n"
+    "\n"
+    "layout(triangles) in;\n"
+    "layout(triangle_strip, max_vertices = 3) out;\n"
+    "\n"
+    "//in vec4 out_vert_Color[];\n"
+    "//out vec4 out_geo_Color;\n"
+    "//barycentric coordinate inside the triangle\n"
+    "out vec3 barycentric_coord;\n"
+    "out vec3 distance;\n"
+    "\n"
+    "void main()\n"
+    "{\n"
+    "    vec2 p0 = gl_in[0].gl_Position.xy;\n"
+    "    p0 = p0 / gl_in[0].gl_Position.w;\n"
+    "    vec2 p1 = gl_in[1].gl_Position.xy;\n"
+    "    p1 = p1 / gl_in[1].gl_Position.w;\n"
+    "    vec2 p2 = gl_in[2].gl_Position.xy;\n"
+    "    p2 = p2 / gl_in[2].gl_Position.w;\n"
+    "\n"
+    "\n"
+    "    gl_Position = gl_in[0].gl_Position;\n"
+    "    vec2 v10 = (p1 - p0);   \n"
+    "    vec2 v20 = (p2 - p0);   \n"
+    "    // Compute 2D area of triangle.\n"
+    "    float area0 = abs(v10.x*v20.y - v10.y*v20.x);\n"
+    "    // Compute distance from vertex to line in 2D coords\n"
+    "    float h0 = area0/length(v10-v20); \n"
+    "    h0 *= gl_in[0].gl_Position.w;\n"
+    "    barycentric_coord = vec3(1, 0.0, 0.0);\n"
+    "    distance = vec3(h0, 0.0, 0.0);\n"
+    "    EmitVertex();\n"
+    "\n"
+    "    gl_Position = gl_in[1].gl_Position;\n"
+    "    vec2 v01 = (p0 - p1);   \n"
+    "    vec2 v21 = (p2 - p1);   \n"
+    "    // Compute 2D area of triangle.\n"
+    "    float area1 = abs(v01.x*v21.y - v01.y*v21.x);\n"
+    "    // Compute distance from vertex to line in 2D coords\n"
+    "    float h1 = area1/length(v01-v21); \n"
+    "    h1 *= gl_in[1].gl_Position.w;\n"
+    "    barycentric_coord = vec3(0.0, 1, 0.0);\n"
+    "    distance = vec3(0.0, h1, 0.0);\n"
+    "    EmitVertex();\n"
+    "\n"
+    "    gl_Position = gl_in[2].gl_Position;\n"
+    "    vec2 v02 = (p0 - p2);   \n"
+    "    vec2 v12 = (p1 - p2);   \n"
+    "    // Compute 2D area of triangle.\n"
+    "    float area2 = abs(v02.x*v12.y - v02.y*v12.x);\n"
+    "    // Compute distance from vertex to line in 2D coords\n"
+    "    float h2 = area2/length(v02-v12);\n"
+    "    h2 *= gl_in[2].gl_Position.w;\n"
+    "    barycentric_coord = vec3(0.0, 0.0, 1);\n"
+    "    distance = vec3(0.0, 0.0, h2);\n"
+    "    EmitVertex();\n"
+    "\n"
+    "    EndPrimitive();\n"
+    "}";
+
+}
+} // namespace shader
+} // namespace rendering
+
+#endif // SPATIALMODELEDITOR_GEOMETRY_HPP

--- a/gui/rendering/Shaders/default/vertex.hpp
+++ b/gui/rendering/Shaders/default/vertex.hpp
@@ -5,11 +5,12 @@
 #pragma once
 
 namespace rendering {
+namespace shader {
+namespace default_ {
 
 const char text_vertex[] =
-    "#version 140\n"
+    "#version 150\n"
     "#extension GL_ARB_explicit_attrib_location : enable\n"
-    "#extension GL_ARB_explicit_attrib_location: enable\n"
     "#define PI 3.14159265359\n"
     "layout(location=0) in vec4 in_Position;\n"
     "layout(location=1) in vec4 in_Color;\n"
@@ -87,3 +88,5 @@ const char text_vertex[] =
     "}\n";
 
 }
+} // namespace shader
+} // namespace rendering

--- a/gui/rendering/WireframeObjects.cpp
+++ b/gui/rendering/WireframeObjects.cpp
@@ -27,7 +27,7 @@ rendering::WireframeObjects::WireframeObjects(
 
   m_indices.reserve(info.getNumberOfCompartment());
   for (size_t i = 0; i < info.getNumberOfCompartment(); i++) {
-    m_indices.push_back(info.getMeshSegmentsIndicesAsFlatArray(i));
+    m_indices.push_back(info.getMeshTrianglesIndicesAsFlatArray(i));
   }
 
   for (const auto &v : m_vertices) {
@@ -112,7 +112,7 @@ void rendering::WireframeObjects::CreateVBO() {
   for (int i = 0; i < m_elementBufferIds.size(); i++) {
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_elementBufferIds[i]);
     CheckOpenGLError("glBindBuffer");
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_indices[i].size(),
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeofGLVector(m_indices[i]),
                  m_indices[i].data(), GL_STATIC_DRAW);
     CheckOpenGLError("glBufferData");
   }
@@ -140,12 +140,14 @@ void rendering::WireframeObjects::Render(
   glEnableVertexAttribArray(0);
   CheckOpenGLError("glEnableVertexAttribArray");
 
-  glLineWidth(lineWidth);
-  glEnable(GL_LINE_SMOOTH);
-  //  glEnable(GL_CULL_FACE);
+  // glLineWidth(lineWidth);
+  program->SetThickness(lineWidth);
+  // glDisable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glClearColor(clearColor.redF(), clearColor.greenF(), clearColor.blueF(),
                clearColor.alphaF());
+  program->SetBackgroundColor(clearColor.redF(), clearColor.greenF(),
+                              clearColor.blueF());
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
   program->SetMeshTranslationOffset(m_translationOffset.x(),
@@ -163,7 +165,7 @@ void rendering::WireframeObjects::Render(
     program->SetColor(m_colors[i].redF(), m_colors[i].greenF(),
                       m_colors[i].blueF(), m_colors[i].alphaF());
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_elementBufferIds[i]);
-    glDrawElements(GL_LINES, static_cast<int>(m_indices[i].size()),
+    glDrawElements(GL_TRIANGLES, static_cast<int>(m_indices[i].size()),
                    GL_UNSIGNED_INT, (void *)nullptr);
   }
 

--- a/gui/rendering/rendering.hpp
+++ b/gui/rendering/rendering.hpp
@@ -11,3 +11,4 @@
 #include "Shaders/default/vertex.hpp"
 #include "Utils.hpp"
 #include "WireframeObjects.hpp"
+#include "rendering/Shaders/default/geometry.hpp"

--- a/gui/widgets/qopenglmousetracker.cpp
+++ b/gui/widgets/qopenglmousetracker.cpp
@@ -4,14 +4,14 @@
 
 #include "qopenglmousetracker.hpp"
 
-QOpenGLMouseTracker::QOpenGLMouseTracker(float lineWidth,
+QOpenGLMouseTracker::QOpenGLMouseTracker(QWidget *parent, float lineWidth,
                                          float lineSelectPrecision,
                                          QColor selectedObjectColor,
                                          float cameraFOV, float cameraNearZ,
                                          float cameraFarZ, float frameRate)
-    : m_lineWidth(lineWidth), m_lineSelectPrecision(lineSelectPrecision),
+    : QOpenGLWidget(parent), m_lineWidth(lineWidth),
+      m_lineSelectPrecision(lineSelectPrecision),
       m_selectedObjectColor(selectedObjectColor),
-      m_SubMeshes(std::unique_ptr<rendering::WireframeObjects>(nullptr)),
       m_camera(cameraFOV, static_cast<float>(size().width()),
                static_cast<float>(size().height()), cameraNearZ, cameraFarZ),
       m_frameRate(frameRate),
@@ -66,9 +66,10 @@ void QOpenGLMouseTracker::initializeGL() {
               std::string(" ") + gl_version + std::string(" ") +
               std::string("\n\n\t") + ext + std::string("\n"));
 
-  m_mainProgram =
-      std::unique_ptr<rendering::ShaderProgram>(new rendering::ShaderProgram(
-          rendering::text_vertex_color_as_uniform, rendering::text_fragment));
+  m_mainProgram = std::make_unique<rendering::ShaderProgram>(
+      rendering::shader::colorAsUniform::text_vertex_color_as_uniform,
+      rendering::shader::default_::text_geometry,
+      rendering::shader::default_::text_fragment);
 }
 
 void QOpenGLMouseTracker::renderScene(float lineWidth) {
@@ -123,6 +124,9 @@ void QOpenGLMouseTracker::SetCameraFrustum(GLfloat FOV, GLfloat width,
 
 void QOpenGLMouseTracker::mousePressEvent(QMouseEvent *event) {
 
+  if (m_SubMeshes == nullptr) {
+    return;
+  }
   m_xAtPress = static_cast<int>(event->position().x());
   m_yAtPress = static_cast<int>(event->position().y());
 
@@ -157,10 +161,13 @@ void QOpenGLMouseTracker::mousePressEvent(QMouseEvent *event) {
     SPDLOG_INFO("Reset state for selected objects to UNSELECTED objects!");
   }
 
-  repaint();
+  update();
 }
 
 void QOpenGLMouseTracker::mouseMoveEvent(QMouseEvent *event) {
+  if (m_SubMeshes == nullptr) {
+    return;
+  }
 
   int xAtPress = event->pos().x();
   int yAtPress = event->pos().y();
@@ -180,7 +187,7 @@ void QOpenGLMouseTracker::mouseMoveEvent(QMouseEvent *event) {
                           subMeshesOrientation.y() - static_cast<float>(x_len),
                           subMeshesOrientation.z());
 
-  repaint();
+  update();
 
   QRgb pixel = m_offscreenPickingImage.pixel(xAtPress, yAtPress);
   QColor color(pixel);
@@ -204,7 +211,7 @@ void QOpenGLMouseTracker::wheelEvent(QWheelEvent *event) {
 
   emit mouseWheelEvent(event);
 
-  repaint();
+  update();
 }
 
 void QOpenGLMouseTracker::SetCameraPosition(float x, float y, float z) {
@@ -241,7 +248,6 @@ QVector3D QOpenGLMouseTracker::GetSubMeshesPosition() const {
 
 void QOpenGLMouseTracker::SetSubMeshes(const sme::mesh::Mesh3d &mesh,
                                        const std::vector<QColor> &colors) {
-
   if (colors.empty()) {
     m_SubMeshes = std::make_unique<rendering::WireframeObjects>(
         mesh, this, mesh.getColors(), mesh.getOffset());
@@ -249,6 +255,7 @@ void QOpenGLMouseTracker::SetSubMeshes(const sme::mesh::Mesh3d &mesh,
     m_SubMeshes = std::make_unique<rendering::WireframeObjects>(
         mesh, this, colors, mesh.getOffset());
   }
+  update();
 }
 
 void QOpenGLMouseTracker::setFPS(float frameRate) { m_frameRate = frameRate; }
@@ -286,4 +293,9 @@ void QOpenGLMouseTracker::setBackgroundColor(QColor background) {
 
 QColor QOpenGLMouseTracker::getBackgroundColor() const {
   return m_backgroundColor;
+}
+
+void QOpenGLMouseTracker::clear() {
+  m_SubMeshes.reset();
+  update();
 }

--- a/gui/widgets/qopenglmousetracker.hpp
+++ b/gui/widgets/qopenglmousetracker.hpp
@@ -14,11 +14,11 @@
 class QOpenGLMouseTracker : public QOpenGLWidget {
   Q_OBJECT
 public:
-  QOpenGLMouseTracker(float lineWidth = 1.0f, float lineSelectPrecision = 10.0f,
+  QOpenGLMouseTracker(QWidget *parent = nullptr, float lineWidth = 0.005f,
+                      float lineSelectPrecision = 0.2f,
                       QColor selectedObjectColor = QColor(255, 255, 0),
                       float cameraFOV = 60.0f, float cameraNearZ = 0.001f,
                       float cameraFarZ = 2000.0f, float frameRate = 30.0f);
-  ~QOpenGLMouseTracker() = default;
 
   void SetCameraFrustum(GLfloat FOV, GLfloat width, GLfloat height,
                         GLfloat nearZ, GLfloat farZ);
@@ -48,8 +48,8 @@ public:
                     const std::vector<QColor> &colors = std::vector<QColor>(0));
 
   void setFPS(float frameRate);
-  void setLineWidth(float lineWidth = 1.0f);
-  void setLineSelectPrecision(float lineSelectPrecision = 10.0f);
+  void setLineWidth(float lineWidth = 0.005f);
+  void setLineSelectPrecision(float lineSelectPrecision = 0.2f);
 
   void setSelectedObjectColor(QColor color = QColor(255, 255, 0));
 
@@ -68,6 +68,8 @@ public:
 
   void setBackgroundColor(QColor background);
   QColor getBackgroundColor() const;
+
+  void clear();
 
 signals:
   void mouseClicked(QRgb color, uint32_t meshID);
@@ -88,9 +90,9 @@ protected:
 
   QColor m_selectedObjectColor;
 
-  std::unique_ptr<rendering::WireframeObjects> m_SubMeshes;
+  std::unique_ptr<rendering::WireframeObjects> m_SubMeshes{};
 
-  std::unique_ptr<rendering::ShaderProgram> m_mainProgram;
+  std::unique_ptr<rendering::ShaderProgram> m_mainProgram{};
   rendering::Camera m_camera;
 
   QImage m_offscreenPickingImage;


### PR DESCRIPTION
Geometry viewer improvements:

- Switch to Opengl 3.2
- Adding a Geometry shader stage as part of the pipeline.
- Reimplementing glLineWith() using the programmable pipeline: SetThickness()
- Switch from using a different color for selected objects to geometry width increase.