### PR TITLE
Improve mesh viewer

### DIFF
--- a/ci/gui-cli-Windows.sh
+++ b/ci/gui-cli-Windows.sh
@@ -32,7 +32,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER \
     -DSME_LOG_LEVEL=OFF \
     -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
-    -DPython_ROOT_DIR=$PYDIR \
+    -DPython_ROOT_DIR="$PYDIR" \
     -DFREETYPE_LIBRARY_RELEASE=/c/smelibs/lib/libQt6BundledFreetype.a \
     -DFREETYPE_INCLUDE_DIR_freetype2=/c/smelibs/include/QtFreetype \
     -DFREETYPE_INCLUDE_DIR_ft2build=/c/smelibs/include/QtFreetype

--- a/gui/tabs/tabgeometry.hpp
+++ b/gui/tabs/tabgeometry.hpp
@@ -61,6 +61,7 @@ private:
   void lblCompMesh_mouseClicked(QRgb col, sme::common::Voxel point);
   void mshCompMesh_mouseClicked(int compartmentIndex);
   void spinMaxTriangleArea_valueChanged(int value);
+  void updateBoundaries();
   void updateMesh2d();
   void spinMaxCellVolume_valueChanged(int value);
   void cmbRenderMode_currentIndexChanged(int index);

--- a/gui/widgets/qmeshrenderer.cpp
+++ b/gui/widgets/qmeshrenderer.cpp
@@ -6,8 +6,89 @@
 
 QMeshRenderer::QMeshRenderer(QWidget *parent) : SmeVtkWidget(parent) {}
 
+void QMeshRenderer::setMesh(const sme::mesh::Mesh3d &mesh,
+                            std::size_t compartmentIndex, bool resetCamera) {
+  if (!isVisible() || compartmentIndex >= mesh.getNumberOfCompartments()) {
+    return;
+  }
+  clear();
+  colors = mesh.getColors();
+  points->SetNumberOfPoints(static_cast<vtkIdType>(mesh.getVertices().size()));
+  for (vtkIdType i = 0; const auto &v : mesh.getVertices()) {
+    points->SetPoint(i, static_cast<float>(v.p.x()),
+                     static_cast<float>(v.p.y()), static_cast<float>(v.z));
+    ++i;
+  }
+  points->Modified();
+  for (const auto &compartmentTetrahedronIndices :
+       mesh.getTetrahedronIndices()) {
+    auto &grid = grids.emplace_back();
+    auto &edge = edges.emplace_back();
+    auto &solidActor = solidActors.emplace_back();
+    auto &solidMapper = solidMappers.emplace_back();
+    auto &wireframeActor = wireframeActors.emplace_back();
+    auto &wireframeMapper = wireframeMappers.emplace_back();
+    grid->AllocateExact(
+        static_cast<vtkIdType>(compartmentTetrahedronIndices.size()), 4);
+    for (const auto &t : compartmentTetrahedronIndices) {
+      grid->InsertNextCell(VTK_TETRA, 4,
+                           reinterpret_cast<const vtkIdType *>(t.data()));
+    }
+    grid->SetPoints(points);
+    edge->SetInputData(grid);
+    solidMapper->SetInputData(grid);
+    solidActor->SetMapper(solidMapper);
+    solidActor->GetProperty()->EdgeVisibilityOn();
+    renderer->AddActor(solidActor);
+    wireframeMapper->SetInputConnection(edge->GetOutputPort());
+    wireframeActor->SetMapper(wireframeMapper);
+    renderer->AddActor(wireframeActor);
+  }
+  if (resetCamera) {
+    renderer->ResetCameraClippingRange();
+    renderer->ResetCamera();
+  }
+  setCompartmentIndex(compartmentIndex);
+}
+
+void QMeshRenderer::setCompartmentIndex(std::size_t compartmentIndex) {
+  currentCompartmentIndex = compartmentIndex;
+  updateAndRender();
+}
+
+void QMeshRenderer::setColors(std::vector<QRgb> newColors) {
+  colors = std::move(newColors);
+  updateAndRender();
+}
+
+void QMeshRenderer::setRenderMode(RenderMode mode) {
+  renderMode = mode;
+  updateAndRender();
+}
+
+void QMeshRenderer::clear() {
+  currentCompartmentIndex = 0;
+  colors.clear();
+  renderMode = RenderMode::Solid;
+  renderer->RemoveAllViewProps();
+  points->Reset();
+  grids.clear();
+  edges.clear();
+  solidMappers.clear();
+  wireframeMappers.clear();
+  solidActors.clear();
+  wireframeActors.clear();
+}
+
 void QMeshRenderer::mousePressEvent(QMouseEvent *ev) {
   if (ev->buttons() == Qt::NoButton) {
+    return;
+  }
+  lastMouseClickPos = ev->pos();
+}
+
+void QMeshRenderer::mouseReleaseEvent(QMouseEvent *ev) {
+  if (ev->pos() != lastMouseClickPos) {
     return;
   }
   auto *interactor = renderWindow->GetInteractor();
@@ -27,66 +108,7 @@ void QMeshRenderer::mousePressEvent(QMouseEvent *ev) {
   }
 }
 
