### PR TITLE
Add Python 3.13 wheels

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  SONAR_SCANNER_VERSION: '5.0.1.3006'
+  SONAR_SCANNER_VERSION: '6.2.1.4610'
 jobs:
   quality:
     name: ${{ matrix.script }}
@@ -25,9 +25,9 @@ jobs:
       matrix:
         script: [codecov, sonar, asan, ubsan]
     steps:
-      - uses: spatial-model-editor/setup-ci@2024.05.31
+      - uses: spatial-model-editor/setup-ci@2024.10.29
         with:
-          sme_deps: '2024.05.15'
+          sme_deps: '2024.10.29'
           cache_id: ${{ matrix.script }}
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     env:
-      CIBUILDWHEEL_VERSION: "2.18"
-      CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_x86_64:2024.04.24"
+      CIBUILDWHEEL_VERSION: "2.21"
+      CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_x86_64:2024.09.12"
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
       MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
       MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
@@ -41,9 +41,9 @@ jobs:
       MACOS_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PWD }}
     name: "${{ matrix.target }} :: ${{ matrix.platform.os }}"
     steps:
-      - uses: spatial-model-editor/setup-ci@2024.05.31
+      - uses: spatial-model-editor/setup-ci@2024.10.29
         with:
-          sme_deps: '2024.05.15'
+          sme_deps: '2024.10.29'
           cache_id: ${{ matrix.target }}
       - uses: actions/checkout@v4
         with:
@@ -81,7 +81,7 @@ jobs:
           merge-multiple: true
           path: artifacts
       # if this is an untagged commit to main: add a "0.0.0" version wheel to github latest release for readthedocs to use
-      - run: cp artifacts/dist/sme-*-cp311-cp311-manylinux_2_28_x86_64.whl artifacts/binaries/sme-0.0.0-cp311-cp311-manylinux_2_28_x86_64.whl
+      - run: cp artifacts/dist/sme-*-cp312-cp312-manylinux_2_28_x86_64.whl artifacts/binaries/sme-0.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
         if: github.ref == 'refs/heads/main'
       - name: Upload binaries to latest pre-release
         # if this is an untagged commit to main: upload binaries to github latest release

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages:
     - ffmpeg
 sphinx:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
-## [latest]
+
+## [1.7.0] - 2024-10-29
 ### Added
