### PR TITLE
Include sme version when saving a model

### DIFF
--- a/core/model/src/model.cpp
+++ b/core/model/src/model.cpp
@@ -5,8 +5,10 @@
 #include "sme/mesh2d.hpp"
 #include "sme/mesh3d.hpp"
 #include "sme/utils.hpp"
+#include "sme/version.hpp"
 #include "sme/xml_annotation.hpp"
 #include "validation.hpp"
+#include <QDateTime>
 #include <QFileInfo>
 #include <algorithm>
 #include <combine/combinearchive.h>
@@ -143,7 +145,10 @@ void Model::exportSBMLFile(const std::string &filename) {
   }
   updateSBMLDoc();
   SPDLOG_INFO("Exporting SBML model to {}", filename);
-  if (!libsbml::SBMLWriter().writeSBML(doc.get(), filename)) {
+  if (QFile f(filename.c_str());
+      f.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    f.write(getXml().toUtf8());
+  } else {
     SPDLOG_ERROR("Failed to write to {}", filename);
     return;
   }
@@ -222,6 +227,11 @@ QString Model::getXml() {
   countAndPrintSBMLDocErrors(doc.get());
   common::unique_C_ptr<char> xmlChar{libsbml::writeSBMLToString(doc.get())};
   xml = QString(xmlChar.get());
+  xml.insert(
+      xml.indexOf("?>") + 2,
+      QString("\n<!-- Created by Spatial Model Editor version %1 on %2 -->")
+          .arg(common::SPATIAL_MODEL_EDITOR_VERSION)
+          .arg(QDateTime::currentDateTime().toString()));
   return xml;
 }
 

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -4,6 +4,7 @@
 #include "sme/mesh2d.hpp"
 #include "sme/model.hpp"
 #include "sme/utils.hpp"
+#include "sme/version.hpp"
 #include <sbml/SBMLTypes.h>
 #include <sbml/extension/SBMLDocumentPlugin.h>
 #include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
@@ -880,9 +881,12 @@ TEST_CASE("SBML: load multi-compartment model, change volume of geometry",
   REQUIRE(interiorPoint.x() == dbl_approx(a * 68.5));
   REQUIRE(interiorPoint.y() == dbl_approx(a * 83.5));
   // export sbml, import sbml, check all sizes preserved
-  auto xml{s.getXml().toStdString()};
+  auto xml = s.getXml();
+  REQUIRE(
+      xml.contains(QString("<!-- Created by Spatial Model Editor version %1")
+                       .arg(common::SPATIAL_MODEL_EDITOR_VERSION)));
   model::Model s2;
-  s2.importSBMLString(xml);
+  s2.importSBMLString(xml.toStdString());
   REQUIRE(s.getGeometry().getVoxelSize().width() == dbl_approx(a));
   REQUIRE(s.getGeometry().getVoxelSize().height() == dbl_approx(a));
   REQUIRE(s.getGeometry().getVoxelSize().depth() == dbl_approx(d));


### PR DESCRIPTION
- add a comment to the generated XML with the sme version and current datetime
- resolves #1049
