### PR TITLE
Render membranes between compartments in QMeshRenderer

### DIFF
--- a/core/mesh/include/sme/mesh3d.hpp
+++ b/core/mesh/include/sme/mesh3d.hpp
@@ -22,6 +22,7 @@ class Image_3;
 namespace sme::mesh {
 
 using QTetrahedronF = std::array<sme::common::VoxelF, 4>;
+using TriangleVertexIndices = std::array<std::size_t, 3>;
 using TetrahedronVertexIndices = std::array<std::size_t, 4>;
 
 class Mesh3d {
@@ -33,7 +34,10 @@ private:
   std::vector<sme::common::VoxelF> vertices_;
   std::vector<std::vector<QTetrahedronF>> tetrahedra_;
   std::vector<std::vector<TetrahedronVertexIndices>> tetrahedronVertexIndices_;
+  std::vector<std::vector<TriangleVertexIndices>>
+      membraneTriangleVertexIndices_;
   std::vector<std::uint8_t> labelToCompartmentIndex_;
+  std::vector<std::uint8_t> compartmentsToMembraneIndex_;
   bool validMesh_{false};
   std::vector<QRgb> colors_;
   std::string errorMessage_{};
@@ -50,12 +54,17 @@ public:
    * @param[in] voxelSize the physical size of a voxel
    * @param[in] originPoint the physical location of the ``(0,0,0)`` voxel
    * @param[in] compartmentColors the colors of compartments in the image
+   * @param[in] membraneIdColorPairs the ids and color-pairs of membranes in the
+   * image
    */
-  explicit Mesh3d(const sme::common::ImageStack &imageStack,
-                  std::vector<std::size_t> maxCellVolume = {},
-                  const common::VolumeF &voxelSize = {1.0, 1.0, 1.0},
-                  const common::VoxelF &originPoint = {0.0, 0.0, 0.0},
-                  std::vector<QRgb> compartmentColors = {});
+  explicit Mesh3d(
+      const sme::common::ImageStack &imageStack,
+      std::vector<std::size_t> maxCellVolume = {},
+      const common::VolumeF &voxelSize = {1.0, 1.0, 1.0},
+      const common::VoxelF &originPoint = {0.0, 0.0, 0.0},
+      const std::vector<QRgb> &compartmentColors = {},
+      const std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>>
+          &membraneIdColorPairs = {});
   ~Mesh3d();
   /**
    * @brief Returns true if the mesh is valid
@@ -110,9 +119,14 @@ public:
   [[nodiscard]] std::vector<double> getVerticesAsFlatArray() const;
   /**
    *
-   * @return number of compartments available.
+   * @return number of compartments in mesh.
    */
   [[nodiscard]] std::size_t getNumberOfCompartments() const;
+  /**
+   *
+   * @return number of membranes in mesh.
+   */
+  [[nodiscard]] std::size_t getNumberOfMembranes() const;
   /**
    * @brief The mesh tetrahedron indices as a flat array of ints
    *
@@ -129,6 +143,14 @@ public:
   [[nodiscard]] const std::vector<std::vector<TetrahedronVertexIndices>> &
   getTetrahedronIndices() const;
   /**
+   * @brief The mesh tetrahedron indices
+   *
+   * The indices of the vertices of each triangle on the boundary between
+   * compartments c1 and c2
+   */
+  [[nodiscard]] const std::vector<std::vector<TriangleVertexIndices>> &
+  getMembraneTriangleIndices() const;
+  /**
    * @brief The mesh in GMSH format
    *
    * @returns the mesh in GMSH format
@@ -136,16 +158,19 @@ public:
   [[nodiscard]] QString getGMSH() const;
 
   /**
-   * @brief Get the colors of the compartments
+   * @brief Get the colors of the compartments and membranes
    *
    */
   [[nodiscard]] const std::vector<QRgb> &getColors() const;
 
   /**
-   * @brief Set the colors of the compartments
+   * @brief Set the colors of the compartments and membranes
    *
    */
-  void setColors(std::vector<QRgb> colors);
+  void
+  setColors(const std::vector<QRgb> &compartmentColors,
+            const std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>>
+                &membraneIdColorPairs);
 
   static constexpr std::size_t dim = 3;
 };

--- a/core/mesh/src/mesh3d.cpp
+++ b/core/mesh/src/mesh3d.cpp
@@ -47,6 +47,20 @@ using CGALSizingField =
 
 namespace sme::mesh {
 
+static QRgb interpolate(QRgb c1, QRgb c2) {
+  auto hsv1 = QColor(c1).toHsv();
+  auto hsv2 = QColor(c2).toHsv();
+  // if a color is achromatic (hue of -1) use the hue of the other color
+  float hue1 = hsv1.hueF() < 0.f ? hsv2.hueF() : hsv1.hueF();
+  float hue2 = hsv2.hueF() < 0.f ? hsv1.hueF() : hsv2.hueF();
+  // if both colors are achromatic then just set hue to 0
+  float hueF = std::max(0.f, 0.5f * hue1 + 0.5f * hue2);
+  return QColor::fromHsvF(
+             hueF, 0.5f * hsv1.saturationF() + 0.5f * hsv2.hsvSaturationF(),
+             0.5f * hsv1.valueF() + 0.5f * hsv2.valueF())
+      .rgb();
+}
+
 static sme::common::VoxelF toVoxelF(CGALC3t3::Vertex_handle vertexHandle) {
   return {vertexHandle->point().x(), vertexHandle->point().y(),
           vertexHandle->point().z()};
@@ -58,6 +72,9 @@ static constexpr auto NullCompartmentIndex =
 void Mesh3d::constructMesh() {
   vertices_.clear();
   for (auto &v : tetrahedronVertexIndices_) {
+    v.clear();
+  }
+  for (auto &v : membraneTriangleVertexIndices_) {
     v.clear();
   }
   for (auto &v : tetrahedra_) {
@@ -120,6 +137,30 @@ void Mesh3d::constructMesh() {
     ++id;
   }
 
+  // extract triangles for each membrane
+  for (auto facet1 : c3t3.triangulation().finite_facets()) {
+    auto c1 = labelToCompartmentIndex_[static_cast<std::size_t>(
+        c3t3.subdomain_index(facet1.first))];
+    if (c1 != NullCompartmentIndex) {
+      auto facet2 = c3t3.triangulation().mirror_facet(facet1);
+      auto c2 = labelToCompartmentIndex_[static_cast<std::size_t>(
+          c3t3.subdomain_index(facet2.first))];
+      if (c2 != NullCompartmentIndex && c1 != c2) {
+        auto idx =
+            compartmentsToMembraneIndex_[c1 * getNumberOfCompartments() + c2];
+        if (idx != NullCompartmentIndex) {
+          membraneTriangleVertexIndices_[idx].push_back(
+              {static_cast<std::size_t>(
+                   facet1.first->vertex((facet1.second + 1) % 4)->id()),
+               static_cast<std::size_t>(
+                   facet1.first->vertex((facet1.second + 2) % 4)->id()),
+               static_cast<std::size_t>(
+                   facet1.first->vertex((facet1.second + 3) % 4)->id())});
+        }
+      }
+    }
+  }
+
   for (auto c : c3t3.triangulation().finite_cell_handles()) {
     if (auto compartmentIndex =
             labelToCompartmentIndex_[static_cast<std::size_t>(
@@ -149,9 +190,10 @@ Mesh3d::Mesh3d(const sme::common::ImageStack &imageStack,
                std::vector<std::size_t> maxCellVolume,
                const common::VolumeF &voxelSize,
                const common::VoxelF &originPoint,
-               std::vector<QRgb> compartmentColors)
-    : compartmentMaxCellVolume_(std::move(maxCellVolume)),
-      colors_(std::move(compartmentColors)) {
+               const std::vector<QRgb> &compartmentColors,
+               const std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>>
+                   &membraneIdColorPairs)
+    : compartmentMaxCellVolume_(std::move(maxCellVolume)) {
   if (imageStack.empty()) {
     errorMessage_ = "Compartment geometry image missing";
     return;
@@ -163,21 +205,41 @@ Mesh3d::Mesh3d(const sme::common::ImageStack &imageStack,
   const auto &colorTable = imageStack_.colorTable();
   SPDLOG_INFO("ImageStack {}x{}x{} with {} colors", vol.width(), vol.height(),
               vol.depth(), colorTable.size());
-  for (auto color : colors_) {
+  for (auto color : compartmentColors) {
     if (!colorTable.contains(color)) {
       SPDLOG_WARN("Compartment color is not present in geometry image");
       errorMessage_ = "Compartment color is not present in geometry image";
       return;
     }
   }
+  setColors(compartmentColors, membraneIdColorPairs);
+
+  compartmentsToMembraneIndex_.assign(compartmentColors.size() *
+                                          compartmentColors.size(),
+                                      NullCompartmentIndex);
+  constexpr auto invalidIndex = std::numeric_limits<std::size_t>::max();
+  for (std::uint8_t i = 0; const auto &[id, colors] : membraneIdColorPairs) {
+    auto c1 =
+        common::element_index(compartmentColors, colors.first, invalidIndex);
+    auto c2 =
+        common::element_index(compartmentColors, colors.second, invalidIndex);
+    if (c1 == invalidIndex || c2 == invalidIndex) {
+      SPDLOG_WARN("Membrane color is not present in geometry image");
+      errorMessage_ = "Membrane color is not present in geometry image";
+      return;
+    }
+    compartmentsToMembraneIndex_[c1 * compartmentColors.size() + c2] = i;
+    compartmentsToMembraneIndex_[c2 * compartmentColors.size() + c1] = i;
+    ++i;
+  }
 
   // convert from label to compartment index: label 0 is reserved for out of
   // mesh voxels, so label n is colorIndex n-1 from the image colorTable
   labelToCompartmentIndex_.assign(
       static_cast<std::size_t>(colorTable.size()) + 1, NullCompartmentIndex);
-  for (std::size_t compartmentIndex = 0; compartmentIndex < colors_.size();
-       ++compartmentIndex) {
-    auto compartmentColor = colors_[compartmentIndex];
+  for (std::size_t compartmentIndex = 0;
+       compartmentIndex < compartmentColors.size(); ++compartmentIndex) {
+    auto compartmentColor = compartmentColors[compartmentIndex];
     auto colorIndex = colorTable.indexOf(compartmentColor);
     if (colorIndex >= 0) {
       auto label = static_cast<std::size_t>(colorIndex) + 1;
@@ -217,14 +279,15 @@ Mesh3d::Mesh3d(const sme::common::ImageStack &imageStack,
   SPDLOG_INFO("Constructed {}x{}x{} Image_3", image3_->xdim(), image3_->ydim(),
               image3_->zdim());
 
-  tetrahedronVertexIndices_.resize(colors_.size());
-  tetrahedra_.resize(colors_.size());
+  tetrahedronVertexIndices_.resize(compartmentColors.size());
+  tetrahedra_.resize(compartmentColors.size());
+  membraneTriangleVertexIndices_.resize(membraneIdColorPairs.size());
 
-  if (compartmentMaxCellVolume_.size() != colors_.size()) {
+  if (compartmentMaxCellVolume_.size() != getNumberOfCompartments()) {
     // if cell volumes are not correctly specified use default value
     constexpr std::size_t defaultCompartmentMaxCellVolume{5};
     compartmentMaxCellVolume_ = std::vector<std::size_t>(
-        colors_.size(), defaultCompartmentMaxCellVolume);
+        getNumberOfCompartments(), defaultCompartmentMaxCellVolume);
     SPDLOG_INFO("no max cell volumes specified, using default value: {}",
                 defaultCompartmentMaxCellVolume);
   }
@@ -305,6 +368,10 @@ std::size_t Mesh3d::getNumberOfCompartments() const {
   return tetrahedronVertexIndices_.size();
 }
 
+std::size_t Mesh3d::getNumberOfMembranes() const {
+  return membraneTriangleVertexIndices_.size();
+}
+
 std::vector<int>
 Mesh3d::getTetrahedronIndicesAsFlatArray(std::size_t compartmentIndex) const {
 
@@ -324,6 +391,11 @@ Mesh3d::getTetrahedronIndicesAsFlatArray(std::size_t compartmentIndex) const {
 const std::vector<std::vector<TetrahedronVertexIndices>> &
 Mesh3d::getTetrahedronIndices() const {
   return tetrahedronVertexIndices_;
+}
+
+const std::vector<std::vector<TriangleVertexIndices>> &
+Mesh3d::getMembraneTriangleIndices() const {
+  return membraneTriangleVertexIndices_;
 }
 
 QString Mesh3d::getGMSH() const {
@@ -375,8 +447,14 @@ QString Mesh3d::getGMSH() const {
 
 const std::vector<QRgb> &Mesh3d::getColors() const { return colors_; }
 
-void Mesh3d::setColors(std::vector<QRgb> colors) {
-  colors_ = std::move(colors);
+void Mesh3d::setColors(
+    const std::vector<QRgb> &compartmentColors,
+    const std::vector<std::pair<std::string, std::pair<QRgb, QRgb>>>
+        &membraneIdColorPairs) {
+  colors_ = compartmentColors;
+  for (const auto &[id, colors] : membraneIdColorPairs) {
+    colors_.push_back(interpolate(colors.first, colors.second));
+  }
 }
 
 } // namespace sme::mesh

--- a/core/mesh/src/mesh3d_t.cpp
+++ b/core/mesh/src/mesh3d_t.cpp
@@ -311,10 +311,14 @@ TEST_CASE("Mesh3d more complex geometries",
     }
     SECTION("Nucleus+Cell only") {
       mesh::Mesh3d mesh3d(imageStack, maxCellVolume, voxelSize, originPoint,
-                          {colNucleus, colCell});
+                          {colNucleus, colCell},
+                          {{"nucl-cell-membrane", {colNucleus, colCell}}});
       REQUIRE(mesh3d.isValid() == true);
       REQUIRE(mesh3d.getErrorMessage().empty());
+      REQUIRE(mesh3d.getNumberOfCompartments() == 2);
+      REQUIRE(mesh3d.getNumberOfMembranes() == 1);
       REQUIRE(mesh3d.getTetrahedronIndices().size() == 2);
+      REQUIRE(mesh3d.getMembraneTriangleIndices().size() == 1);
       // nucleus
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 0,
                                colOutside) == dbl_approx(0));
@@ -329,13 +333,19 @@ TEST_CASE("Mesh3d more complex geometries",
                                colCell) >= 0.90);
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 1,
                                colNucleus) <= 0.08);
+      // nuc-cell membrane
+      REQUIRE(!mesh3d.getMembraneTriangleIndices()[0].empty());
     }
     SECTION("Nucleus+Outside only") {
       mesh::Mesh3d mesh3d(imageStack, maxCellVolume, voxelSize, originPoint,
-                          {colNucleus, colOutside});
+                          {colNucleus, colOutside},
+                          {{"nucl-out-membrane", {colNucleus, colOutside}}});
       REQUIRE(mesh3d.isValid() == true);
       REQUIRE(mesh3d.getErrorMessage().empty());
+      REQUIRE(mesh3d.getNumberOfCompartments() == 2);
+      REQUIRE(mesh3d.getNumberOfMembranes() == 1);
       REQUIRE(mesh3d.getTetrahedronIndices().size() == 2);
+      REQUIRE(mesh3d.getMembraneTriangleIndices().size() == 1);
       // nucleus
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 0,
                                colOutside) == dbl_approx(0));
@@ -350,13 +360,19 @@ TEST_CASE("Mesh3d more complex geometries",
                                colCell) <= 0.05);
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 1,
                                colNucleus) == dbl_approx(0));
+      // nuc-out membrane contains no triangles
+      REQUIRE(mesh3d.getMembraneTriangleIndices()[0].empty());
     }
     SECTION("Cell+Outside only") {
       mesh::Mesh3d mesh3d(imageStack, maxCellVolume, voxelSize, originPoint,
-                          {colOutside, colCell});
+                          {colOutside, colCell},
+                          {{"cell-out-membrane", {colCell, colOutside}}});
       REQUIRE(mesh3d.isValid() == true);
       REQUIRE(mesh3d.getErrorMessage().empty());
+      REQUIRE(mesh3d.getNumberOfCompartments() == 2);
+      REQUIRE(mesh3d.getNumberOfMembranes() == 1);
       REQUIRE(mesh3d.getTetrahedronIndices().size() == 2);
+      REQUIRE(mesh3d.getMembraneTriangleIndices().size() == 1);
       // outside
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 0,
                                colOutside) >= 0.95);
@@ -371,20 +387,31 @@ TEST_CASE("Mesh3d more complex geometries",
                                colCell) >= 0.90);
       REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint, 1,
                                colNucleus) <= 0.08);
+      // cell-out membrane
+      REQUIRE(!mesh3d.getMembraneTriangleIndices()[0].empty());
     }
     SECTION("All three compartments") {
       auto colorsAsStdVec = sme::common::toStdVec(colors);
       mesh::Mesh3d mesh3d(imageStack, maxCellVolume, voxelSize, originPoint,
-                          colorsAsStdVec);
+                          colorsAsStdVec,
+                          {{"nucl-cell-membrane", {colNucleus, colCell}},
+                           {"cell-out-membrane", {colCell, colOutside}}});
       REQUIRE(mesh3d.isValid() == true);
       REQUIRE(mesh3d.getErrorMessage().empty());
+      REQUIRE(mesh3d.getNumberOfCompartments() == 3);
+      REQUIRE(mesh3d.getNumberOfMembranes() == 2);
       REQUIRE(mesh3d.getTetrahedronIndices().size() == 3);
+      REQUIRE(mesh3d.getMembraneTriangleIndices().size() == 2);
       for (auto compartmentIndex : std::vector<std::size_t>{0, 1, 2}) {
         CAPTURE(compartmentIndex);
         REQUIRE(matchingFraction(imageStack, mesh3d, voxelSize, originPoint,
                                  compartmentIndex,
                                  colorsAsStdVec[compartmentIndex]) >= 0.90);
       }
+      // nucl-cell membrane
+      REQUIRE(!mesh3d.getMembraneTriangleIndices()[0].empty());
+      // cell-out membrane
+      REQUIRE(!mesh3d.getMembraneTriangleIndices()[1].empty());
     }
   }
   SECTION("Two disconnected eggs") {

--- a/core/model/src/geometry_sampled_field.cpp
+++ b/core/model/src/geometry_sampled_field.cpp
@@ -223,12 +223,12 @@ static std::vector<QRgb> setImagePixels(
     auto matches = getMatchingSampledValues(values, sampledVolume);
     if (std::ranges::find(matches, true) != matches.cend()) {
       auto col{common::indexedColors()[iCol].rgb()};
-      SPDLOG_WARN("Color {} is {}", iCol, col);
+      SPDLOG_DEBUG("Color {} is {}", iCol, col);
       auto sampledValue{
           static_cast<std::size_t>(sampledVolume->getSampledValue())};
       if (sampledValue < importedSampledFieldColors.size()) {
         col = importedSampledFieldColors[sampledValue];
-        SPDLOG_WARN("  -> Using importedSampledFieldColor {}", col);
+        SPDLOG_DEBUG("  -> Using importedSampledFieldColor {}", col);
       }
       SPDLOG_DEBUG("  {}/{} -> color {:x}", sampledVolume->getId(),
                    sampledVolume->getDomainType(), col);

--- a/core/model/src/model_geometry.cpp
+++ b/core/model/src/model_geometry.cpp
@@ -303,9 +303,9 @@ void ModelGeometry::updateMesh() {
   if (images.volume().depth() > 1) {
     SPDLOG_INFO("Updating 3d mesh");
     mesh.reset();
-    mesh3d = std::make_unique<mesh::Mesh3d>(images, std::vector<std::size_t>{},
-                                            voxelSize, physicalOrigin,
-                                            common::toStdVec(colors));
+    mesh3d = std::make_unique<mesh::Mesh3d>(
+        images, std::vector<std::size_t>{}, voxelSize, physicalOrigin,
+        common::toStdVec(colors), modelMembranes->getIdColorPairs());
     isMeshValid = mesh3d->isValid();
   } else {
     SPDLOG_INFO("Updating 2d mesh");
@@ -498,7 +498,8 @@ void ModelGeometry::updateGeometryImageColor(QRgb oldColor, QRgb newColor) {
   modelMembranes->updateGeometryImageColor(oldColor, newColor);
   modelMembranes->updateCompartments(modelCompartments->getCompartments());
   if (mesh3d != nullptr) {
-    mesh3d->setColors(common::toStdVec(modelCompartments->getColors()));
+    mesh3d->setColors(common::toStdVec(modelCompartments->getColors()),
+                      modelMembranes->getIdColorPairs());
   }
   hasUnsavedChanges = true;
 }

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -916,7 +916,10 @@ TEST_CASE("SBML: load .xml model, simulate, save as .sme, load .sme",
   model::Model s2;
   s2.importFile("tmpmodelsmetest.sme");
   REQUIRE(s2.getCompartments().getIds() == s.getCompartments().getIds());
-  REQUIRE(s.getXml() == s2.getXml());
+  auto xml = s.getXml();
+  auto xml2 = s2.getXml();
+  // only compare xml after comment as it contains a datetime stamp
+  REQUIRE(xml.slice(xml.indexOf("<sbml")) == xml2.slice(xml2.indexOf("<sbml")));
   REQUIRE(s2.getSimulationData().timePoints.size() == 3);
   REQUIRE(s2.getSimulationData().timePoints[2] == dbl_approx(0.2));
   REQUIRE(s2.getSimulationData().concPadding.size() == 3);

--- a/gui/widgets/qmeshrenderer.cpp
+++ b/gui/widgets/qmeshrenderer.cpp
@@ -1,18 +1,32 @@
 #include "qmeshrenderer.hpp"
 #include "sme/logger.hpp"
+#include "sme/utils.hpp"
 #include <vtkCamera.h>
 #include <vtkPropPicker.h>
 #include <vtkProperty.h>
+
+static std::array<double, 3> makeEdgeColor(const QColor &color) {
+  // lighter or darker edge color depending on lightness of color
+  auto edge = color.lightnessF() > 0.3 ? color.darker(300) : color.lighter(300);
+  if (edge.lightnessF() < 0.1) {
+    // black remains black when lightened, so also add some grey if edge is dark
+    edge = QColor(edge.red() + 50, edge.green() + 50, edge.blue() + 50);
+  }
+  return {edge.redF(), edge.greenF(), edge.blueF()};
+}
 
 QMeshRenderer::QMeshRenderer(QWidget *parent) : SmeVtkWidget(parent) {}
 
 void QMeshRenderer::setMesh(const sme::mesh::Mesh3d &mesh,
                             std::size_t compartmentIndex, bool resetCamera) {
-  if (!isVisible() || compartmentIndex >= mesh.getNumberOfCompartments()) {
+  if (!isVisible()) {
     return;
   }
+  if (compartmentIndex >=
+      mesh.getNumberOfCompartments() + mesh.getNumberOfMembranes()) {
+    compartmentIndex = 0;
+  }
   clear();
-  colors = mesh.getColors();
   points->SetNumberOfPoints(static_cast<vtkIdType>(mesh.getVertices().size()));
   for (vtkIdType i = 0; const auto &v : mesh.getVertices()) {
     points->SetPoint(i, static_cast<float>(v.p.x()),
@@ -44,11 +58,38 @@ void QMeshRenderer::setMesh(const sme::mesh::Mesh3d &mesh,
     wireframeActor->SetMapper(wireframeMapper);
     renderer->AddActor(wireframeActor);
   }
+  for (const auto &membraneTriangleIndices :
+       mesh.getMembraneTriangleIndices()) {
+    auto &triangle = triangles.emplace_back();
+    auto &membrane = membranes.emplace_back();
+    auto &edge = edges.emplace_back();
+    auto &solidActor = solidActors.emplace_back();
+    auto &solidMapper = solidMappers.emplace_back();
+    auto &wireframeActor = wireframeActors.emplace_back();
+    auto &wireframeMapper = wireframeMappers.emplace_back();
+    triangle->AllocateExact(
+        static_cast<vtkIdType>(membraneTriangleIndices.size()), 3);
+    for (const auto &triangleIndex : membraneTriangleIndices) {
+      triangle->InsertNextCell(
+          3, reinterpret_cast<const vtkIdType *>(triangleIndex.data()));
+    }
+    membrane->SetPoints(points);
+    membrane->SetPolys(triangle);
+    solidMapper->SetInputData(membrane);
+    solidActor->SetMapper(solidMapper);
+    solidActor->GetProperty()->EdgeVisibilityOn();
+    renderer->AddActor(solidActor);
+    edge->SetInputData(membrane);
+    wireframeMapper->SetInputConnection(edge->GetOutputPort());
+    wireframeActor->SetMapper(wireframeMapper);
+    renderer->AddActor(wireframeActor);
+  }
   if (resetCamera) {
     renderer->ResetCameraClippingRange();
     renderer->ResetCamera();
   }
-  setCompartmentIndex(compartmentIndex);
+  currentCompartmentIndex = compartmentIndex;
+  setColors(mesh.getColors());
 }
 
 void QMeshRenderer::setCompartmentIndex(std::size_t compartmentIndex) {
@@ -56,8 +97,20 @@ void QMeshRenderer::setCompartmentIndex(std::size_t compartmentIndex) {
   updateAndRender();
 }
 
-void QMeshRenderer::setColors(std::vector<QRgb> newColors) {
-  colors = std::move(newColors);
+void QMeshRenderer::setMembraneIndex(std::size_t membraneIndex) {
+  setCompartmentIndex(grids.size() + membraneIndex);
+}
+
+void QMeshRenderer::setColors(std::vector<QRgb> colors) {
+  for (std::size_t i = 0; i < colors.size(); ++i) {
+    QColor color(colors[i]);
+    std::array<double, 3> floatColor{color.redF(), color.greenF(),
+                                     color.blueF()};
+    solidActors[i]->GetProperty()->SetColor(floatColor.data());
+    wireframeActors[i]->GetProperty()->SetColor(floatColor.data());
+    auto edgeColor = makeEdgeColor(color);
+    solidActors[i]->GetProperty()->SetEdgeColor(edgeColor.data());
+  }
   updateAndRender();
 }
 
@@ -68,11 +121,12 @@ void QMeshRenderer::setRenderMode(RenderMode mode) {
 
 void QMeshRenderer::clear() {
   currentCompartmentIndex = 0;
-  colors.clear();
   renderMode = RenderMode::Solid;
   renderer->RemoveAllViewProps();
   points->Reset();
   grids.clear();
+  triangles.clear();
+  membranes.clear();
   edges.clear();
   solidMappers.clear();
   wireframeMappers.clear();
@@ -108,31 +162,27 @@ void QMeshRenderer::mouseReleaseEvent(QMouseEvent *ev) {
   }
 }
 
-static std::array<double, 3> makeEdgeColor(const QColor &color) {
-  // lighter or darker edge color depending on lightness of color
-  auto edge = color.lightnessF() > 0.3 ? color.darker(300) : color.lighter(300);
-  if (edge.lightnessF() < 0.1) {
-    // black remains black when lightened, so also add some grey if edge is dark
-    edge = QColor(edge.red() + 50, edge.green() + 50, edge.blue() + 50);
-  }
-  return {edge.redF(), edge.greenF(), edge.blueF()};
-}
-
 void QMeshRenderer::updateAndRender() {
-  for (std::size_t i = 0; i < solidActors.size(); ++i) {
-    QColor color(colors[i]);
-    std::array<double, 3> floatColor{color.redF(), color.greenF(),
-                                     color.blueF()};
-    solidActors[i]->SetVisibility(renderMode == RenderMode::Solid);
-    solidActors[i]->GetProperty()->SetColor(floatColor.data());
-    solidActors[i]->GetProperty()->SetOpacity(
-        i == currentCompartmentIndex ? 1.0 : 0.15);
-    wireframeActors[i]->SetVisibility(renderMode == RenderMode::Wireframe);
-    wireframeActors[i]->GetProperty()->SetColor(floatColor.data());
-    wireframeActors[i]->GetProperty()->SetOpacity(
-        i == currentCompartmentIndex ? 1.0 : 0.05);
-    auto edgeColor = makeEdgeColor(color);
-    solidActors[i]->GetProperty()->SetEdgeColor(edgeColor.data());
+  for (auto &solidActor : solidActors) {
+    solidActor->SetVisibility(false);
+  }
+  for (auto &wireframeActor : wireframeActors) {
+    wireframeActor->SetVisibility(false);
+  }
+  std::size_t iMin = currentCompartmentIndex < grids.size() ? 0 : grids.size();
+  std::size_t iMax = currentCompartmentIndex < grids.size()
+                         ? grids.size()
+                         : grids.size() + triangles.size();
+  for (std::size_t i = iMin; i < iMax; ++i) {
+    if (renderMode == RenderMode::Solid) {
+      solidActors[i]->SetVisibility(true);
+      solidActors[i]->GetProperty()->SetOpacity(
+          i == currentCompartmentIndex ? 1.0 : 0.15);
+    } else if (renderMode == RenderMode::Wireframe) {
+      wireframeActors[i]->SetVisibility(true);
+      wireframeActors[i]->GetProperty()->SetOpacity(
+          i == currentCompartmentIndex ? 1.0 : 0.05);
+    }
   }
   renderWindow->Render();
 }

--- a/gui/widgets/qmeshrenderer.hpp
+++ b/gui/widgets/qmeshrenderer.hpp
@@ -5,10 +5,12 @@
 #include "smevtkwidget.hpp"
 #include <QMouseEvent>
 #include <vtkActor.h>
+#include <vtkCellArray.h>
 #include <vtkDataSetMapper.h>
 #include <vtkExtractEdges.h>
 #include <vtkNew.h>
 #include <vtkPoints.h>
+#include <vtkPolyData.h>
 #include <vtkUnstructuredGrid.h>
 
 class QMeshRenderer : public SmeVtkWidget {
@@ -23,6 +25,7 @@ public:
   void setMesh(const sme::mesh::Mesh3d &mesh, std::size_t compartmentIndex,
                bool resetCamera = true);
   void setCompartmentIndex(std::size_t compartmentIndex);
+  void setMembraneIndex(std::size_t membraneIndex);
   void setColors(std::vector<QRgb> newColors);
   void setRenderMode(RenderMode mode);
   void clear();
@@ -38,10 +41,11 @@ private:
   void updateAndRender();
   QPoint lastMouseClickPos{};
   std::size_t currentCompartmentIndex{0};
-  std::vector<QRgb> colors{};
   RenderMode renderMode{RenderMode::Solid};
   vtkNew<vtkPoints> points{};
   std::vector<vtkNew<vtkUnstructuredGrid>> grids{};
+  std::vector<vtkNew<vtkCellArray>> triangles{};
+  std::vector<vtkNew<vtkPolyData>> membranes{};
   std::vector<vtkNew<vtkExtractEdges>> edges{};
   std::vector<vtkNew<vtkDataSetMapper>> solidMappers{};
   std::vector<vtkNew<vtkDataSetMapper>> wireframeMappers{};

--- a/gui/widgets/qmeshrenderer_t.cpp
+++ b/gui/widgets/qmeshrenderer_t.cpp
@@ -27,8 +27,15 @@ TEST_CASE("QMeshRenderer",
     meshRenderer.setCompartmentIndex(i);
     wait(delay_ms);
   }
+  // highlight each membrane in turn
+  for (std::size_t i = 0; i < mesh.getNumberOfMembranes(); ++i) {
+    meshRenderer.setMembraneIndex(i);
+    wait(delay_ms);
+  }
   // change the compartment colors
-  meshRenderer.setColors({0xff00ff, 0x00ff00, 0x0000ff});
+  meshRenderer.setColors({0xff00ff, 0x00ff00, 0x0000ff, 0xffff00, 0x00ffff});
+  wait(delay_ms);
+  meshRenderer.setCompartmentIndex(2);
   wait(delay_ms);
   // change the render mode
   meshRenderer.setRenderMode(QMeshRenderer::RenderMode::Wireframe);


### PR DESCRIPTION
- QMeshRenderer
  - add membranes as vtkPolyData of vtkCellArray
  - add setMembraneIndex method
- Mesh3d
  - add membraneIdColorPairs to constructor
  - provide triangles for each membrane
  - calculate hsv-interpolated color between the two compartment colors for membranes
- resolves #1033