+- Python 3.13 wheels [#1002](https://github.com/spatial-model-editor/spatial-model-editor/issues/1002)
 - colours in the geometry image can now be changed [#960](https://github.com/spatial-model-editor/spatial-model-editor/issues/960)
 - voxels can be selected in the 3d rendering of the geometry image [#979](https://github.com/spatial-model-editor/spatial-model-editor/issues/979)
+
+### Fixed
+- parameter optimization error with 3d models [#1007](https://github.com/spatial-model-editor/spatial-model-editor/issues/1007)
 
 ## [1.6.0] - 2024-03-26
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.13...3.29)
+cmake_minimum_required(VERSION 3.16...3.30)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.6.0
+  VERSION 1.7.0
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES C CXX)
 

--- a/app/spatial-model-editor.cpp
+++ b/app/spatial-model-editor.cpp
@@ -6,7 +6,6 @@
 #include <QVTKOpenGLNativeWidget.h>
 #include <QtGui>
 #include <fmt/core.h>
-#include <locale>
 
 int main(int argc, char *argv[]) {
   QString filename;

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -6,8 +6,6 @@
 #include <QFile>
 #include <fmt/core.h>
 #include <limits>
-#include <locale>
-#include <memory>
 
 using namespace sme;
 
@@ -107,8 +105,6 @@ static void printSimulatorBenchmarks(const BenchmarkParams &params) {
   Q_INIT_RESOURCE(resources);
   // disable logging
   spdlog::set_level(spdlog::level::off);
-  // symengine assumes C locale
-  std::locale::global(std::locale::classic());
 
   // fixed step-size simulations
   double dt = params.simulator_timestep;

--- a/benchmark/pixel.cpp
+++ b/benchmark/pixel.cpp
@@ -5,7 +5,6 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <fmt/core.h>
-#include <locale>
 
 using namespace sme;
 
@@ -85,8 +84,6 @@ static void printFixedTimestepPixel(const PixelParams &params) {
   Q_INIT_RESOURCE(resources);
   // disable logging
   spdlog::set_level(spdlog::level::off);
-  // symengine assumes C locale
-  std::locale::global(std::locale::classic());
 
   fmt::print("# timestep\tvalue\t\t\tlower-order\t\truntime\tsteps\tmodel\n");
   for (double dt : {1.0,     0.5,      0.25,      0.125,   0.1,     0.05,

--- a/ci/quality-sonar.sh
+++ b/ci/quality-sonar.sh
@@ -11,9 +11,9 @@ Xvfb -screen 0 1280x800x24 :99 &
 export DISPLAY=:99
 
 # download sonar scanner (generated from https://sonarcloud.io/ CI setup helper)
-export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
-curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
-unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux-x64
+wget https://github.com/spatial-model-editor/spatial-model-editor.github.io/releases/download/1.0.0/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux-x64.zip
+unzip -o sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux-x64.zip -d $HOME/.sonar/
 export PATH=$SONAR_SCANNER_HOME/bin:$PATH
 export SONAR_SCANNER_OPTS="-server"
 curl --create-dirs -sSLo $HOME/.sonar/build-wrapper-linux-x86.zip https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip

--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -14,6 +14,7 @@
 #include <initializer_list>
 #include <iomanip>
 #include <iterator>
+#include <locale>
 #include <numeric>
 #include <optional>
 #include <ranges>
@@ -281,7 +282,7 @@ bool isCyclicPermutation(const std::vector<T> &a, const std::vector<T> &b) {
 }
 
 // Creates a unique_ptr of type T with std::free as custom deleter
-// Avoids taking this address of std::free as this is undefined behaviour
+// Avoids taking the address of std::free as this is undefined behaviour
 // https://stackoverflow.com/questions/27440953/stdunique-ptr-for-c-functions-that-need-free/43626234#43626234
 struct free_deleter {
   template <typename T> void operator()(T *p) const {
@@ -289,5 +290,12 @@ struct free_deleter {
   }
 };
 template <typename T> using unique_C_ptr = std::unique_ptr<T, free_deleter>;
+
+// C-locale versions of isalpha, isdigit, etc.
+inline bool isalpha(char c) { return std::isalpha(c, std::locale::classic()); }
+
+inline bool isalnum(char c) { return std::isalnum(c, std::locale::classic()); }
+
+inline bool isdigit(char c) { return std::isdigit(c, std::locale::classic()); }
 
 } // namespace sme::common

--- a/core/common/src/simple_symbolic.cpp
+++ b/core/common/src/simple_symbolic.cpp
@@ -9,23 +9,14 @@ namespace sme::common {
 
 using namespace SymEngine;
 
-static RCP<const Basic> safeParse(const std::string &expr) {
-  // hack until https://github.com/symengine/symengine/issues/1566 is resolved:
-  // (SymEngine parser relies on strtod and assumes C locale)
-  std::locale userLocale{std::locale::global(std::locale::classic())};
-  auto e{parse_sbml(expr)};
-  std::locale::global(userLocale);
-  return e;
-}
-
 std::string SimpleSymbolic::divide(const std::string &expr,
                                    const std::string &var) {
-  return sbml(*div(safeParse(expr), safeParse(var)));
+  return sbml(*div(parse_sbml(expr), parse_sbml(var)));
 }
 
 std::string SimpleSymbolic::multiply(const std::string &expr,
                                      const std::string &var) {
-  return sbml(*mul(safeParse(expr), safeParse(var)));
+  return sbml(*mul(parse_sbml(expr), parse_sbml(var)));
 }
 
 std::string SimpleSymbolic::substitute(
@@ -36,7 +27,7 @@ std::string SimpleSymbolic::substitute(
     SPDLOG_DEBUG("  - constant {} = {}", name, value);
     d[symbol(name)] = real_double(value);
   }
-  return sbml(*safeParse(expr)->subs(d));
+  return sbml(*parse_sbml(expr)->subs(d));
 }
 
 bool SimpleSymbolic::contains(const std::string &expr, const std::string &var) {
@@ -46,7 +37,7 @@ bool SimpleSymbolic::contains(const std::string &expr, const std::string &var) {
 std::set<std::string, std::less<>>
 SimpleSymbolic::symbols(const std::string &expr) {
   std::set<std::string, std::less<>> result;
-  for (const auto &s : free_symbols(*safeParse(expr))) {
+  for (const auto &s : free_symbols(*parse_sbml(expr))) {
     result.insert(rcp_dynamic_cast<const Symbol>(s)->get_name());
   }
   return result;

--- a/core/common/src/symbolic.cpp
+++ b/core/common/src/symbolic.cpp
@@ -56,9 +56,6 @@ bool Symbolic::parse(
     SPDLOG_DEBUG("  - constant {} = {}", name, value);
     d[SymEngine::symbol(name)] = SymEngine::real_double(value);
   }
-  // hack until https://github.com/symengine/symengine/issues/1566 is resolved:
-  // (SymEngine parser relies on strtod and assumes C locale)
-  std::locale userLocale{std::locale::global(std::locale::classic())};
   // map from function id to symengine expressions
   std::map<std::string, SymEngineFunc, std::less<>> symEngineFuncs;
   for (const auto &function : functions) {
@@ -94,7 +91,6 @@ bool Symbolic::parse(
                               "requires {} argument(s), found {}",
                               expression, f.name, f.args.size(), args.size());
               SPDLOG_WARN("{}", errorMessage);
-              std::locale::global(userLocale);
               return false;
             }
             SymEngine::map_basic_basic arg_map;
@@ -117,7 +113,6 @@ bool Symbolic::parse(
                                    "function calls are not supported",
                                    expression);
         SPDLOG_WARN("{}", errorMessage);
-        std::locale::global(userLocale);
         return false;
       }
       exprInlined.push_back(e->subs(d));
@@ -126,7 +121,6 @@ bool Symbolic::parse(
       SPDLOG_WARN("{}", e.what());
       errorMessage = fmt::format("Error parsing expression '{}': {}",
                                  expression, e.what());
-      std::locale::global(userLocale);
       return false;
     }
     SPDLOG_DEBUG("  --> {}", sbml(*exprInlined.back()));
@@ -143,7 +137,6 @@ bool Symbolic::parse(
             fmt::format("Error parsing expression '{}': Unknown symbol '{}'",
                         expression, sbml(*(*iter)));
         SPDLOG_WARN("{}", errorMessage);
-        std::locale::global(userLocale);
         return false;
       }
     }
@@ -153,12 +146,10 @@ bool Symbolic::parse(
           fmt::format("Error parsing expression '{}': Unknown function '{}'",
                       expression, sbml(*(*fn.begin())));
       SPDLOG_WARN("{}", errorMessage);
-      std::locale::global(userLocale);
       return false;
     }
   }
   valid = true;
-  std::locale::global(userLocale);
   return true;
 }
 

--- a/core/model/src/id.cpp
+++ b/core/model/src/id.cpp
@@ -1,5 +1,6 @@
 #include "id.hpp"
 #include "sme/logger.hpp"
+#include "sme/utils.hpp"
 #include <QString>
 #include <QStringList>
 #include <memory>
@@ -24,14 +25,14 @@ QString nameToUniqueSId(const QString &name, libsbml::Model *model) {
   std::string id;
   // remove any non-alphanumeric chars, convert spaces etc to underscores
   for (auto c : name.toStdString()) {
-    if (std::isalnum(c, std::locale::classic())) {
+    if (sme::common::isalnum(c)) {
       id.push_back(c);
     } else if (charsToConvertToUnderscore.find(c) != std::string::npos) {
       id.push_back('_');
     }
   }
   // first char must be a letter or underscore
-  if (!std::isalpha(id.front(), std::locale::classic()) && id.front() != '_') {
+  if (!sme::common::isalpha(id.front()) && id.front() != '_') {
     id = "_" + id;
   }
   SPDLOG_DEBUG("  -> '{}'", id);

--- a/core/model/src/model_functions.cpp
+++ b/core/model/src/model_functions.cpp
@@ -137,13 +137,12 @@ makeValidArgumentName(const std::string &name,
                       const libsbml::FunctionDefinition *func) {
   std::string s;
   // first char must be a letter or underscore
-  if (auto c = name.front();
-      !(std::isalpha(c, std::locale::classic()) || c == '_')) {
+  if (auto c = name.front(); !(sme::common::isalpha(c) || c == '_')) {
     s.append("_");
   }
   // other chars must be letters, numbers or underscores
   for (const auto c : name) {
-    if (std::isalnum(c, std::locale::classic()) || c == '_') {
+    if (sme::common::isalnum(c) || c == '_') {
       s += c;
     }
   }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 breathe
 docutils
-https://github.com/spatial-model-editor/spatial-model-editor/releases/download/latest/sme-0.0.0-cp311-cp311-manylinux_2_28_x86_64.whl
+https://github.com/spatial-model-editor/spatial-model-editor/releases/download/latest/sme-0.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
 ipykernel
 matplotlib
 myst_parser

--- a/gui/widgets/qplaintextmathedit.cpp
+++ b/gui/widgets/qplaintextmathedit.cpp
@@ -1,12 +1,12 @@
 #include "qplaintextmathedit.hpp"
 #include "sme/logger.hpp"
+#include "sme/utils.hpp"
 #include <QAbstractItemModel>
 #include <QAbstractItemView>
 #include <QScrollBar>
 #include <QString>
 #include <algorithm>
 #include <limits>
-#include <locale>
 
 static constexpr char quoteChar{'"'};
 
@@ -65,13 +65,12 @@ void QPlainTextMathEdit::setVariables(
 
 static bool isValidSymbol(std::string_view name) {
   // first char must be a letter or underscore
-  if (auto c{name.front()};
-      !(std::isalpha(c, std::locale::classic()) || c == '_')) {
+  if (auto c{name.front()}; !(sme::common::isalpha(c) || c == '_')) {
     return false;
   }
   // other chars must be letters, numbers or underscores
   return std::all_of(name.begin(), name.end(), [](char c) {
-    return std::isalnum(c, std::locale::classic()) || c == '_';
+    return sme::common::isalnum(c) || c == '_';
   });
 }
 
@@ -270,9 +269,8 @@ substitute(const std::string &expr,
     } else {
       // find next delimiter
       end = expr.find_first_of(delimiters, start + 1);
-      if (std::isdigit(expr[start], std::locale::classic()) &&
-          end < expr.size() && expr[end - 1] == 'e' &&
-          (expr[end] == '-' || expr[end] == '+')) {
+      if (sme::common::isdigit(expr[start]) && end < expr.size() &&
+          expr[end - 1] == 'e' && (expr[end] == '-' || expr[end] == '+')) {
         // symbol starts with a numerical digit, and ends with "e-" or "e+",
         // this can only be valid input if we have the first half of a number in
         // scientific notation, so carry on to next delimiter to get the rest of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sme"
-version = "1.6.0"
+version = "1.7.0"
 description = "Spatial Model Editor python bindings"
 readme = "README.md"
 license = {text = "MIT"}
@@ -23,6 +23,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3,7 +3,6 @@
 #include <QApplication>
 #include <QSurfaceFormat>
 #include <catch2/catch_session.hpp>
-#include <locale>
 
 int main(int argc, char *argv[]) {
   Catch::StringMaker<double>::precision = 25;
@@ -37,12 +36,6 @@ int main(int argc, char *argv[]) {
 
   Q_INIT_RESOURCE(resources);
   Q_INIT_RESOURCE(test_resources);
-
-  // Qt sets the locale according to the system one
-  // This can cause problems with numerical code
-  // e.g. when a double is "3,142" vs "3.142"
-  // Here we reset the default "C" locale to avoid these issues
-  std::locale::global(std::locale::classic());
 
   spdlog::set_pattern("%^[%L%$][%14s:%4#] %! :: %v%$");
   spdlog::set_level(spdlog::level::trace);


### PR DESCRIPTION
- cibuildwheel -> 2.20
- sme_deps and sme_manylinux -> 2024.09.12
- remove safeParse wrapper now that symengine parsing is locale-independent
- add locale-independent versions of isalpha, isdigit etc to utils
- update changelog
- bump version to 1.7.0
