### PR TITLE
Synchronise cameras between Mesh and Voxel render views

### DIFF
--- a/core/common/include/sme/image_stack.hpp
+++ b/core/common/include/sme/image_stack.hpp
@@ -15,6 +15,7 @@ class ImageStack {
 private:
   std::vector<QImage> imgs{};
   Volume sz{0, 0, 0};
+  VolumeF voxel{1.0, 1.0, 1.0};
 
 public:
   ImageStack();
@@ -42,6 +43,12 @@ public:
   [[nodiscard]] inline bool empty() const { return imgs.empty(); }
   [[nodiscard]] QList<QRgb> colorTable() const;
   [[nodiscard]] inline const Volume &volume() const noexcept { return sz; }
+  [[nodiscard]] inline const VolumeF &voxelSize() const noexcept {
+    return voxel;
+  }
+  inline void setVoxelSize(const VolumeF &voxelSize) noexcept {
+    voxel = voxelSize;
+  }
   inline std::vector<QImage>::iterator begin() noexcept { return imgs.begin(); }
   [[nodiscard]] inline std::vector<QImage>::const_iterator
   begin() const noexcept {

--- a/core/mesh/src/mesh2d.cpp
+++ b/core/mesh/src/mesh2d.cpp
@@ -251,10 +251,12 @@ Mesh2d::getBoundariesImages(const QSize &size,
       {static_cast<int>(scaleFactor.x() * img.width() + 2 * offset.x()),
        static_cast<int>(scaleFactor.y() * img.height() + 2 * offset.y()), 1},
       QImage::Format_ARGB32_Premultiplied);
+  boundaryImage.setVoxelSize({pixel.width(), pixel.height(), 1.0});
   boundaryImage.fill(qRgba(0, 0, 0, 0));
 
   common::ImageStack maskImage(boundaryImage.volume(),
                                QImage::Format_ARGB32_Premultiplied);
+  maskImage.setVoxelSize({pixel.width(), pixel.height(), 1.0});
   maskImage.fill(qRgb(255, 255, 255));
 
   constexpr std::size_t zindex{0};
@@ -304,12 +306,14 @@ Mesh2d::getMeshImages(const QSize &size, std::size_t compartmentIndex) const {
       {static_cast<int>(scaleFactor.x() * img.width() + 2 * offset.x()),
        static_cast<int>(scaleFactor.y() * img.height() + 2 * offset.y()), 1},
       QImage::Format_ARGB32_Premultiplied);
+  meshImage.setVoxelSize({pixel.width(), pixel.height(), 1.0});
   meshImage.fill(0);
   // construct mask image
   constexpr std::size_t zindex{0};
   QPainter p(&meshImage[zindex]);
   p.setRenderHint(QPainter::Antialiasing);
   maskImage = common::ImageStack(meshImage.volume(), QImage::Format_RGB32);
+  maskImage.setVoxelSize({pixel.width(), pixel.height(), 1.0});
   maskImage.fill(qRgb(255, 255, 255));
   QPainter pMask(&maskImage[zindex]);
   // draw triangles

--- a/core/mesh/src/mesh3d.cpp
+++ b/core/mesh/src/mesh3d.cpp
@@ -331,9 +331,6 @@ Mesh3d::getTetrahedronIndices() const {
 
 QString Mesh3d::getGMSH() const {
   // note: gmsh indexing starts with 1, so we need to add 1 to all indices
-  // meshing is done in terms of voxel geometry, to convert to physical points:
-  //   - rescale each vertex by a factor pixel
-  //   - add origin to each vertex
   QString msh;
   msh.append("$MeshFormat\n");
   msh.append("2.2 0 8\n");

--- a/core/mesh/src/mesh3d_t.cpp
+++ b/core/mesh/src/mesh3d_t.cpp
@@ -541,7 +541,7 @@ TEST_CASE("Mesh3d more complex geometries",
 }
 
 TEST_CASE("Mesh3d max cell volume",
-          "[core/mesh/mesh3d][core/mesh][core][mesh3d][expensive][Q]") {
+          "[core/mesh/mesh3d][core/mesh][core][mesh3d][expensive]") {
   for (const auto model :
        {sme::test::Mod::VerySimpleModel3D, sme::test::Mod::SelKov3D,
         sme::test::Mod::FitzhughNagumo3D}) {

--- a/core/model/src/geometry.cpp
+++ b/core/model/src/geometry.cpp
@@ -20,6 +20,7 @@ Compartment::Compartment(std::string compId, const common::ImageStack &imgs,
     return;
   }
   images = common::ImageStack(imgs.volume(), QImage::Format_Mono);
+  images.setVoxelSize(imgs.voxelSize());
   int nx{images.volume().width()};
   int ny{images.volume().height()};
   int nz{static_cast<int>(images.volume().depth())};
@@ -115,6 +116,7 @@ Membrane::Membrane(std::string membraneId, const Compartment *A,
     : id{std::move(membraneId)}, compA{A}, compB{B} {
   const auto &imageSize{A->getImageSize()};
   images = {imageSize, QImage::Format_ARGB32_Premultiplied};
+  images.setVoxelSize(A->getCompartmentImages().voxelSize());
   SPDLOG_INFO("membraneID: {}", id);
   SPDLOG_INFO("compartment A: {}", compA->getId());
   QRgb colA = A->getColour();
@@ -246,6 +248,7 @@ void Field::setUniformConcentration(double concentration) {
 common::ImageStack Field::getConcentrationImages() const {
   common::ImageStack images{comp->getImageSize(),
                             QImage::Format_ARGB32_Premultiplied};
+  images.setVoxelSize(comp->getCompartmentImages().voxelSize());
   images.fill(0);
   // for now rescale conc to [0,1] to multiply species colour
   double cmax{common::max(conc)};

--- a/core/model/src/model_geometry.cpp
+++ b/core/model/src/model_geometry.cpp
@@ -247,6 +247,7 @@ void ModelGeometry::importSampledFieldGeometry(const libsbml::Model *model) {
   hasImage = true;
   sbmlAnnotation->sampledFieldColours = common::toStdVec(images.colorTable());
   voxelSize = calculateVoxelSize(images.volume(), physicalSize);
+  images.setVoxelSize(voxelSize);
   modelMembranes->updateCompartmentImages(images);
   for (const auto &[id, colour] : gsf.compartmentIdColourPairs) {
     SPDLOG_INFO("setting compartment {} colour to {:x}", id, colour);
@@ -272,6 +273,7 @@ void ModelGeometry::importGeometryFromImages(const common::ImageStack &imgs,
   }
   images = common::ImageStack{imgs};
   images.convertToIndexed();
+  images.setVoxelSize(voxelSize);
   sbmlAnnotation->sampledFieldColours = common::toStdVec(images.colorTable());
   modelMembranes->updateCompartmentImages(images);
   auto *geom{getOrCreateGeometry(sbmlModel)};
@@ -371,11 +373,12 @@ int ModelGeometry::getNumDimensions() const { return numDimensions; }
 
 void ModelGeometry::setVoxelSize(const common::VolumeF &newVoxelSize,
                                  bool updateSBML) {
-  SPDLOG_INFO("Setting pixel volume to {}x{}x{}", newVoxelSize.width(),
+  SPDLOG_INFO("Setting voxel size to {}x{}x{}", newVoxelSize.width(),
               newVoxelSize.height(), newVoxelSize.depth());
   hasUnsavedChanges = true;
   auto oldVoxelSize{voxelSize};
   voxelSize = newVoxelSize;
+  images.setVoxelSize(voxelSize);
 
   // update origin
   physicalOrigin.p.rx() *= voxelSize.width() / oldVoxelSize.width();

--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -498,6 +498,7 @@ common::ImageStack Simulation::getConcImage(
     }
   }
   common::ImageStack imgs(imageSize, QImage::Format_ARGB32_Premultiplied);
+  imgs.setVoxelSize(model.getGeometry().getVoxelSize());
   imgs.fill(0);
   // iterate over compartments
   for (std::size_t ic = 0; ic < compartments.size(); ++ic) {

--- a/gui/dialogs/dialoganalytic.cpp
+++ b/gui/dialogs/dialoganalytic.cpp
@@ -29,6 +29,7 @@ DialogAnalytic::DialogAnalytic(
   lengthUnit = units.getLength().name;
   concentrationUnit =
       QString("%1/%2").arg(units.getAmount().name).arg(units.getVolume().name);
+  imgs.setVoxelSize(speciesGeometry.voxelSize);
   imgs.fill(0);
   concentration.resize(voxels.size(), 0.0);
   // add x,y,z variables
@@ -44,11 +45,9 @@ DialogAnalytic::DialogAnalytic(
   }
   // todo: add non-constant parameters somewhere?
   ui->txtExpression->setConstants(modelParameters.getGlobalConstants());
-  sme::common::VolumeF physicalSize{speciesGeometry.compartmentImageSize *
-                                    speciesGeometry.voxelSize};
   ui->lblImage->displayGrid(ui->chkGrid->isChecked());
   ui->lblImage->displayScale(ui->chkScale->isChecked());
-  ui->lblImage->setPhysicalSize(physicalSize, lengthUnit);
+  ui->lblImage->setPhysicalUnits(lengthUnit);
   ui->lblImage->invertYAxis(invertYAxis);
   ui->lblImage->setZSlider(ui->slideZIndex);
 

--- a/gui/dialogs/dialogconcentrationimage.cpp
+++ b/gui/dialogs/dialogconcentrationimage.cpp
@@ -45,15 +45,13 @@ DialogConcentrationImage::DialogConcentrationImage(
   }
   ui->lblMinConcUnits->setText(quantityUnit);
   ui->lblMaxConcUnits->setText(quantityUnit);
+  imgs.setVoxelSize(speciesGeometry.voxelSize);
   imgs.fill(0);
 
   ui->lblImage->displayGrid(ui->chkGrid->isChecked());
   ui->lblImage->displayScale(ui->chkScale->isChecked());
   ui->lblImage->invertYAxis(invertYAxis);
-  sme::common::VolumeF physicalSize{speciesGeometry.compartmentImageSize *
-                                    speciesGeometry.voxelSize};
-  ui->lblImage->setPhysicalSize(physicalSize, lengthUnit);
-
+  ui->lblImage->setPhysicalUnits(lengthUnit);
   if (concentrationArray.empty()) {
     SPDLOG_DEBUG("empty initial concentrationArray - "
                  "setting concentration to zero everywhere");

--- a/gui/dialogs/dialoggeometryimage.cpp
+++ b/gui/dialogs/dialoggeometryimage.cpp
@@ -102,7 +102,7 @@ void DialogGeometryImage::updateVoxelSize() {
       sme::model::rescale(volumeLocalUnits, localUnit, modelUnit)};
   // Physical voxel volume in model units
   voxelModelUnits = volumeModelUnits / rescaledImage.volume();
-  ui->lblImage->setPhysicalSize(volumeModelUnits, modelUnit.name);
+  ui->lblImage->setPhysicalUnits(modelUnit.name);
   ui->lblPixelSize->setText(QString("%1 %4 x %2 %4 x %3 %4")
                                 .arg(voxelModelUnits.width())
                                 .arg(voxelModelUnits.height())

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -59,8 +59,7 @@ DialogOptimize::DialogOptimize(sme::model::Model &model, QWidget *parent)
     lbl->invertYAxis(model.getDisplayOptions().invertYAxis);
     lbl->displayScale(model.getDisplayOptions().showGeometryScale);
     lbl->displayGrid(model.getDisplayOptions().showGeometryGrid);
-    lbl->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                         model.getUnits().getLength().name);
+    lbl->setPhysicalUnits(model.getUnits().getLength().name);
   }
   connect(ui->cmbTarget, &QComboBox::currentIndexChanged, this,
           &DialogOptimize::cmbTarget_currentIndexChanged);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -347,10 +347,7 @@ void MainWindow::validateSBMLDoc(const QString &filename) {
 
 void MainWindow::enableTabs() {
   bool enable{model.getIsValid() && model.getGeometry().getIsValid()};
-  if (model.getIsValid() && model.getGeometry().getHasImage()) {
-    ui->lblGeometry->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                     model.getUnits().getLength().name);
-  }
+  ui->lblGeometry->setPhysicalUnits(model.getUnits().getLength().name);
   for (int i = 1; i < ui->tabMain->count(); ++i) {
     ui->tabMain->setTabEnabled(i, enable);
   }
@@ -632,7 +629,7 @@ void MainWindow::actionGeometry_scale_triggered(bool checked) {
 void MainWindow::action3d_render_triggered(bool checked) {
   if (checked) {
     ui->stackGeometry->setCurrentIndex(1);
-    ui->voxGeometry->setImage(ui->lblGeometry->getImage());
+    ui->voxGeometry->setImage(model.getGeometry().getImages());
     return;
   }
   ui->stackGeometry->setCurrentIndex(0);

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -90,6 +90,7 @@ TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
           &TabGeometry::listCompartments_itemDoubleClicked);
   connect(ui->listMembranes, &QListWidget::itemSelectionChanged, this,
           &TabGeometry::listMembranes_itemSelectionChanged);
+  ui->mshCompMesh->syncCamera(voxGeometry);
 }
 
 TabGeometry::~TabGeometry() = default;
@@ -115,9 +116,8 @@ void TabGeometry::loadModelData(const QString &selection) {
     ui->btnChangeCompartment->setEnabled(true);
   }
   lblGeometry->setImage(model.getGeometry().getImages());
+  lblGeometry->setPhysicalUnits(model.getUnits().getLength().name);
   voxGeometry->setImage(model.getGeometry().getImages());
-  lblGeometry->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                               model.getUnits().getLength().name);
   enableTabs();
   selectMatchingOrFirstItem(ui->listCompartments, selection);
 }
@@ -354,8 +354,7 @@ void TabGeometry::spinBoundaryIndex_valueChanged(int value) {
   ui->lblCompBoundary->setImages(
       model.getGeometry().getMesh2d()->getBoundariesImages(size,
                                                            boundaryIndex));
-  ui->lblCompBoundary->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                       model.getUnits().getLength().name);
+  ui->lblCompBoundary->setPhysicalUnits(model.getUnits().getLength().name);
   QGuiApplication::restoreOverrideCursor();
 }
 
@@ -368,8 +367,7 @@ void TabGeometry::spinMaxBoundaryPoints_valueChanged(int value) {
   ui->lblCompBoundary->setImages(
       model.getGeometry().getMesh2d()->getBoundariesImages(size,
                                                            boundaryIndex));
-  ui->lblCompBoundary->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                       model.getUnits().getLength().name);
+  ui->lblCompBoundary->setPhysicalUnits(model.getUnits().getLength().name);
   QGuiApplication::restoreOverrideCursor();
 }
 
@@ -457,8 +455,7 @@ void TabGeometry::updateMesh2d() {
   auto compIndex = static_cast<std::size_t>(ui->listCompartments->currentRow());
   ui->lblCompMesh->setImages(
       mesh2d->getMeshImages(ui->lblCompMesh->size(), compIndex));
-  ui->lblCompMesh->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                   model.getUnits().getLength().name);
+  ui->lblCompMesh->setPhysicalUnits(model.getUnits().getLength().name);
 }
 
 void TabGeometry::spinMaxCellVolume_valueChanged(int value) {
@@ -537,8 +534,6 @@ void TabGeometry::listCompartments_itemSelectionChanged() {
     // update image of compartment
     const auto *comp{model.getCompartments().getCompartment(compId)};
     ui->lblCompShape->setImage(comp->getCompartmentImages());
-    ui->lblCompShape->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                      model.getUnits().getLength().name);
     ui->lblCompShape->setText("");
     // update mesh or boundary image if tab is currently visible
     updateBoundaries();
@@ -586,8 +581,7 @@ void TabGeometry::listMembranes_itemSelectionChanged() {
   // update image
   const auto *m{model.getMembranes().getMembrane(membraneId)};
   ui->lblCompShape->setImage(m->getImages());
-  ui->lblCompShape->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                    model.getUnits().getLength().name);
+  ui->lblCompShape->setPhysicalUnits(model.getUnits().getLength().name);
   auto nVoxelPairs{m->getIndexPairs(sme::geometry::Membrane::X).size() +
                    m->getIndexPairs(sme::geometry::Membrane::Y).size() +
                    m->getIndexPairs(sme::geometry::Membrane::Z).size()};
@@ -607,7 +601,6 @@ void TabGeometry::listMembranes_itemSelectionChanged() {
     ui->lblCompMesh->setImages(mesh->getMeshImages(
         ui->lblCompMesh->size(),
         static_cast<std::size_t>(currentRow + ui->listCompartments->count())));
-    ui->lblCompMesh->setPhysicalSize(model.getGeometry().getPhysicalSize(),
-                                     model.getUnits().getLength().name);
+    ui->lblCompMesh->setPhysicalUnits(model.getUnits().getLength().name);
   }
 }

--- a/gui/widgets/CMakeLists.txt
+++ b/gui/widgets/CMakeLists.txt
@@ -17,5 +17,6 @@ if(BUILD_TESTING)
            qlabelmousetracker_t.cpp
            qplaintextmathedit_t.cpp
            qmeshrenderer_t.cpp
-           qvoxelrenderer_t.cpp)
+           qvoxelrenderer_t.cpp
+           smevtkwidget_t.cpp)
 endif()

--- a/gui/widgets/qlabelmousetracker.cpp
+++ b/gui/widgets/qlabelmousetracker.cpp
@@ -30,6 +30,7 @@ void QLabelMouseTracker::setImage(const sme::common::ImageStack &img) {
     zSlider->setMinimum(0);
     zSlider->setMaximum(static_cast<int>(image.volume().depth()) - 1);
   }
+  physicalSize = image.voxelSize() * image.volume();
   resizeImage(this->size());
   setCurrentPixel(mapFromGlobal(QCursor::pos()));
 }
@@ -291,11 +292,8 @@ void QLabelMouseTracker::setTransformationMode(Qt::TransformationMode mode) {
   resizeImage(size());
 }
 
-void QLabelMouseTracker::setPhysicalSize(const sme::common::VolumeF &size,
-                                         const QString &units) {
-  physicalSize = size;
+void QLabelMouseTracker::setPhysicalUnits(const QString &units) {
   lengthUnits = units;
-  resizeImage(this->size());
 }
 
 void QLabelMouseTracker::displayGrid(bool enable) {

--- a/gui/widgets/qlabelmousetracker.hpp
+++ b/gui/widgets/qlabelmousetracker.hpp
@@ -38,7 +38,7 @@ public:
   [[nodiscard]] QPointF getRelativePosition() const;
   void setAspectRatioMode(Qt::AspectRatioMode aspectRatioMode);
   void setTransformationMode(Qt::TransformationMode transformationMode);
-  void setPhysicalSize(const sme::common::VolumeF &size, const QString &units);
+  void setPhysicalUnits(const QString &units);
   void displayGrid(bool enable);
   void displayScale(bool enable);
   void invertYAxis(bool enable);

--- a/gui/widgets/qlabelmousetracker_t.cpp
+++ b/gui/widgets/qlabelmousetracker_t.cpp
@@ -66,7 +66,8 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
   img.setPixel(0, 1, col3);
   img.setPixel(0, 2, col3);
   img.setPixel(1, 1, col4);
-  mouseTracker.setImage(sme::common::ImageStack{{img}});
+  auto imageStack = sme::common::ImageStack{{img}};
+  mouseTracker.setImage(imageStack);
   mouseTracker.show();
   mouseTracker.resize(100, 100);
   wait();
@@ -165,14 +166,16 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
   SECTION("Resize physical volume") {
     // 100px x 100px mousetracker widget size:
     // 1:1 aspect ratio physical size
-    mouseTracker.setPhysicalSize({0.77, 0.77, 0.77}, "");
+    imageStack.setVoxelSize({0.77, 0.77, 0.77});
+    mouseTracker.setImage(imageStack);
     // click on middle (1,1) pixel
     sendMouseClick(&mouseTracker, QPoint(50, 50));
     REQUIRE(clicks.size() == 1);
     REQUIRE(clicks.back() == col4);
     REQUIRE(mouseTracker.getColour() == col4);
     // 2:1 aspect ratio physical size
-    mouseTracker.setPhysicalSize({2.0, 1.0, 1.0}, "");
+    imageStack.setVoxelSize({2.0, 1.0, 1.0});
+    mouseTracker.setImage(imageStack);
     // click outside geometry
     sendMouseClick(&mouseTracker, QPoint(50, 52));
     REQUIRE(clicks.size() == 1);
@@ -182,7 +185,8 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
     REQUIRE(clicks.back() == col4);
     REQUIRE(mouseTracker.getColour() == col4);
     // 5:1 aspect ratio physical size
-    mouseTracker.setPhysicalSize({50.0, 10.0, 1.0}, "");
+    imageStack.setVoxelSize({50.0, 10.0, 1.0});
+    mouseTracker.setImage(imageStack);
     // click outside geometry
     sendMouseClick(&mouseTracker, QPoint(50, 22));
     REQUIRE(clicks.size() == 2);
@@ -192,7 +196,8 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
     REQUIRE(clicks.back() == col4);
     REQUIRE(mouseTracker.getColour() == col4);
     // 1:3 aspect ratio physical size
-    mouseTracker.setPhysicalSize({3.0, 9.0, 1.0}, "");
+    imageStack.setVoxelSize({3.0, 9.0, 1.0});
+    mouseTracker.setImage(imageStack);
     // click outside geometry
     sendMouseClick(&mouseTracker, QPoint(35, 50));
     REQUIRE(clicks.size() == 3);
@@ -203,7 +208,8 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
     REQUIRE(mouseTracker.getColour() == col4);
     // 1:100000 aspect ratio physical size: display width clipped to single
     // pixel
-    mouseTracker.setPhysicalSize({1.0, 100000.0, 1.0}, "");
+    imageStack.setVoxelSize({1.0, 100000.0, 1.0});
+    mouseTracker.setImage(imageStack);
     // click outside geometry
     sendMouseClick(&mouseTracker, QPoint(3, 50));
     REQUIRE(clicks.size() == 4);
@@ -212,7 +218,8 @@ TEST_CASE("QLabelMouseTracker: 3x3 pixel, 4 colour image", tags) {
     REQUIRE(clicks.size() == 5);
     // 100000:1 aspect ratio physical size: display height clipped to single
     // pixel
-    mouseTracker.setPhysicalSize({100000.0, 1.0, 1.0}, "");
+    imageStack.setVoxelSize({100000.0, 1.0, 1.0});
+    mouseTracker.setImage(imageStack);
     // click outside geometry
     sendMouseClick(&mouseTracker, QPoint(50, 3));
     REQUIRE(clicks.size() == 5);

--- a/gui/widgets/qmeshrenderer_t.cpp
+++ b/gui/widgets/qmeshrenderer_t.cpp
@@ -2,12 +2,11 @@
 #include "model_test_utils.hpp"
 #include "qmeshrenderer.hpp"
 #include "qt_test_utils.hpp"
-#include "sme/image_stack.hpp"
 
 using namespace sme::test;
 
 // set to e.g. 1000 to interactively inspect the rendering
-constexpr int delay_ms{1000};
+constexpr int delay_ms{0};
 
 TEST_CASE("QMeshRenderer",
           "[qmeshrenderer][gui/widgets/qmeshrenderer][gui/widgets][gui]") {

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -16,7 +16,6 @@ class QVoxelRenderer : public SmeVtkWidget {
 public:
   explicit QVoxelRenderer(QWidget *parent = nullptr);
   void setImage(const sme::common::ImageStack &img);
-  void setPhysicalSize(const sme::common::VolumeF &size, const QString &units);
 
 signals:
   void mouseClicked(QRgb col, sme::common::Voxel voxel);
@@ -26,7 +25,6 @@ protected:
 
 private:
   vtkNew<vtkVolume> volume;
-  vtkNew<vtkVolumeProperty> volumeProperty;
   vtkNew<vtkGPUVolumeRayCastMapper> volumeMapper;
   vtkNew<vtkPiecewiseFunction> opacityTransferFunction;
   vtkNew<vtkImageData> imageData;

--- a/gui/widgets/qvoxelrenderer_t.cpp
+++ b/gui/widgets/qvoxelrenderer_t.cpp
@@ -6,7 +6,7 @@
 
 using namespace sme::test;
 
-// set to e.g. 10000 to interactively inspect the rendering of each ImageStack
+// set to e.g. 1000 to interactively inspect the rendering
 constexpr int delay_ms{0};
 
 TEST_CASE("QVoxelRenderer",
@@ -67,11 +67,9 @@ TEST_CASE("QVoxelRenderer",
     }
     voxelRenderer.setImage(imageStack);
     wait(delay_ms);
-    // set physical size that maintains existing cubic voxels
-    voxelRenderer.setPhysicalSize({20.0, 47.0, 10.0}, "units");
-    wait(delay_ms);
     // set physical size that makes z-slices 5x thicker
-    voxelRenderer.setPhysicalSize({20.0, 47.0, 50.0}, "units");
+    imageStack.setVoxelSize({1.0, 1.0, 5.0});
+    voxelRenderer.setImage(imageStack);
     wait(delay_ms);
   }
   SECTION("100x100x1 geometry image") {
@@ -80,5 +78,11 @@ TEST_CASE("QVoxelRenderer",
     REQUIRE(imageStack.volume() == sme::common::Volume{100, 100, 1});
     voxelRenderer.setImage(imageStack);
     wait(delay_ms);
+    // changing the voxel size shouldn't change the rendered opacity
+    for (double x : {1.0, 0.1, 0.01, 0.001}) {
+      imageStack.setVoxelSize({x, x, x});
+      voxelRenderer.setImage(imageStack);
+      wait(delay_ms);
+    }
   }
 }

--- a/gui/widgets/smevtkwidget.cpp
+++ b/gui/widgets/smevtkwidget.cpp
@@ -1,4 +1,5 @@
 #include "smevtkwidget.hpp"
+#include "sme/logger.hpp"
 #include <vtkCamera.h>
 
 SmeVtkWidget::SmeVtkWidget(QWidget *parent) : QVTKOpenGLNativeWidget(parent) {
@@ -20,4 +21,22 @@ SmeVtkWidget::SmeVtkWidget(QWidget *parent) : QVTKOpenGLNativeWidget(parent) {
   }();
   renderer->GetActiveCamera()->Azimuth(45);
   renderer->GetActiveCamera()->Elevation(30);
+}
+
+void SmeVtkWidget::syncCamera(SmeVtkWidget *smeVtkWidget) {
+  if (renderer->GetActiveCamera() ==
+      smeVtkWidget->renderer->GetActiveCamera()) {
+    SPDLOG_TRACE("Camera is already synced with this widget");
+    return;
+  }
+  SPDLOG_TRACE("Syncing camera with supplied SmeVtkWidget");
+  renderer->SetActiveCamera(smeVtkWidget->renderer->GetActiveCamera());
+  renderOnInteractorModified(smeVtkWidget->renderWindow.Get()->GetInteractor());
+  smeVtkWidget->renderOnInteractorModified(renderWindow->GetInteractor());
+}
+
+void SmeVtkWidget::renderOnInteractorModified(
+    vtkRenderWindowInteractor *interactor) {
+  interactor->AddObserver(vtkCommand::ModifiedEvent, renderWindow.Get(),
+                          &vtkGenericOpenGLRenderWindow::Render);
 }

--- a/gui/widgets/smevtkwidget.hpp
+++ b/gui/widgets/smevtkwidget.hpp
@@ -10,10 +10,16 @@
 
 class SmeVtkWidget : public QVTKOpenGLNativeWidget {
   Q_OBJECT
-protected:
+public:
   explicit SmeVtkWidget(QWidget *parent = nullptr);
+  void syncCamera(SmeVtkWidget *smeVtkWidget);
+
+protected:
   vtkNew<vtkRenderer> renderer;
   vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
   vtkNew<vtkAxesActor> axesActor;
   vtkNew<vtkOrientationMarkerWidget> axesWidget;
+
+private:
+  void renderOnInteractorModified(vtkRenderWindowInteractor *interactor);
 };

--- a/gui/widgets/smevtkwidget_t.cpp
+++ b/gui/widgets/smevtkwidget_t.cpp
@@ -1,0 +1,45 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "qmeshrenderer.hpp"
+#include "qt_test_utils.hpp"
+#include "qvoxelrenderer.hpp"
+#include "smevtkwidget.hpp"
+
+using namespace sme::test;
+
+// set to e.g. 1000 to interactively inspect the rendering
+constexpr int delay_ms{0};
+
+TEST_CASE("SmeVtkWidget",
+          "[smevtkwidget][gui/widgets/smevtkwidget][gui/widgets][gui]") {
+  QMeshRenderer meshRenderer;
+  meshRenderer.show();
+  meshRenderer.resize(200, 200);
+  QVoxelRenderer voxelRenderer;
+  voxelRenderer.show();
+  voxelRenderer.resize(200, 200);
+  auto model = sme::test::getExampleModel(Mod::VerySimpleModel3D);
+  meshRenderer.setMesh(*model.getGeometry().getMesh3d(), 0);
+  voxelRenderer.setImage(model.getGeometry().getImages());
+  wait(delay_ms);
+  // mouse interactions with two independent SmeVtkWidgets
+  sendMouseDrag(&meshRenderer, {100, 100}, {120, 120});
+  wait(delay_ms);
+  sendMouseDrag(&voxelRenderer, {110, 120}, {80, 90});
+  wait(delay_ms);
+  meshRenderer.syncCamera(&voxelRenderer);
+  // mouse interactions with two synced SmeVtkWidgets
+  sendMouseDrag(&meshRenderer, {100, 100}, {150, 150});
+  wait(delay_ms);
+  sendMouseDrag(&voxelRenderer, {160, 160}, {80, 50});
+  wait(delay_ms);
+  // change physical size of a voxel
+  model.getGeometry().setVoxelSize({1.0, 1.5, 2.0});
+  voxelRenderer.setImage(model.getGeometry().getImages());
+  meshRenderer.setMesh(*model.getGeometry().getMesh3d(), 0);
+  wait(delay_ms);
+  sendMouseDrag(&meshRenderer, {100, 100}, {150, 150});
+  wait(delay_ms);
+  sendMouseDrag(&voxelRenderer, {160, 160}, {80, 50});
+  wait(delay_ms);
+}


### PR DESCRIPTION
- add `SmeVtkWidget::syncCamera` method
  - sets the current camera for the widget to the camera of the supplied widget
  - adds observers to re-render each widget when the connected widget is interacted with
  - TabGeometry calls this on load to connect the QMeshRenderer and QVoxelRenderer cameras
  - resolves #973
- add voxelSize data to ImageStack
  - resolves #1046
- QVoxelRenderer
  - set the voxel size from the ImageStack
  - reduce opacity and remove dependence on rgb value
  - set opacity unit distance to a voxel so that the opacity is not affected by a change in voxel size
  - fix y direction in QVoxelRenderer to be consistent with QLabelMouseTracker and QMeshRenderer
  - remove setPhysicalSize, replace with setPhysicalUnits
- QMeshRenderer
  - remove setPhysicalSize