### PR TITLE
Use the same max cell volume for all compartments in 3d meshing

### DIFF
--- a/core/mesh/src/mesh3d.cpp
+++ b/core/mesh/src/mesh3d.cpp
@@ -125,10 +125,11 @@ void Mesh3d::constructMesh() {
             labelToCompartmentIndex_[static_cast<std::size_t>(
                 c3t3.subdomain_index(c))];
         compartmentIndex != NullCompartmentIndex) {
-      SPDLOG_TRACE(
-          "cell with vertex ids {},{},{},{} in subdomain {} -> compartment {}",
-          c->vertex(0)->id(), c->vertex(1)->id(), c->vertex(2)->id(),
-          c->vertex(3)->id(), c3t3.subdomain_index(c), compartmentIndex);
+      SPDLOG_TRACE("cell with vertex ids {},{},{},{} in subdomain {} -> "
+                   "compartment {}",
+                   c->vertex(0)->id(), c->vertex(1)->id(), c->vertex(2)->id(),
+                   c->vertex(3)->id(), c3t3.subdomain_index(c),
+                   compartmentIndex);
       auto &vi = tetrahedronVertexIndices_[compartmentIndex].emplace_back();
       for (int i = 0; i < 4; ++i) {
         vi[static_cast<std::size_t>(i)] =
@@ -251,17 +252,13 @@ void Mesh3d::setCompartmentMaxCellVolume(std::size_t compartmentIndex,
     SPDLOG_INFO("  -> max cell volume unchanged");
     return;
   }
-  // ensure maxCellVolume values for each compartment do not differ by more than
-  // a factor 2 from each other, as this can lead to CGAL segfaults
-  constexpr std::size_t maxRelDiff{2};
+  // for now enforce that all compartments have the same max cell volume to
+  // avoid CGAL segfaulting for some combinations of max cell volumes (see
+  // #1037)
+  SPDLOG_INFO("  -> setting all max cell volumes to {}", maxCellVolume);
   for (auto &cellVolume : compartmentMaxCellVolume_) {
-    if (cellVolume * maxRelDiff < maxCellVolume) {
-      cellVolume = static_cast<std::size_t>(maxCellVolume / maxRelDiff);
-    } else if (cellVolume > maxRelDiff * maxCellVolume) {
-      cellVolume = maxRelDiff * maxCellVolume;
-    }
+    cellVolume = maxCellVolume;
   }
-  currentMaxCellVolume = maxCellVolume;
   constructMesh();
 }
 

--- a/core/mesh/src/mesh3d_t.cpp
+++ b/core/mesh/src/mesh3d_t.cpp
@@ -550,35 +550,14 @@ TEST_CASE("Mesh3d max cell volume",
     REQUIRE(mesh3d != nullptr);
     REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == 5);
     REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == 5);
-    // make max cell volume for compartment zero much larger:
-    mesh3d->setCompartmentMaxCellVolume(0, 50);
-    // note: CGAL segfaults when the max cell volumes are too different (see
-    // #1037) so we also automatically adjust the other values to keep them all
-    // within a factor of 2 of the value that was changed
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == 50);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == 25);
-    mesh3d->setCompartmentMaxCellVolume(0, 4);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == 4);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == 8);
-    mesh3d->setCompartmentMaxCellVolume(1, 100);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == 50);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == 100);
-    mesh3d->setCompartmentMaxCellVolume(1, 4);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == 8);
-    REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == 4);
-    mesh3d->setCompartmentMaxCellVolume(1, 200);
-    for (std::size_t i = 100; i >= 4; --i) {
+    REQUIRE(mesh3d->isValid());
+    for (std::size_t i = 100; i >= 3; --i) {
       CAPTURE(i);
       mesh3d->setCompartmentMaxCellVolume(0, i);
       REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) == i);
-      REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) <= 2 * i);
-    }
-    mesh3d->setCompartmentMaxCellVolume(0, 200);
-    for (std::size_t i = 100; i >= 4; --i) {
-      CAPTURE(i);
-      mesh3d->setCompartmentMaxCellVolume(1, i);
+      // setting max cell volume for one compartment should set it for all
       REQUIRE(mesh3d->getCompartmentMaxCellVolume(1) == i);
-      REQUIRE(mesh3d->getCompartmentMaxCellVolume(0) <= 2 * i);
+      REQUIRE(mesh3d->isValid());
     }
   }
 }

--- a/gui/tabs/tabgeometry.ui
+++ b/gui/tabs/tabgeometry.ui
@@ -574,7 +574,7 @@
                  <item row="1" column="2">
                   <widget class="QSpinBox" name="spinMaxCellVolume">
                    <property name="minimum">
-                    <number>4</number>
+                    <number>3</number>
                    </property>
                    <property name="maximum">
                     <number>999999</number>


### PR DESCRIPTION
- this seems to avoid the CGAL segfault issues that occured for some combinations of max cell volume values
- wrap mesh generation in a try catch block
  - currently not helpful as CGAL aborts rather than raise an exception since we compile with DNDEBUG
  - but could be relevant if at some point we compile CGAL with assertions enabled
- update tests accordingly
- decrease minimum value allowed in the GUI to 3
  - even smaller values work, but can be very slow to generate, and unlikely to make sense to try to simulate a mesh with many millions of tetrahedrons
- resolves #1037
