### PR TITLE
Improve CGAL meshing segfault issue

### DIFF
--- a/core/mesh/src/mesh3d.cpp
+++ b/core/mesh/src/mesh3d.cpp
@@ -251,6 +251,16 @@ void Mesh3d::setCompartmentMaxCellVolume(std::size_t compartmentIndex,
     SPDLOG_INFO("  -> max cell volume unchanged");
     return;
   }
+  // ensure maxCellVolume values for each compartment do not differ by more than
+  // a factor 2 from each other, as this can lead to CGAL segfaults
+  constexpr std::size_t maxRelDiff{2};
+  for (auto &cellVolume : compartmentMaxCellVolume_) {
+    if (cellVolume * maxRelDiff < maxCellVolume) {
+      cellVolume = static_cast<std::size_t>(maxCellVolume / maxRelDiff);
+    } else if (cellVolume > maxRelDiff * maxCellVolume) {
+      cellVolume = maxRelDiff * maxCellVolume;
+    }
+  }
   currentMaxCellVolume = maxCellVolume;
   constructMesh();
 }

--- a/gui/tabs/tabgeometry.ui
+++ b/gui/tabs/tabgeometry.ui
@@ -574,7 +574,7 @@
                  <item row="1" column="2">
                   <widget class="QSpinBox" name="spinMaxCellVolume">
                    <property name="minimum">
-                    <number>1</number>
+                    <number>4</number>
                    </property>
                    <property name="maximum">
                     <number>999999</number>


### PR DESCRIPTION
- when a compartment max cell volume is modified
  - ensure that all other compartment max cell volumes are adjusted to lie within a factor 2
  - a large discrepancy in this value between compartments can lead to a CGAL segfault
- increase lowest allowed max cell volume to 4
  - this is small enough to produce a fine mesh at the ~voxel level of detail
  - even smaller values
    - result in huge meshes which are unlikely to be practical to simulate
    - have an increased risk of CGAL segfaults
- these changes doesn't guarantee CGAL won't segfault, but hopefully this is good enough in practice
- add 3d meshing tests with many different pairs of max cell volume values
- resolves #1037
