### PR TITLE
Add voxel picking to `QVoxelRenderer`

### DIFF
--- a/core/common/include/sme/image_stack.hpp
+++ b/core/common/include/sme/image_stack.hpp
@@ -52,6 +52,7 @@ public:
   void rescaleXY(QSize size);
   void flipYAxis();
   void convertToIndexed();
+  [[nodiscard]] bool valid(const Voxel &voxel) const;
   ImageStack scaled(int width, int height);
   ImageStack scaledToWidth(int width);
   ImageStack scaledToHeight(int height);

--- a/core/common/src/image_stack.cpp
+++ b/core/common/src/image_stack.cpp
@@ -124,6 +124,10 @@ void ImageStack::convertToIndexed() {
   }
 }
 
+bool ImageStack::valid(const Voxel &voxel) const {
+  return voxel.z < sz.depth() && imgs[voxel.z].valid(voxel.p);
+}
+
 ImageStack ImageStack::scaled(int width, int height) {
   ImageStack scaled{*this};
   for (std::size_t z = 0; z < sz.depth(); ++z) {

--- a/core/common/src/image_stack_t.cpp
+++ b/core/common/src/image_stack_t.cpp
@@ -6,6 +6,7 @@ TEST_CASE("ImageStack",
   SECTION("empty") {
     sme::common::ImageStack imageStack{};
     REQUIRE(imageStack.empty() == true);
+    REQUIRE(imageStack.valid({0, 0, 0}) == false);
   }
   SECTION("construct from volume") {
     sme::common::ImageStack imageStack({3, 10, 12},
@@ -15,8 +16,13 @@ TEST_CASE("ImageStack",
     REQUIRE(imageStack.volume().height() == 10);
     REQUIRE(imageStack.volume().depth() == 12);
     REQUIRE(imageStack.volume().nVoxels() == 3 * 10 * 12);
+    REQUIRE(imageStack.valid({0, 0, 0}) == true);
+    REQUIRE(imageStack.valid({1, 1, 11}) == true);
+    REQUIRE(imageStack.valid({1, 1, 12}) == false);
+    REQUIRE(imageStack.valid({2, 0, 0}) == true);
+    REQUIRE(imageStack.valid({3, 0, 0}) == false);
   }
-  SECTION("construct from grayscalae intensity array") {
+  SECTION("construct from grayscale intensity array") {
     SECTION("all values identical and non-zero should be white") {
       sme::common::ImageStack img1{{2, 2, 1},
                                    std::vector<double>{1.2, 1.2, 1.2, 1.2}};

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,5 @@ myst_parser
 nbsphinx
 numpy
 pandoc
-sphinx>=4.5.0
+sphinx>=7.2,<7.3
 sphinx_rtd_theme>=1.0.0

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -24,6 +24,8 @@ TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
 
   connect(lblGeometry, &QLabelMouseTracker::mouseClicked, this,
           &TabGeometry::lblGeometry_mouseClicked);
+  connect(voxGeometry, &QVoxelRenderer::mouseClicked, this,
+          &TabGeometry::lblGeometry_mouseClicked);
   connect(ui->btnAddCompartment, &QPushButton::clicked, this,
           &TabGeometry::btnAddCompartment_clicked);
   connect(ui->btnRemoveCompartment, &QPushButton::clicked, this,

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -24,6 +24,12 @@ public:
   void setImage(const sme::common::ImageStack &img);
   void setPhysicalSize(const sme::common::VolumeF &size, const QString &units);
 
+signals:
+  void mouseClicked(QRgb col, sme::common::Voxel voxel);
+
+protected:
+  void mousePressEvent(QMouseEvent *ev) override;
+
 private:
   vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
   vtkNew<vtkRenderer> renderer;


### PR DESCRIPTION
- add `mouseClicked` signal with same behaviour as `QLabelMouseTracker`
- user can now select compartments in `TabGeometry` with 3d rendering enabled
- add bool `valid(const Voxel &voxel)` method to ImageStack
- resolves #927