-void QMeshRenderer::clear() {
-  renderer->RemoveAllViewProps();
-  points->Reset();
-  grids.clear();
-  edges.clear();
-  solidActors.clear();
-  solidMappers.clear();
-  wireframeActors.clear();
-  wireframeMappers.clear();
-}
-
-void QMeshRenderer::setRenderMode(RenderMode mode) {
-  renderMode = mode;
-  for (auto &solidActor : solidActors) {
-    solidActor->SetVisibility(renderMode == RenderMode::Solid);
-  }
-  for (auto &wireframeActor : wireframeActors) {
-    wireframeActor->SetVisibility(renderMode == RenderMode::Wireframe);
-  }
-  renderWindow->Render();
-}
-
-void QMeshRenderer::setMesh(const sme::mesh::Mesh3d &mesh,
-                            std::size_t compartmentIndex) {
-  if (!isVisible() || compartmentIndex >= mesh.getNumberOfCompartments()) {
-    return;
-  }
-  clear();
-  for (const auto &v : mesh.getVertices()) {
-    points->InsertNextPoint(v.p.x(), v.p.y(), v.z);
-  }
-  for (const auto &compartmentTetrahedronIndices :
-       mesh.getTetrahedronIndices()) {
-    auto &grid = grids.emplace_back();
-    auto &edge = edges.emplace_back();
-    auto &solidActor = solidActors.emplace_back();
-    auto &solidMapper = solidMappers.emplace_back();
-    auto &wireframeActor = wireframeActors.emplace_back();
-    auto &wireframeMapper = wireframeMappers.emplace_back();
-    for (const auto &t : compartmentTetrahedronIndices) {
-      grid->InsertNextCell(VTK_TETRA, 4,
-                           reinterpret_cast<const vtkIdType *>(t.data()));
-    }
-    grid->SetPoints(points);
-    edge->SetInputData(grid);
-    solidMapper->SetInputData(grid);
-    solidActor->SetMapper(solidMapper);
-    solidActor->GetProperty()->EdgeVisibilityOn();
-    renderer->AddActor(solidActor);
-    wireframeMapper->SetInputConnection(edge->GetOutputPort());
-    wireframeActor->SetMapper(wireframeMapper);
-    renderer->AddActor(wireframeActor);
-  }
-  setColours(mesh.getColors(), compartmentIndex);
-  renderer->ResetCameraClippingRange();
-  renderer->ResetCamera();
-  setRenderMode(renderMode);
-}
-
-std::array<double, 3> makeEdgeColor(const QColor &color) {
+static std::array<double, 3> makeEdgeColor(const QColor &color) {
   // lighter or darker edge color depending on lightness of color
   auto edge = color.lightnessF() > 0.3 ? color.darker(300) : color.lighter(300);
   if (edge.lightnessF() < 0.1) {
@@ -96,19 +118,21 @@ std::array<double, 3> makeEdgeColor(const QColor &color) {
   return {edge.redF(), edge.greenF(), edge.blueF()};
 }
 
-void QMeshRenderer::setColours(const std::vector<QRgb> &colors,
-                               std::size_t compartmentIndex) {
+void QMeshRenderer::updateAndRender() {
   for (std::size_t i = 0; i < solidActors.size(); ++i) {
     QColor color(colors[i]);
     std::array<double, 3> floatColor{color.redF(), color.greenF(),
                                      color.blueF()};
+    solidActors[i]->SetVisibility(renderMode == RenderMode::Solid);
     solidActors[i]->GetProperty()->SetColor(floatColor.data());
+    solidActors[i]->GetProperty()->SetOpacity(
+        i == currentCompartmentIndex ? 1.0 : 0.15);
+    wireframeActors[i]->SetVisibility(renderMode == RenderMode::Wireframe);
     wireframeActors[i]->GetProperty()->SetColor(floatColor.data());
-    solidActors[i]->GetProperty()->SetOpacity(i == compartmentIndex ? 1.0
-                                                                    : 0.15);
-    wireframeActors[i]->GetProperty()->SetOpacity(i == compartmentIndex ? 1.0
-                                                                        : 0.05);
+    wireframeActors[i]->GetProperty()->SetOpacity(
+        i == currentCompartmentIndex ? 1.0 : 0.05);
     auto edgeColor = makeEdgeColor(color);
     solidActors[i]->GetProperty()->SetEdgeColor(edgeColor.data());
   }
+  renderWindow->Render();
 }

--- a/gui/widgets/qmeshrenderer.hpp
+++ b/gui/widgets/qmeshrenderer.hpp
@@ -20,7 +20,10 @@ public:
   };
 
   explicit QMeshRenderer(QWidget *parent = nullptr);
-  void setMesh(const sme::mesh::Mesh3d &mesh, std::size_t compartmentIndex);
+  void setMesh(const sme::mesh::Mesh3d &mesh, std::size_t compartmentIndex,
+               bool resetCamera = true);
+  void setCompartmentIndex(std::size_t compartmentIndex);
+  void setColors(std::vector<QRgb> newColors);
   void setRenderMode(RenderMode mode);
   void clear();
 
@@ -29,16 +32,19 @@ signals:
 
 protected:
   void mousePressEvent(QMouseEvent *ev) override;
+  void mouseReleaseEvent(QMouseEvent *ev) override;
 
 private:
-  void setColours(const std::vector<QRgb> &colors,
-                  std::size_t compartmentIndex);
+  void updateAndRender();
+  QPoint lastMouseClickPos{};
+  std::size_t currentCompartmentIndex{0};
+  std::vector<QRgb> colors{};
   RenderMode renderMode{RenderMode::Solid};
-  vtkNew<vtkPoints> points;
-  std::vector<vtkNew<vtkUnstructuredGrid>> grids;
-  std::vector<vtkNew<vtkExtractEdges>> edges;
-  std::vector<vtkNew<vtkDataSetMapper>> solidMappers;
-  std::vector<vtkNew<vtkDataSetMapper>> wireframeMappers;
-  std::vector<vtkNew<vtkActor>> solidActors;
-  std::vector<vtkNew<vtkActor>> wireframeActors;
+  vtkNew<vtkPoints> points{};
+  std::vector<vtkNew<vtkUnstructuredGrid>> grids{};
+  std::vector<vtkNew<vtkExtractEdges>> edges{};
+  std::vector<vtkNew<vtkDataSetMapper>> solidMappers{};
+  std::vector<vtkNew<vtkDataSetMapper>> wireframeMappers{};
+  std::vector<vtkNew<vtkActor>> solidActors{};
+  std::vector<vtkNew<vtkActor>> wireframeActors{};
 };

--- a/gui/widgets/qmeshrenderer_t.cpp
+++ b/gui/widgets/qmeshrenderer_t.cpp
@@ -7,7 +7,7 @@
 using namespace sme::test;
 
 // set to e.g. 1000 to interactively inspect the rendering
-constexpr int delay_ms{0};
+constexpr int delay_ms{1000};
 
 TEST_CASE("QMeshRenderer",
           "[qmeshrenderer][gui/widgets/qmeshrenderer][gui/widgets][gui]") {
@@ -19,14 +19,17 @@ TEST_CASE("QMeshRenderer",
   meshRenderer.resize(200, 200);
   auto model = sme::test::getExampleModel(Mod::VerySimpleModel3D);
   auto &mesh = *model.getGeometry().getMesh3d();
+  meshRenderer.setMesh(mesh, 0);
+  // zoom in
+  sendMouseWheel(&meshRenderer, 1);
+  sendMouseWheel(&meshRenderer, 1);
   // highlight each compartment in turn
   for (std::size_t i = 0; i < mesh.getNumberOfCompartments(); ++i) {
-    meshRenderer.setMesh(mesh, i);
+    meshRenderer.setCompartmentIndex(i);
     wait(delay_ms);
   }
   // change the compartment colours
-  mesh.setColors({0xff00ff, 0x00ff00, 0x0000ff});
-  meshRenderer.setMesh(mesh, 1);
+  meshRenderer.setColors({0xff00ff, 0x00ff00, 0x0000ff});
   wait(delay_ms);
   // change the render mode
   meshRenderer.setRenderMode(QMeshRenderer::RenderMode::Wireframe);
@@ -41,4 +44,7 @@ TEST_CASE("QMeshRenderer",
   sendMouseClick(&meshRenderer, {100, 100});
   REQUIRE(mouseClicks.size() == 1);
   REQUIRE(mouseClicks[0] == 0);
+  // new mesh with reset camera
+  meshRenderer.setMesh(mesh, 0);
+  wait(delay_ms);
 }


### PR DESCRIPTION
- reduce how often the mesh camera position is updated
  - camera zoom is now preserved when color or max cell volumes are changed
  - mesh is no longer reloaded when compartment index or colour is changed
  - resolves https://github.com/spatial-model-editor/spatial-model-editor/issues/1036
- improve performance
  - pre-allocate memory for points and cells
  - refactor QMeshRenderer and QTabGeometry
- only select compartment for mouse events where press and release are at the same position
  - resolves https://github.com/spatial-model-editor/spatial-model-editor/issues/1035