### PR TITLE
Fix crash on compartment re-assignment after color change

### DIFF
--- a/ci/gui-cli-Windows.sh
+++ b/ci/gui-cli-Windows.sh
@@ -4,7 +4,7 @@
 
 set -e -x
 
-PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.12.*)
+PYDIR=$(ls -d /c/hostedtoolcache/windows/Python/3.13.*)
 export PATH="$PYDIR/x64:$PYDIR/x64/Scripts:$PATH"
 echo "PATH=$PATH"
 
@@ -32,6 +32,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER_LAUNCHER=$CMAKE_CXX_COMPILER_LAUNCHER \
     -DSME_LOG_LEVEL=OFF \
     -DSME_EXTRA_CORE_DEFS=$SME_EXTRA_CORE_DEFS \
+    -DPython_ROOT_DIR=$PYDIR \
     -DFREETYPE_LIBRARY_RELEASE=/c/smelibs/lib/libQt6BundledFreetype.a \
     -DFREETYPE_INCLUDE_DIR_freetype2=/c/smelibs/include/QtFreetype \
     -DFREETYPE_INCLUDE_DIR_ft2build=/c/smelibs/include/QtFreetype
@@ -39,7 +40,7 @@ ninja -v
 ccache -s -v
 
 # check dependencies
-objdump.exe -x sme/sme.cp312-win_amd64.pyd >sme_obj.txt
+objdump.exe -x sme/sme.cp313-win_amd64.pyd >sme_obj.txt
 head -n 20 sme_obj.txt
 head -n 1000 sme_obj.txt | grep "DLL Name"
 
@@ -50,7 +51,7 @@ tail -n 100 tests.txt
 
 # python tests
 cd ..
-mv build/sme/sme.cp312-win_amd64.pyd .
+mv build/sme/sme.cp313-win_amd64.pyd .
 python -m pip install -r sme/requirements-test.txt
 python -m pytest sme/test -v
 

--- a/core/model/include/sme/model_membranes.hpp
+++ b/core/model/include/sme/model_membranes.hpp
@@ -45,6 +45,7 @@ public:
   void updateCompartments(
       const std::vector<std::unique_ptr<geometry::Compartment>> &compartments);
   void updateCompartmentImages(const common::ImageStack &imgs);
+  void updateGeometryImageColour(QRgb oldColour, QRgb newColour);
   void importMembraneIdsAndNames();
   void exportToSBML(const common::VolumeF &voxelSize);
   explicit ModelMembranes(libsbml::Model *model = nullptr);

--- a/core/model/include/sme/model_membranes_util.hpp
+++ b/core/model/include/sme/model_membranes_util.hpp
@@ -55,6 +55,7 @@ public:
   ~ImageMembranePixels();
   void setImages(const common::ImageStack &imgs);
   [[nodiscard]] int getColourIndex(QRgb colour) const;
+  void updateColour(QRgb oldColour, QRgb newColour);
   [[nodiscard]] const std::vector<VoxelPair> *getVoxels(int iA, int iB) const;
   [[nodiscard]] const common::Volume &getImageSize() const;
 };

--- a/core/model/src/model_geometry.cpp
+++ b/core/model/src/model_geometry.cpp
@@ -492,6 +492,8 @@ void ModelGeometry::updateGeometryImageColor(QRgb oldColour, QRgb newColour) {
   images.setColor(colorIndex, newColour);
   sbmlAnnotation->sampledFieldColours = common::toStdVec(images.colorTable());
   modelCompartments->updateGeometryImageColor(oldColour, newColour);
+  modelMembranes->updateGeometryImageColour(oldColour, newColour);
+  modelMembranes->updateCompartments(modelCompartments->getCompartments());
   if (mesh3d != nullptr) {
     mesh3d->setColors(common::toStdVec(modelCompartments->getColours()));
   }

--- a/core/model/src/model_geometry_t.cpp
+++ b/core/model/src/model_geometry_t.cpp
@@ -144,6 +144,18 @@ TEST_CASE("Model geometry",
       // none of the above should have had any effect
       REQUIRE(m.getGeometry().getHasUnsavedChanges() == false);
     }
+    SECTION("change image color and re-assign compartment (#1038)") {
+      auto cols{m.getCompartments().getColours()};
+      auto newCol1 = qRgb(211, 12, 77);
+      REQUIRE(m.getCompartments().getColours()[1] == cols[1]);
+      m.getGeometry().updateGeometryImageColor(cols[1], newCol1);
+      REQUIRE(m.getCompartments().getColours()[1] == newCol1);
+      auto compIds = m.getCompartments().getIds();
+      m.getCompartments().setColour(compIds[0], newCol1);
+      m.getCompartments().setColour(compIds[1], cols[0]);
+      REQUIRE(m.getCompartments().getColours()[0] == newCol1);
+      REQUIRE(m.getCompartments().getColours()[1] == cols[0]);
+    }
     SECTION("update geometry image colours") {
       REQUIRE(m.getGeometry().getHasUnsavedChanges() == false);
       auto c3 = qRgb(255, 255, 255);

--- a/core/model/src/model_membranes.cpp
+++ b/core/model/src/model_membranes.cpp
@@ -140,6 +140,18 @@ void ModelMembranes::updateCompartmentImages(const common::ImageStack &imgs) {
   membranePixels = std::make_unique<ImageMembranePixels>(imgs);
 }
 
+void ModelMembranes::updateGeometryImageColour(QRgb oldColour, QRgb newColour) {
+  for (auto &idColourPair : idColourPairs) {
+    if (idColourPair.second.first == oldColour) {
+      idColourPair.second.first = newColour;
+    }
+    if (idColourPair.second.second == oldColour) {
+      idColourPair.second.second = newColour;
+    }
+  }
+  membranePixels->updateColour(oldColour, newColour);
+}
+
 void ModelMembranes::importMembraneIdsAndNames() {
   if (sbmlModel == nullptr) {
     return;

--- a/core/model/src/model_membranes_util.cpp
+++ b/core/model/src/model_membranes_util.cpp
@@ -137,6 +137,14 @@ int ImageMembranePixels::getColourIndex(QRgb colour) const {
   return -1;
 }
 
+void ImageMembranePixels::updateColour(QRgb oldColour, QRgb newColour) {
+  for (auto &colour : colours) {
+    if (colour == oldColour) {
+      colour = newColour;
+    }
+  }
+}
+
 const std::vector<VoxelPair> *ImageMembranePixels::getVoxels(int iA,
                                                              int iB) const {
   if (auto i = colourIndexPairIndex.find(iA, iB); i.has_value()) {


### PR DESCRIPTION
- update the colours stored in ModelMembranes and ImageMembranePixels when a colour in the image is changed
- resolves #1038
