### PR TITLE
Fill in gaps in 3 d optimization

### DIFF
--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -119,7 +119,8 @@ public:
   /**
    * @brief Get the raw values of the optimization target
    */
-  [[nodiscard]] const std::vector<double>& getTargetValues(std::size_t index) const;
+  [[nodiscard]] const std::vector<double> &
+  getTargetValues(std::size_t index) const;
 
   /**
    * @brief Get an image of the current best result for a target

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -102,15 +102,53 @@ public:
    */
   bool setBestResults(double fitness,
                       std::vector<std::vector<double>> &&results);
+
+  /**
+   * @brief Get the values for a target obtained with the best currently
+   * available parameters.
+   *
+   */
+  [[nodiscard]] std::vector<double>
+  getBestResultValues(std::size_t index) const;
+
   /**
    * @brief Get an image of the a target
    */
   [[nodiscard]] common::ImageStack getTargetImage(std::size_t index) const;
+
+  /**
+   * @brief Get the raw values of the optimization target
+   */
+  [[nodiscard]] std::vector<double> getTargetValues(std::size_t index) const;
+
   /**
    * @brief Get an image of the current best result for a target
    */
   [[nodiscard]] std::optional<common::ImageStack>
   getUpdatedBestResultImage(std::size_t index);
+
+  /**
+   * @brief Get the current best result for a target
+   */
+  [[nodiscard]] common::ImageStack getCurrentBestResultImage() const;
+
+  /**
+   * @brief Get the size of the domain of the image representing the
+   * optimization target in number of pixels in each dimension
+   */
+  [[nodiscard]] sme::common::Volume getImageSize();
+
+  /**
+   * @brief get the maximum value of the target values
+   */
+  [[nodiscard]] double getMaxValue(std::size_t index);
+
+  /**
+   * @brief Get the difference between the optimization target and the current
+   * best result
+   */
+  [[nodiscard]] common::ImageStack getDifferenceImage(std::size_t index);
+
   /**
    * @brief The number of completed evolve iterations
    */

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -119,7 +119,7 @@ public:
   /**
    * @brief Get the raw values of the optimization target
    */
-  [[nodiscard]] std::vector<double> getTargetValues(std::size_t index) const;
+  [[nodiscard]] const std::vector<double>& getTargetValues(std::size_t index) const;
 
   /**
    * @brief Get an image of the current best result for a target

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -294,7 +294,7 @@ const std::vector<double> &Optimization::getFitness() const {
 common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
 
   auto size = getImageSize();
-  // size.depth(), index);
+
   std::vector<double> tgt_values = getTargetValues(index);
 
   // separate allocation to make sure that common::max does not segfault when

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -302,7 +302,8 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
   auto diff_values = std::vector<double>(size.nVoxels(), 0);
 
   if (bestResults.imageIndex == std::numeric_limits<std::size_t>::max()) {
-    return sme::common::ImageStack(size, diff_values, common::max(tgt_values));
+    return sme::common::ImageStack(
+        size, diff_values, tgt_values.size() > 0 ? common::max(tgt_values) : 0);
   }
   auto res_values = getBestResultValues(index);
   if (res_values.size() > 0) {

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -300,7 +300,7 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
   // separate allocation to make sure that common::max does not segfault when
   // called on an empty array.
   auto diff_values =
-      std::vector<double>(size.width() * size.height() * size.depth(), 0);
+      std::vector<double>(size.nVoxels(), 0);
 
   if (bestResults.imageIndex == std::numeric_limits<std::size_t>::max()) {
     return sme::common::ImageStack(size, diff_values, common::max(tgt_values));

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -347,18 +347,14 @@ Optimization::getUpdatedBestResultImage(std::size_t index) {
   return {};
 }
 
-common::ImageStack Optimization::getCurrentBestResultImage() {
+common::ImageStack Optimization::getCurrentBestResultImage() const {
   std::scoped_lock lock{bestResultsMutex};
-  SPDLOG_CRITICAL("getCurrentBestResultImage, {}, {}, {}",
-                  bestResults.values.size(), bestResults.imageIndex,
-                  optConstData->maxTargetValues.size());
+  SPDLOG_DEBUG("getCurrentBestResultImage, {}, {}, {}",
+               bestResults.values.size(), bestResults.imageIndex,
+               optConstData->maxTargetValues.size());
   if (bestResults.values.empty() or
       bestResults.imageIndex >= optConstData->maxTargetValues.size()) {
-    auto size = optConstData->imageSize;
-    auto v =
-        std::vector<double>(size.width() * size.height() * size.depth(), 0);
-    ;
-    return common::ImageStack(optConstData->imageSize, v, 0.0);
+    return common::ImageStack();
   }
   return common::ImageStack(
       optConstData->imageSize, bestResults.values[bestResults.imageIndex],

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -294,24 +294,24 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
   SPDLOG_INFO("getDifferenceImage({})", index);
 
   auto size = getImageSize();
-  SPDLOG_INFO("volume: ({}, {}, {}), index: {}", size.width(), size.height(),
-              size.depth(), index);
+  // SPDLOG_INFO("volume: ({}, {}, {}), index: {}", size.width(), size.height(),
+  // size.depth(), index);
   auto tgt_values = getTargetValues(index);
   auto diff_values = tgt_values;
-  SPDLOG_INFO("tgt_value: {}", tgt_values.size());
+  // SPDLOG_INFO("tgt_value: {}", tgt_values.size());
   auto res_values = getBestResultValues(index);
-  SPDLOG_INFO("res_values: {}", res_values.size());
-  SPDLOG_INFO("target values: {}", tgt_values.size());
-  SPDLOG_INFO("result values: {}", res_values.size());
+  // SPDLOG_INFO("res_values: {}", res_values.size());
+  // SPDLOG_INFO("target values: {}", tgt_values.size());
+  // SPDLOG_INFO("result values: {}", res_values.size());
   if (res_values.size() > 0) {
-    SPDLOG_INFO("diff values max before: {}", common::max(diff_values));
-    SPDLOG_INFO("tgt_values values max: {}", common::max(tgt_values));
-    SPDLOG_INFO("res_values values max: {}", common::max(res_values));
+    // SPDLOG_INFO("diff values max before: {}", common::max(diff_values));
+    // SPDLOG_INFO("tgt_values values max: {}", common::max(tgt_values));
+    // SPDLOG_INFO("res_values values max: {}", common::max(res_values));
     std::ranges::transform(tgt_values, res_values, diff_values.begin(),
                            std::minus<double>());
   }
-  SPDLOG_INFO("diff values: {}", diff_values.size());
-  SPDLOG_INFO("max diff value: {}", common::max(diff_values));
+  // SPDLOG_INFO("diff values: {}", diff_values.size());
+  // SPDLOG_INFO("max diff value: {}", common::max(diff_values));
   return sme::common::ImageStack(size, diff_values, common::max(diff_values));
 }
 

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -102,25 +102,25 @@ getPagmoAlgorithm(sme::simulate::OptAlgorithmType optAlgorithmType) {
     algo.set_xtol_rel(
         0); // this serves to effectively disable the stopping criterion based
             // on the relative change in the parameters
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   case BOBYQA: {
     auto algo = pagmo::nlopt("bobyqa");
     algo.set_xtol_rel(0);
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   case NMS: {
     auto algo = pagmo::nlopt("neldermead");
     algo.set_xtol_rel(0);
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   case sbplx: {
     auto algo = pagmo::nlopt("sbplx");
     algo.set_xtol_rel(0);
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   case AL: {
@@ -130,16 +130,16 @@ getPagmoAlgorithm(sme::simulate::OptAlgorithmType optAlgorithmType) {
     auto algo = pagmo::nlopt("auglag");
     auto aux_algo = pagmo::nlopt("neldermead");
     algo.set_xtol_rel(0);
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     aux_algo.set_xtol_rel(0);
-    aux_algo.set_maxeval(1);
+    aux_algo.set_maxeval(10);
     algo.set_local_optimizer(aux_algo);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   case PRAXIS: {
     auto algo = pagmo::nlopt("praxis");
     algo.set_xtol_rel(0);
-    algo.set_maxeval(1);
+    algo.set_maxeval(10);
     return std::make_unique<pagmo::algorithm>(std::move(algo));
   }
   default:

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -295,7 +295,7 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
 
   auto size = getImageSize();
   // size.depth(), index);
-  auto tgt_values = getTargetValues(index);
+  const std::vector<double> &tgt_values = getTargetValues(index);
 
   // separate allocation to make sure that common::max does not segfault when
   // called on an empty array.
@@ -362,7 +362,7 @@ common::ImageStack Optimization::getCurrentBestResultImage() const {
 
 std::vector<double> Optimization::getBestResultValues(std::size_t index) const {
   std::scoped_lock lock{bestResultsMutex};
-  if (index > bestResults.values.size() or bestResults.values.empty()) {
+  if (index >= bestResults.values.size() or bestResults.values.empty()) {
     SPDLOG_DEBUG("index outside of range for result retrieval: {} , {}", index,
                  bestResults.values.size());
     return {};
@@ -372,7 +372,7 @@ std::vector<double> Optimization::getBestResultValues(std::size_t index) const {
 
 std::vector<double> Optimization::getTargetValues(std::size_t index) const {
 
-  if (index > optConstData->optimizeOptions.optCosts.size()) {
+  if (index >= optConstData->optimizeOptions.optCosts.size()) {
     SPDLOG_DEBUG("index outside of range for target retrieval: {} , {}", index,
                  bestResults.values.size());
     return {};

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -299,8 +299,7 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
 
   // separate allocation to make sure that common::max does not segfault when
   // called on an empty array.
-  auto diff_values =
-      std::vector<double>(size.nVoxels(), 0);
+  auto diff_values = std::vector<double>(size.nVoxels(), 0);
 
   if (bestResults.imageIndex == std::numeric_limits<std::size_t>::max()) {
     return sme::common::ImageStack(size, diff_values, common::max(tgt_values));

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -291,16 +291,18 @@ const std::vector<double> &Optimization::getFitness() const {
 }
 
 common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
-  SPDLOG_INFO("getDifferenceImage({})", index);
+  // SPDLOG_INFO("getDifferenceImage({})", index);
 
   auto size = getImageSize();
   // SPDLOG_INFO("volume: ({}, {}, {}), index: {}", size.width(), size.height(),
   // size.depth(), index);
   auto tgt_values = getTargetValues(index);
-  auto diff_values = tgt_values;
-  // SPDLOG_INFO("tgt_value: {}", tgt_values.size());
+
+  // separate allocation to make sure that common::max does not segfault when
+  // called on an empty array.
+  auto diff_values =
+      std::vector<double>(size.width() * size.height() * size.depth(), 0);
   auto res_values = getBestResultValues(index);
-  // SPDLOG_INFO("res_values: {}", res_values.size());
   // SPDLOG_INFO("target values: {}", tgt_values.size());
   // SPDLOG_INFO("result values: {}", res_values.size());
   if (res_values.size() > 0) {

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -291,10 +291,8 @@ const std::vector<double> &Optimization::getFitness() const {
 }
 
 common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
-  // SPDLOG_INFO("getDifferenceImage({})", index);
 
   auto size = getImageSize();
-  // SPDLOG_INFO("volume: ({}, {}, {}), index: {}", size.width(), size.height(),
   // size.depth(), index);
   auto tgt_values = getTargetValues(index);
 
@@ -303,17 +301,10 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
   auto diff_values =
       std::vector<double>(size.width() * size.height() * size.depth(), 0);
   auto res_values = getBestResultValues(index);
-  // SPDLOG_INFO("target values: {}", tgt_values.size());
-  // SPDLOG_INFO("result values: {}", res_values.size());
   if (res_values.size() > 0) {
-    // SPDLOG_INFO("diff values max before: {}", common::max(diff_values));
-    // SPDLOG_INFO("tgt_values values max: {}", common::max(tgt_values));
-    // SPDLOG_INFO("res_values values max: {}", common::max(res_values));
     std::ranges::transform(tgt_values, res_values, diff_values.begin(),
                            std::minus<double>());
   }
-  // SPDLOG_INFO("diff values: {}", diff_values.size());
-  // SPDLOG_INFO("max diff value: {}", common::max(diff_values));
   return sme::common::ImageStack(size, diff_values, common::max(diff_values));
 }
 
@@ -338,25 +329,15 @@ common::ImageStack Optimization::getTargetImage(std::size_t index) const {
 std::optional<common::ImageStack>
 Optimization::getUpdatedBestResultImage(std::size_t index) {
   std::scoped_lock lock{bestResultsMutex};
-  SPDLOG_INFO("getUpdatedBestResultImage({})", index);
-  SPDLOG_INFO("bestResults.imageIndex: {}", bestResults.imageIndex);
   if (bestResults.values.empty()) {
-    SPDLOG_INFO("bestResults.values is empty");
     return {};
   }
   if (bestResults.imageChanged || index != bestResults.imageIndex) {
-    SPDLOG_INFO("bestResults.values is not empty");
-    SPDLOG_INFO("bestResults size: {}, max {}",
-                bestResults.values[index].size(),
-                common::max(bestResults.values[index]));
-
     bestResults.imageChanged = false;
     bestResults.imageIndex = index;
     return common::ImageStack(optConstData->imageSize,
                               bestResults.values[index],
                               optConstData->maxTargetValues[index]);
-  } else {
-    SPDLOG_INFO("bestResults.imageChanged is false and index is the same");
   }
   return {};
 }
@@ -373,8 +354,6 @@ std::vector<double> Optimization::getBestResultValues(std::size_t index) const {
       bestResultsMutex}; // TODO: lock to avoid getting while it's still set?
                          // not sure it's necessary, but will leave it here just
                          // to be sure
-  SPDLOG_INFO("getBestResultValues({})", index);
-  SPDLOG_INFO("bestResults.values.size(): {}", bestResults.values.size());
   if (index > bestResults.values.size() or bestResults.values.empty()) {
     SPDLOG_CRITICAL("index outside of range for result retrieval: {} , {}",
                     index, bestResults.values.size());

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -295,7 +295,7 @@ common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
 
   auto size = getImageSize();
   // size.depth(), index);
-  const std::vector<double> &tgt_values = getTargetValues(index);
+  std::vector<double> tgt_values = getTargetValues(index);
 
   // separate allocation to make sure that common::max does not segfault when
   // called on an empty array.
@@ -370,13 +370,8 @@ std::vector<double> Optimization::getBestResultValues(std::size_t index) const {
   return bestResults.values[index];
 }
 
-std::vector<double> Optimization::getTargetValues(std::size_t index) const {
-
-  if (index >= optConstData->optimizeOptions.optCosts.size()) {
-    SPDLOG_DEBUG("index outside of range for target retrieval: {} , {}", index,
-                 bestResults.values.size());
-    return {};
-  }
+const std::vector<double> &
+Optimization::getTargetValues(std::size_t index) const {
 
   return optConstData->optimizeOptions.optCosts[index].targetValues;
 }

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -264,6 +264,19 @@ const std::vector<std::vector<double>> &Optimization::getParams() const {
   return bestParams;
 }
 
+sme::common::Volume Optimization::getImageSize() {
+  return optConstData->imageSize;
+}
+
+double Optimization::getMaxValue(std::size_t index) {
+  if (index >= optConstData->maxTargetValues.size()) {
+    SPDLOG_CRITICAL("index outside of range for max value retrieval: {} , {}",
+                    index, optConstData->maxTargetValues.size());
+    return 0;
+  }
+  return optConstData->maxTargetValues[index];
+}
+
 std::vector<QString> Optimization::getParamNames() const {
   std::vector<QString> names;
   names.reserve(optConstData->optimizeOptions.optParams.size());
@@ -275,6 +288,31 @@ std::vector<QString> Optimization::getParamNames() const {
 
 const std::vector<double> &Optimization::getFitness() const {
   return bestFitness;
+}
+
+common::ImageStack Optimization::getDifferenceImage(std::size_t index) {
+  SPDLOG_INFO("getDifferenceImage({})", index);
+
+  auto size = getImageSize();
+  SPDLOG_INFO("volume: ({}, {}, {}), index: {}", size.width(), size.height(),
+              size.depth(), index);
+  auto tgt_values = getTargetValues(index);
+  auto diff_values = tgt_values;
+  SPDLOG_INFO("tgt_value: {}", tgt_values.size());
+  auto res_values = getBestResultValues(index);
+  SPDLOG_INFO("res_values: {}", res_values.size());
+  SPDLOG_INFO("target values: {}", tgt_values.size());
+  SPDLOG_INFO("result values: {}", res_values.size());
+  if (res_values.size() > 0) {
+    SPDLOG_INFO("diff values max before: {}", common::max(diff_values));
+    SPDLOG_INFO("tgt_values values max: {}", common::max(tgt_values));
+    SPDLOG_INFO("res_values values max: {}", common::max(res_values));
+    std::ranges::transform(tgt_values, res_values, diff_values.begin(),
+                           std::minus<double>());
+  }
+  SPDLOG_INFO("diff values: {}", diff_values.size());
+  SPDLOG_INFO("max diff value: {}", common::max(diff_values));
+  return sme::common::ImageStack(size, diff_values, common::max(diff_values));
 }
 
 bool Optimization::setBestResults(double fitness,
@@ -298,17 +336,60 @@ common::ImageStack Optimization::getTargetImage(std::size_t index) const {
 std::optional<common::ImageStack>
 Optimization::getUpdatedBestResultImage(std::size_t index) {
   std::scoped_lock lock{bestResultsMutex};
+  SPDLOG_INFO("getUpdatedBestResultImage({})", index);
+  SPDLOG_INFO("bestResults.imageIndex: {}", bestResults.imageIndex);
   if (bestResults.values.empty()) {
+    SPDLOG_INFO("bestResults.values is empty");
     return {};
   }
   if (bestResults.imageChanged || index != bestResults.imageIndex) {
+    SPDLOG_INFO("bestResults.values is not empty");
+    SPDLOG_INFO("bestResults size: {}, max {}",
+                bestResults.values[index].size(),
+                common::max(bestResults.values[index]));
+
     bestResults.imageChanged = false;
     bestResults.imageIndex = index;
     return common::ImageStack(optConstData->imageSize,
                               bestResults.values[index],
                               optConstData->maxTargetValues[index]);
+  } else {
+    SPDLOG_INFO("bestResults.imageChanged is false and index is the same");
   }
   return {};
+}
+
+common::ImageStack Optimization::getCurrentBestResultImage() const {
+  std::scoped_lock lock{bestResultsMutex};
+  return common::ImageStack(
+      optConstData->imageSize, bestResults.values[bestResults.imageIndex],
+      optConstData->maxTargetValues[bestResults.imageIndex]);
+}
+
+std::vector<double> Optimization::getBestResultValues(std::size_t index) const {
+  std::scoped_lock lock{
+      bestResultsMutex}; // TODO: lock to avoid getting while it's still set?
+                         // not sure it's necessary, but will leave it here just
+                         // to be sure
+  SPDLOG_INFO("getBestResultValues({})", index);
+  SPDLOG_INFO("bestResults.values.size(): {}", bestResults.values.size());
+  if (index > bestResults.values.size() or bestResults.values.empty()) {
+    SPDLOG_CRITICAL("index outside of range for result retrieval: {} , {}",
+                    index, bestResults.values.size());
+    return {};
+  }
+  return bestResults.values[index];
+}
+
+std::vector<double> Optimization::getTargetValues(std::size_t index) const {
+
+  if (index > optConstData->optimizeOptions.optCosts.size()) {
+    SPDLOG_CRITICAL("index outside of range for target retrieval: {} , {}",
+                    index, bestResults.values.size());
+    return {};
+  }
+
+  return optConstData->optimizeOptions.optCosts[index].targetValues;
 }
 
 std::size_t Optimization::getIterations() const { return nIterations.load(); };

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -145,8 +145,6 @@ TEST_CASE("Optimize ABtoC with all algorithms for zero concentration of A",
                                       {}});
 
   for (auto optAlgorithmType : sme::simulate::optAlgorithmTypes) {
-    SPDLOG_CRITICAL("Optimizing with algorithm {}",
-                    static_cast<int>(optAlgorithmType));
     CAPTURE(optAlgorithmType);
     // some algos need larger populations
     if (optAlgorithmType == sme::simulate::OptAlgorithmType::DE) {

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -3,6 +3,8 @@
 #include "qt_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/optimize.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <spdlog/spdlog.h>
 
 using namespace sme;
 using namespace sme::test;
@@ -540,7 +542,15 @@ TEST_CASE("optimizer_imageFunctions",
     auto expected =
         sme::common::ImageStack(sme::common::Volume(100, 100, 1), diff,
                                 *std::max_element(diff.begin(), diff.end()));
-    REQUIRE(img[0] == expected[0]); // we only have one slice
+
+    REQUIRE(img.volume().depth() == expected.volume().depth());
+    REQUIRE(img[0].size() == expected[0].size()); // we only have one slice
+
+    REQUIRE(img[0].pixel(0, 0) == expected[0].pixel(0, 0));
+    REQUIRE(img[0].pixel(10, 10) == expected[0].pixel(10, 10));
+    REQUIRE(img[0].pixel(99, 99) == expected[0].pixel(99, 99));
+    REQUIRE(img[0].pixel(10, 99) == expected[0].pixel(10, 99));
+    REQUIRE(img[0].pixel(99, 10) == expected[0].pixel(99, 10));
   }
   SECTION("getTargetValues") {
     auto idx = 1;

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -16,6 +16,58 @@ static bool is_sorted_descending(const std::vector<T> &v) {
   return std::is_sorted(v.begin(), v.end(), [](T a, T b) { return a > b; });
 }
 
+struct TestOptimization {
+
+  sme::model::Model model;
+
+  TestOptimization() {
+    model = getExampleModel(Mod::ABtoC);
+
+    model.getSimulationSettings().simulatorType =
+        sme::simulate::SimulatorType::Pixel;
+    sme::simulate::OptimizeOptions optimizeOptions;
+    optimizeOptions.optAlgorithm.islands = 1;
+    optimizeOptions.optAlgorithm.population = 3;
+    // optimization parameter: k1 parameter of reaction r1
+    optimizeOptions.optParams.push_back(
+        {sme::simulate::OptParamType::ReactionParameter, "name", "k1", "r1",
+         0.02, 0.88});
+    // optimization cost: absolute difference of concentration of species C from
+    // zero, after simulating for time 1
+    optimizeOptions.optCosts.push_back(
+        {sme::simulate::OptCostType::Concentration,
+         simulate::OptCostDiffType::Absolute,
+         "name1",
+         "C",
+         1.0,
+         0.23,
+         0,
+         2,
+         {}});
+    // optimization cost: absolute difference of concentration of species A from
+    // 2, after simulating for time 1
+    // make explicit target of 2 for all pixels in compartment
+    const auto *comp{model.getSpecies().getField("A")->getCompartment()};
+    const auto compImgWidth{comp->getCompartmentImages()[0].width()};
+    const auto compImgHeight{comp->getCompartmentImages()[0].height()};
+    std::vector<double> target(
+        static_cast<std::size_t>(compImgWidth * compImgHeight), 0.0);
+    constexpr double targetPixel{2.0};
+    for (const auto &voxel : comp->getVoxels()) {
+      target[static_cast<std::size_t>(voxel.p.x()) +
+             static_cast<std::size_t>(compImgWidth) *
+                 static_cast<std::size_t>(compImgHeight - 1 - voxel.p.y())] =
+          targetPixel;
+    }
+    optimizeOptions.optCosts.push_back(
+        {sme::simulate::OptCostType::Concentration,
+         simulate::OptCostDiffType::Absolute, "name2", "A", 1.0, 0.23, 0, 2,
+         target});
+
+    model.getOptimizeOptions() = optimizeOptions;
+  }
+};
+
 TEST_CASE("Invalid population sizes",
           "[core/simulate/optimize][core/simulate][core][optimize]") {
   auto model{getExampleModel(Mod::ABtoC)};
@@ -462,4 +514,48 @@ TEST_CASE("Start long optimization in another thread & stop early",
   REQUIRE(optimization.getFitness().size() >= 1);
   REQUIRE(optimization.getFitness().back() ==
           dbl_approx(std::numeric_limits<double>::max()));
+}
+
+TEST_CASE("optimizer_imageFunctions",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  TestOptimization optim;
+  sme::simulate::Optimization optimizer(optim.model);
+
+  optimizer.evolve(5);
+
+  SECTION("getImageSize") {
+    auto imgSize = optimizer.getImageSize();
+    REQUIRE(imgSize.depth() == 1);
+    REQUIRE(imgSize.width() == 100);
+    REQUIRE(imgSize.height() == 100);
+  }
+  SECTION("getDifferenceImage") {
+    auto idx = 1;
+    auto img = optimizer.getDifferenceImage(idx);
+
+    auto diff = std::vector<double>(10000, 0);
+
+    std::ranges::transform(optimizer.getTargetValues(idx),
+                           optimizer.getBestResultValues(idx), diff.begin(),
+                           std::minus<double>());
+
+    auto expected =
+        sme::common::ImageStack(sme::common::Volume(100, 100, 1), diff,
+                                *std::max_element(diff.begin(), diff.end()));
+    REQUIRE(img[0] == expected[0]); // we only have one slice
+  }
+  SECTION("getTargetValues") {
+    auto idx = 1;
+    auto values = optimizer.getTargetValues(idx);
+    REQUIRE(values.size() == 10000);
+    REQUIRE(*std::ranges::min_element(values) == dbl_approx(0.0));
+    REQUIRE(*std::ranges::max_element(values) == dbl_approx(2.0));
+  }
+  SECTION("getCurrentBestResultImage") {
+    auto idx = 1;
+    auto values = optimizer.getBestResultValues(idx);
+    REQUIRE(values.size() == 10000);
+    REQUIRE(*std::ranges::max_element(values) > 0.0);
+    REQUIRE(*std::ranges::min_element(values) == dbl_approx(0.0));
+  }
 }

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -4,7 +4,6 @@
 #include "sme/model.hpp"
 #include "sme/optimize.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <spdlog/spdlog.h>
 
 using namespace sme;
 using namespace sme::test;

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -240,23 +240,26 @@ void DialogOptimize::btnSetup_clicked() {
 void DialogOptimize::differenceMode_clicked() {
   // this function is the slot connected to the clicked signal of the
   // differenceMode checkbox. disables the second plot pane for the result and
-  // displays the absolute difference of best result and target in the first
-  // pane.
+  // displays the naive difference of target and best result in the first
+  // plot pane.
 
-  SPDLOG_INFO("Difference mode clicked {}", differenceMode);
+  SPDLOG_CRITICAL("Difference mode clicked {}", differenceMode);
 
   if (m_opt == nullptr) {
     return;
   }
 
   differenceMode = !differenceMode;
-  SPDLOG_INFO("Difference mode after: {}", differenceMode);
+  SPDLOG_CRITICAL("Difference mode after: {}", differenceMode);
+
+  ui->lblResult->setVisible(!differenceMode);
+  ui->lblResult3D->setVisible(!differenceMode && vizMode == VizMode::_3D);
+  ui->lblResultLabel->setVisible(!differenceMode);
 
   updateTargetImage();
 
   if (differenceMode) {
-    ui->lblResult->setVisible(false);
-    ui->lblResult3D->setVisible(false);
+
     ui->lblTargetLabel->setText(
         "Difference between estimated and target image:");
   } else {
@@ -264,12 +267,12 @@ void DialogOptimize::differenceMode_clicked() {
     // reset the images when the difference mode is turned off
     ui->lblTargetLabel->setText("Target values:");
   }
-  SPDLOG_INFO("label visible: {}", ui->lblResultLabel->isVisible());
-  SPDLOG_INFO("2d res visible: {}", ui->lblResult->isVisible());
-  SPDLOG_INFO("3d res visible: {}", ui->lblResult3D->isVisible());
-  SPDLOG_INFO("2d tgt visible: {}", ui->lblTarget->isVisible());
-  SPDLOG_INFO("3d tgt visible: {}", ui->lblTarget3D->isVisible());
-  SPDLOG_INFO("tgt label: '{}'", ui->lblTargetLabel->text().toStdString());
+  SPDLOG_CRITICAL("res label visible: {}", ui->lblResultLabel->isVisible());
+  SPDLOG_CRITICAL("2d res visible: {}", ui->lblResult->isVisible());
+  SPDLOG_CRITICAL("3d res visible: {}", ui->lblResult3D->isVisible());
+  SPDLOG_CRITICAL("2d tgt visible: {}", ui->lblTarget->isVisible());
+  SPDLOG_CRITICAL("3d tgt visible: {}", ui->lblTarget3D->isVisible());
+  SPDLOG_CRITICAL("tgt label: '{}'", ui->lblTargetLabel->text().toStdString());
 }
 
 void DialogOptimize::updatePlots() {

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -177,18 +177,26 @@ void DialogOptimize::cmbTarget_currentIndexChanged(int index) {
 }
 
 void DialogOptimize::cmbMode_currentIndexChanged(int modeindex) {
-  // TODO
+  // handles the switch between 2D and 3D visualization modes
+  // this option is always there, even if the data itself is not 3D
   SPDLOG_INFO("Mode index: {}", modeindex);
   if (modeindex == 0) {
+    // 2D mode -> show the vizualization of the target and result images
+    // that are still there
     vizMode = VizMode::_2D;
     ui->lblTarget->setVisible(true);
     ui->lblResult->setVisible(true);
+    ui->lblTarget3D->setVisible(false);
+    ui->lblResult3D->setVisible(false);
   } else {
+    // show the 3D visualization of the target and result images
     vizMode = VizMode::_3D;
     // README: this is temporary and only there to show an effect of setting the
     // dim toggle.
     ui->lblTarget->setVisible(false);
     ui->lblResult->setVisible(false);
+    ui->lblTarget3D->setVisible(true);
+    ui->lblResult3D->setVisible(true);
   }
   SPDLOG_INFO("Viz mode: {}", static_cast<int>(vizMode));
 }

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -265,10 +265,6 @@ void DialogOptimize::updatePlots() {
           static_cast<std::size_t>(ui->cmbTarget->currentIndex()))};
       img.has_value()) {
     ui->lblResult->setImage(img.value());
-    if (vizMode == VizMode::_2D) {
-      ui->lblResult->setZSlider(ui->zaxisValues);
-      ui->lblResult->setZIndex(ui->zaxisValues->value());
-    }
   }
 
   updateDifferenceImage();
@@ -317,21 +313,13 @@ void DialogOptimize::updateTargetImage() {
   if (vizMode == VizMode::_2D) {
     SPDLOG_INFO("Updating target image for 2D visualization ");
     // all the z-axis stuff is only necessary for 2D visualization
-    auto z = ui->zaxisValues->value();
     ui->lblTarget->setImage(img);
-    ui->zaxisValues->setMinimum(0);
-    ui->zaxisValues->setMaximum(ui->lblTarget->getImage().volume().depth());
-    ui->zaxisValues->setValue(z);
-    ui->lblTarget->setZSlider(ui->zaxisValues);
-    ui->lblTarget->setZIndex(z);
-    ui->lblTarget->updateGeometry();
 
   } else {
     SPDLOG_DEBUG("Updating target image for 3D visualization: 2D visible? {}, "
                  "3d visible? {}",
                  ui->lblTarget->isVisible(), ui->lblTarget3D->isVisible());
     ui->lblTarget3D->setImage(img);
-    ui->lblTarget3D->updateGeometry();
   }
 }
 
@@ -345,15 +333,12 @@ void DialogOptimize::updateResultImage() {
   if (vizMode == VizMode::_2D) {
     auto z = ui->zaxisValues->value();
     ui->lblResult->setImage(m_opt->getCurrentBestResultImage());
-    ui->lblResult->setZSlider(ui->zaxisValues);
-    ui->lblResult->setZIndex(z);
-    ui->lblResult->updateGeometry();
+    // ui->lblResult->setZIndex(z);
   } else {
     SPDLOG_DEBUG("Updating result image for 3D visualization  2D visible? {}, "
                  "3d visible? {}",
                  ui->lblResult->isVisible(), ui->lblResult3D->isVisible());
     ui->lblResult3D->setImage(m_opt->getCurrentBestResultImage());
-    ui->lblResult3D->updateGeometry();
   }
 }
 
@@ -365,17 +350,9 @@ void DialogOptimize::updateDifferenceImage() {
   SPDLOG_DEBUG(" Updating difference image for variable {}", variable);
   auto img = m_opt->getDifferenceImage(variable);
   if (vizMode == VizMode::_2D) {
-    auto z = ui->zaxisDifference->value();
     ui->lblDifference->setImage(img);
-    ui->zaxisDifference->setMinimum(0);
-    ui->zaxisDifference->setMaximum(ui->lblTarget->getImage().volume().depth());
-    ui->zaxisDifference->setValue(z);
-    ui->lblDifference->setZSlider(ui->zaxisDifference);
-    ui->lblDifference->setZIndex(z);
-    ui->lblDifference->updateGeometry();
   } else {
     ui->lblDifference3D->setImage(img);
-    ui->lblDifference3D->updateGeometry();
   }
 }
 

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -243,16 +243,16 @@ void DialogOptimize::differenceMode_clicked() {
   // displays the naive difference of target and best result in the first
   // plot pane.
 
-  SPDLOG_CRITICAL("Difference mode clicked {}", differenceMode);
+  SPDLOG_DEBUG("Difference mode clicked {}", differenceMode);
 
   if (m_opt == nullptr) {
     return;
   }
 
   differenceMode = !differenceMode;
-  SPDLOG_CRITICAL("Difference mode after: {}", differenceMode);
+  SPDLOG_DEBUG("Difference mode after: {}", differenceMode);
 
-  ui->lblResult->setVisible(!differenceMode);
+  ui->lblResult->setVisible(!differenceMode && vizMode == VizMode::_2D);
   ui->lblResult3D->setVisible(!differenceMode && vizMode == VizMode::_3D);
   ui->lblResultLabel->setVisible(!differenceMode);
 
@@ -267,12 +267,12 @@ void DialogOptimize::differenceMode_clicked() {
     // reset the images when the difference mode is turned off
     ui->lblTargetLabel->setText("Target values:");
   }
-  SPDLOG_CRITICAL("res label visible: {}", ui->lblResultLabel->isVisible());
-  SPDLOG_CRITICAL("2d res visible: {}", ui->lblResult->isVisible());
-  SPDLOG_CRITICAL("3d res visible: {}", ui->lblResult3D->isVisible());
-  SPDLOG_CRITICAL("2d tgt visible: {}", ui->lblTarget->isVisible());
-  SPDLOG_CRITICAL("3d tgt visible: {}", ui->lblTarget3D->isVisible());
-  SPDLOG_CRITICAL("tgt label: '{}'", ui->lblTargetLabel->text().toStdString());
+  SPDLOG_DEBUG("res label visible: {}", ui->lblResultLabel->isVisible());
+  SPDLOG_DEBUG("2d res visible: {}", ui->lblResult->isVisible());
+  SPDLOG_DEBUG("3d res visible: {}", ui->lblResult3D->isVisible());
+  SPDLOG_DEBUG("2d tgt visible: {}", ui->lblTarget->isVisible());
+  SPDLOG_DEBUG("3d tgt visible: {}", ui->lblTarget3D->isVisible());
+  SPDLOG_DEBUG("tgt label: '{}'", ui->lblTargetLabel->text().toStdString());
 }
 
 void DialogOptimize::updatePlots() {
@@ -339,12 +339,12 @@ void DialogOptimize::updateTargetImage() {
   }
 
   auto variable = ui->cmbTarget->currentIndex();
-  SPDLOG_INFO(" Updating target image for variable {}", variable);
+  SPDLOG_DEBUG(" Updating target image for variable {}", variable);
 
   auto img = differenceMode ? m_opt->getDifferenceImage(variable)
                             : m_opt->getTargetImage(variable);
-  SPDLOG_INFO("difference mode: {}", differenceMode);
-  SPDLOG_INFO(" data: {}, empty: {}", img.volume().depth(), img.empty());
+  SPDLOG_DEBUG("difference mode: {}", differenceMode);
+  SPDLOG_DEBUG(" data: {}, empty: {}", img.volume().depth(), img.empty());
 
   if (vizMode == VizMode::_2D) {
     SPDLOG_INFO("Updating target image for 2D visualization ");
@@ -355,12 +355,14 @@ void DialogOptimize::updateTargetImage() {
     ui->lblTarget->setZIndex(z);
     ui->zaxis->setMaximum(ui->lblTarget->getImage().volume().depth());
     ui->zaxis->setValue(z);
+    ui->lblTarget3D->updateGeometry();
 
   } else {
-    SPDLOG_INFO("Updating target image for 3D visualization: 2D visible? {}, "
-                "3d visible? {}",
-                ui->lblTarget->isVisible(), ui->lblTarget3D->isVisible());
+    SPDLOG_DEBUG("Updating target image for 3D visualization: 2D visible? {}, "
+                 "3d visible? {}",
+                 ui->lblTarget->isVisible(), ui->lblTarget3D->isVisible());
     ui->lblTarget3D->setImage(img);
+    ui->lblTarget3D->updateGeometry();
   }
 }
 
@@ -376,23 +378,19 @@ void DialogOptimize::updateResultImage() {
     ui->lblResult->setImage(m_opt->getCurrentBestResultImage());
     ui->lblResult->setZSlider(ui->zaxis);
     ui->lblResult->setZIndex(z);
-
-    // which of this shit do I need really?
     ui->lblResult->updateGeometry();
-    ui->lblResult->parentWidget()->layout()->invalidate();
-    ui->lblResult->parentWidget()->layout()->activate();
-    ui->lblResult->parentWidget()->adjustSize();
+    // ui->lblResult->parentWidget()->layout()->invalidate();
+    // ui->lblResult->parentWidget()->layout()->activate();
+    // ui->lblResult->parentWidget()->adjustSize();
   } else {
-    SPDLOG_INFO("Updating result image for 3D visualization  2D visible? {}, "
-                "3d visible? {}",
-                ui->lblResult->isVisible(), ui->lblResult3D->isVisible());
+    SPDLOG_DEBUG("Updating result image for 3D visualization  2D visible? {}, "
+                 "3d visible? {}",
+                 ui->lblResult->isVisible(), ui->lblResult3D->isVisible());
     ui->lblResult3D->setImage(m_opt->getCurrentBestResultImage());
-
-    // which of this shit do I need really?
     ui->lblResult3D->updateGeometry();
-    ui->lblResult3D->parentWidget()->layout()->invalidate();
-    ui->lblResult3D->parentWidget()->layout()->activate();
-    ui->lblResult3D->parentWidget()->adjustSize();
+    // ui->lblResult3D->parentWidget()->layout()->invalidate();
+    // ui->lblResult3D->parentWidget()->layout()->activate();
+    // ui->lblResult3D->parentWidget()->adjustSize();
   }
 }
 

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -117,11 +117,12 @@ void DialogOptimize::applyToModel() const {
 
 void DialogOptimize::init() {
   ui->lblResult->setImage({});
-  ui->cmbTarget->clear();
+  ui->lblDifference->setImage({});
   ui->lblResult3D->setImage({});
   ui->lblTarget3D->setImage({});
   ui->lblDifference3D->setImage({});
-  ui->lblDifference->setImage({});
+  ui->cmbTarget->clear();
+  ui->cmbMode->clear();
   if (m_model.getOptimizeOptions().optParams.empty() ||
       m_model.getOptimizeOptions().optCosts.empty()) {
     m_opt.reset();
@@ -137,7 +138,6 @@ void DialogOptimize::init() {
   for (const auto &optCost : m_model.getOptimizeOptions().optCosts) {
     ui->cmbTarget->addItem(optCost.name.c_str());
   }
-  ui->cmbMode->clear();
   ui->cmbMode->setEnabled(true);
   for (auto &&label : {"2D", "3D"}) {
     ui->cmbMode->addItem(label);
@@ -155,18 +155,17 @@ void DialogOptimize::init() {
   initFitnessPlot(ui->pltFitness);
   initParamsPlot(ui->pltParams, m_opt->getParamNames());
 
-  for (auto &&panel : {ui->lblTarget, ui->lblResult, ui->lblDifference}) {
-    panel->setZIndex(0);
-    panel->displayGrid(true);
-    panel->displayScale(true);
-  }
-
   // target and result images have the same dimensions, so we can use only one
   // to set the range of the z-slider
   ui->cmbMode->setCurrentIndex(0);
   ui->lblResult->setZSlider(ui->zaxisValues);
   ui->lblTarget->setZSlider(ui->zaxisValues);
   ui->lblDifference->setZSlider(ui->zaxisDifference);
+  for (auto &&panel : {ui->lblTarget, ui->lblResult, ui->lblDifference}) {
+    panel->setZIndex(0);
+    panel->displayGrid(true);
+    panel->displayScale(true);
+  }
 }
 
 void DialogOptimize::cmbTarget_currentIndexChanged(int index) {

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -73,7 +73,7 @@ DialogOptimize::DialogOptimize(sme::model::Model &model, QWidget *parent)
           &DialogOptimize::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
           &DialogOptimize::reject);
-  connect(ui->differenceMode, &QCheckBox::clicked, this,
+  connect(ui->diffMode, &QCheckBox::clicked, this,
           &DialogOptimize::differenceMode_clicked);
   init();
   m_plotRefreshTimer.setTimerType(Qt::TimerType::VeryCoarseTimer);
@@ -112,6 +112,8 @@ void DialogOptimize::applyToModel() const {
 void DialogOptimize::init() {
   ui->lblResult->setImage({});
   ui->cmbTarget->clear();
+  ui->diffMode->setCheckable(true);
+
   if (m_model.getOptimizeOptions().optParams.empty() ||
       m_model.getOptimizeOptions().optCosts.empty()) {
     m_opt.reset();
@@ -186,6 +188,7 @@ void DialogOptimize::cmbMode_currentIndexChanged(int modeindex) {
     vizMode = VizMode::_2D;
     ui->lblTarget->setVisible(true);
     ui->lblResult->setVisible(!differenceMode);
+    ui->zaxis->setVisible(true);
     ui->lblTarget3D->setVisible(false);
     ui->lblResult3D->setVisible(false);
     updateTargetImage();
@@ -195,9 +198,9 @@ void DialogOptimize::cmbMode_currentIndexChanged(int modeindex) {
 
     // show the 3D visualization of the target and result images
     vizMode = VizMode::_3D;
-
     ui->lblTarget->setVisible(false);
     ui->lblResult->setVisible(false);
+    ui->zaxis->setVisible(false);
     ui->lblTarget3D->setVisible(true);
     ui->lblResult3D->setVisible(!differenceMode);
     updateTargetImage();

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -304,11 +304,11 @@ void DialogOptimize::updateTargetImage() {
   // this handles the distinction between 2D and 3D visualizations when setting
   // image data for the image that displays the target values
   // and handles the z-slider for the 2D visualization
-  if (m_opt == nullptr) {
+  auto variable = ui->cmbTarget->currentIndex();
+  if (m_opt == nullptr || variable < 0 || variable >= ui->cmbTarget->count()) {
     return;
   }
 
-  auto variable = ui->cmbTarget->currentIndex();
   SPDLOG_DEBUG(" Updating target image for variable {}", variable);
 
   auto img = m_opt->getTargetImage(variable);
@@ -358,10 +358,10 @@ void DialogOptimize::updateResultImage() {
 }
 
 void DialogOptimize::updateDifferenceImage() {
-  if (m_opt == nullptr) {
+  auto variable = ui->cmbTarget->currentIndex();
+  if (m_opt == nullptr || variable < 0 || variable >= ui->cmbTarget->count()) {
     return;
   }
-  auto variable = ui->cmbTarget->currentIndex();
   SPDLOG_DEBUG(" Updating difference image for variable {}", variable);
   auto img = m_opt->getDifferenceImage(variable);
   if (vizMode == VizMode::_2D) {

--- a/gui/dialogs/dialogoptimize.hpp
+++ b/gui/dialogs/dialogoptimize.hpp
@@ -27,7 +27,6 @@ public:
   };
 
   VizMode getVizMode() const;
-  bool getDifferenceMode() const;
 
 private:
   sme::model::Model &m_model;
@@ -36,7 +35,6 @@ private:
   std::future<std::size_t> m_optIterations;
   std::size_t m_nPlottedIterations{0};
   QTimer m_plotRefreshTimer;
-  bool differenceMode{false};
   VizMode vizMode{VizMode::_2D};
   void init();
   void cmbTarget_currentIndexChanged(int index);
@@ -44,9 +42,10 @@ private:
   void btnStartStop_clicked();
   void btnSetup_clicked();
   void updatePlots();
+  void updateTabs();
   void finalizePlots();
-  void differenceMode_clicked();
   void selectZ();
   void updateTargetImage();
   void updateResultImage();
+  void updateDifferenceImage();
 };

--- a/gui/dialogs/dialogoptimize.hpp
+++ b/gui/dialogs/dialogoptimize.hpp
@@ -21,6 +21,11 @@ public:
   QString getParametersString() const;
   void applyToModel() const;
 
+  enum struct VizMode {
+    _2D,
+    _3D,
+  };
+
 private:
   sme::model::Model &m_model;
   std::unique_ptr<Ui::DialogOptimize> ui;
@@ -28,10 +33,15 @@ private:
   std::future<std::size_t> m_optIterations;
   std::size_t m_nPlottedIterations{0};
   QTimer m_plotRefreshTimer;
+  bool differenceMode{false};
+  VizMode vizMode{VizMode::_2D};
   void init();
   void cmbTarget_currentIndexChanged(int index);
+  void cmbMode_currentIndexChanged(int index);
   void btnStartStop_clicked();
   void btnSetup_clicked();
   void updatePlots();
   void finalizePlots();
+  void differenceMode_clicked();
+  void selectZ();
 };

--- a/gui/dialogs/dialogoptimize.hpp
+++ b/gui/dialogs/dialogoptimize.hpp
@@ -26,6 +26,9 @@ public:
     _3D,
   };
 
+  VizMode getVizMode() const;
+  bool getDifferenceMode() const;
+
 private:
   sme::model::Model &m_model;
   std::unique_ptr<Ui::DialogOptimize> ui;
@@ -44,4 +47,6 @@ private:
   void finalizePlots();
   void differenceMode_clicked();
   void selectZ();
+  void updateTargetImage();
+  void updateResultImage();
 };

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -354,7 +354,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="layoutWidget">
+       <widget class="QWidget" name="layoutWidget1">
         <layout class="QVBoxLayout" name="vlayout2">
          <item>
           <widget class="QCustomPlot" name="pltFitness" native="true"/>

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1261</width>
-    <height>873</height>
+    <height>885</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -159,6 +159,12 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
           </widget>
          </item>
          <item row="2" column="1">
@@ -178,6 +184,12 @@
           <widget class="QVoxelRenderer" name="lblResult3D">
            <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
           </widget>
          </item>

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -33,9 +33,9 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <widget class="QWidget" name="">
+       <widget class="QWidget" name="layoutWidget">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="3" column="0" colspan="2">
+         <item row="10" column="0" colspan="3">
           <widget class="QLabel" name="lblResultLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -45,6 +45,76 @@
            </property>
            <property name="text">
             <string>Values using current best parameters:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0" colspan="3">
+          <widget class="QLabel" name="lblTargetLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Target values:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0">
+          <widget class="QSlider" name="zaxis">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0">
+          <widget class="QLabel" name="zlabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>z-axis</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="3">
+          <widget class="QLabelMouseTracker" name="lblTarget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>300</height>
+            </size>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+           </property>
+           <property name="text" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblCmbModeLabel">
+           <property name="text">
+            <string>Plotting mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QCheckBox" name="differenceMode">
+           <property name="text">
+            <string>show difference</string>
            </property>
           </widget>
          </item>
@@ -61,30 +131,19 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="2">
+         <item row="11" column="0" colspan="3">
           <widget class="QLabelMouseTracker" name="lblResult" native="true">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
-      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
-           </property>
-           <property name="text" stdset="0">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QLabelMouseTracker" name="lblTarget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+           <property name="minimumSize">
+            <size>
+             <width>300</width>
+             <height>300</height>
+            </size>
            </property>
            <property name="whatsThis">
             <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
@@ -105,22 +164,12 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QLabel" name="lblTargetLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Target values:</string>
-           </property>
-          </widget>
+         <item row="2" column="1">
+          <widget class="QComboBox" name="cmbMode"/>
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="">
+       <widget class="QWidget" name="layoutWidget">
         <layout class="QVBoxLayout" name="vlayout2">
          <item>
           <widget class="QCustomPlot" name="pltFitness" native="true"/>

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1261</width>
-    <height>861</height>
+    <height>873</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,19 +35,6 @@
        </property>
        <widget class="QWidget" name="layoutWidget">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="10" column="0" colspan="3">
-          <widget class="QLabel" name="lblResultLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Values using current best parameters:</string>
-           </property>
-          </widget>
-         </item>
          <item row="8" column="0" colspan="3">
           <widget class="QLabel" name="lblTargetLabel">
            <property name="sizePolicy">
@@ -61,27 +48,7 @@
            </property>
           </widget>
          </item>
-         <item row="13" column="0">
-          <widget class="QSlider" name="zaxis">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="0">
-          <widget class="QLabel" name="zlabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>z-axis</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0" colspan="3">
+         <item row="10" column="0" colspan="3">
           <widget class="QLabelMouseTracker" name="lblTarget" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -104,17 +71,17 @@
            </property>
           </widget>
          </item>
+         <item row="15" column="0">
+          <widget class="QSlider" name="zaxis">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
          <item row="2" column="0">
           <widget class="QLabel" name="lblCmbModeLabel">
            <property name="text">
             <string>Plotting mode:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QCheckBox" name="differenceMode">
-           <property name="text">
-            <string>show difference</string>
            </property>
           </widget>
          </item>
@@ -132,6 +99,39 @@
           </widget>
          </item>
          <item row="11" column="0" colspan="3">
+          <widget class="QLabel" name="lblResultLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Values using current best parameters:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="0">
+          <widget class="QLabel" name="zlabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>z-axis</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QCheckBox" name="differenceMode">
+           <property name="text">
+            <string>show difference</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0" colspan="3">
           <widget class="QLabelMouseTracker" name="lblResult" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -154,6 +154,16 @@
            </property>
           </widget>
          </item>
+         <item row="9" column="0">
+          <widget class="QVoxelRenderer" name="lblTarget3D">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QComboBox" name="cmbMode"/>
+         </item>
          <item row="0" column="1">
           <widget class="QComboBox" name="cmbTarget">
            <property name="sizePolicy">
@@ -164,8 +174,12 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QComboBox" name="cmbMode"/>
+         <item row="12" column="0">
+          <widget class="QVoxelRenderer" name="lblResult3D">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -235,6 +249,11 @@
    <class>QCustomPlot</class>
    <extends>QWidget</extends>
    <header>qcustomplot.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QVoxelRenderer</class>
+   <extends>QOpenGLWidget</extends>
+   <header>qvoxelrenderer.hpp</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1261</width>
-    <height>885</height>
+    <width>1130</width>
+    <height>884</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,166 +30,325 @@
     <layout class="QVBoxLayout" name="vlayout0">
      <item>
       <widget class="QSplitter" name="splitter">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>800</height>
+        </size>
+       </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <widget class="QWidget" name="layoutWidget">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="8" column="0" colspan="3">
-          <widget class="QLabel" name="lblTargetLabel">
+         <item row="1" column="3">
+          <widget class="QComboBox" name="cmbMode">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="text">
-            <string>Target values:</string>
-           </property>
           </widget>
          </item>
-         <item row="10" column="0" colspan="3">
-          <widget class="QLabelMouseTracker" name="lblTarget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>300</height>
-            </size>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
-      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
-           </property>
-           <property name="text" stdset="0">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="15" column="0">
-          <widget class="QSlider" name="zaxis">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
+         <item row="1" column="0" colspan="3">
           <widget class="QLabel" name="lblCmbModeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Plotting mode:</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
+         <item row="0" column="3">
+          <widget class="QComboBox" name="cmbTarget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" rowspan="2" colspan="4">
+          <widget class="QTabWidget" name="tabWidget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>5</horstretch>
+             <verstretch>5</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <widget class="QWidget" name="values">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="title">
+             <string>Values</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <widget class="QLabel" name="lblTargetLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Target values:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabelMouseTracker" name="lblTarget" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>100</height>
+                </size>
+               </property>
+               <property name="whatsThis">
+                <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+               </property>
+               <property name="text" stdset="0">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QVoxelRenderer" name="lblTarget3D">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblResultLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Values using current best parameters:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabelMouseTracker" name="lblResult" native="true">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>100</height>
+                </size>
+               </property>
+               <property name="whatsThis">
+                <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+               </property>
+               <property name="text" stdset="0">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QVoxelRenderer" name="lblResult3D">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="zlabelValues">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>z-axis</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="zaxisValues">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="differences">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="title">
+             <string>Differences</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <item>
+              <widget class="QLabel" name="lblDifferenceLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Difference between result and estimation:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabelMouseTracker" name="lblDifference" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>100</height>
+                </size>
+               </property>
+               <property name="whatsThis">
+                <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
+      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
+               </property>
+               <property name="text" stdset="0">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QVoxelRenderer" name="lblDifference3D">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>100</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="zlabelDifference">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>z-axis</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="zaxisDifference">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="3">
           <widget class="QLabel" name="lblCmbTargetLabel">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="text">
             <string>Target:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="0" colspan="3">
-          <widget class="QLabel" name="lblResultLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Values using current best parameters:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="0">
-          <widget class="QLabel" name="zlabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>z-axis</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QCheckBox" name="diffMode">
-           <property name="text">
-            <string>show difference</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="0" colspan="3">
-          <widget class="QLabelMouseTracker" name="lblResult" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>300</width>
-             <height>300</height>
-            </size>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Initial concentration&lt;/h4&gt;
-      &lt;p&gt;An image of the initial concentration resulting from the supplied analytic expression.&lt;/p&gt;</string>
-           </property>
-           <property name="text" stdset="0">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QVoxelRenderer" name="lblTarget3D">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QComboBox" name="cmbMode"/>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbTarget">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="0">
-          <widget class="QVoxelRenderer" name="lblResult3D">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
            </property>
           </widget>
          </item>
@@ -209,6 +368,9 @@
      </item>
      <item>
       <layout class="QHBoxLayout" name="vlayout1">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
        <item>
         <widget class="QPushButton" name="btnSetup">
          <property name="sizePolicy">

--- a/gui/dialogs/dialogoptimize.ui
+++ b/gui/dialogs/dialogoptimize.ui
@@ -125,7 +125,7 @@
           </widget>
          </item>
          <item row="7" column="0">
-          <widget class="QCheckBox" name="differenceMode">
+          <widget class="QCheckBox" name="diffMode">
            <property name="text">
             <string>show difference</string>
            </property>

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -2,8 +2,11 @@
 #include "dialogoptimize.hpp"
 #include "model_test_utils.hpp"
 #include "qt_test_utils.hpp"
+#include <QCheckBox>
 #include <QComboBox>
+#include <QLabel>
 #include <QPushButton>
+#include <QSlider>
 
 using namespace sme;
 using namespace sme::test;
@@ -13,10 +16,28 @@ struct DialogOptimizeWidgets {
     GET_DIALOG_WIDGET(QComboBox, cmbTarget);
     GET_DIALOG_WIDGET(QPushButton, btnSetup);
     GET_DIALOG_WIDGET(QPushButton, btnStartStop);
+    GET_DIALOG_WIDGET(QCheckBox, differenceMode);
+    GET_DIALOG_WIDGET(QComboBox, cmbMode);
+    GET_DIALOG_WIDGET(QLabel, lblResultLabel);
+    GET_DIALOG_WIDGET(QLabel, lblTargetLabel);
+    GET_DIALOG_WIDGET(QSlider, zaxis);
+    GET_DIALOG_WIDGET(QWidget, lblTarget);
+    GET_DIALOG_WIDGET(QWidget, lblResult);
+    GET_DIALOG_WIDGET(QWidget, lblTarget3D);
+    GET_DIALOG_WIDGET(QWidget, lblResult3D);
   }
   QComboBox *cmbTarget;
   QPushButton *btnSetup;
   QPushButton *btnStartStop;
+  QCheckBox *differenceMode;
+  QComboBox *cmbMode;
+  QLabel *lblResultLabel;
+  QLabel *lblTargetLabel;
+  QSlider *zaxis;
+  QWidget *lblTarget;
+  QWidget *lblResult;
+  QWidget *lblTarget3D;
+  QWidget *lblResult3D;
 };
 
 TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
@@ -40,6 +61,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
                                       0,
                                       {}});
   model.getOptimizeOptions() = optimizeOptions;
+
   SECTION("no optimizeOptions") {
     model.getOptimizeOptions() = {};
     DialogOptimize dia(model);
@@ -66,5 +88,66 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     sendMouseClick(widgets.btnStartStop);
     auto lines{dia.getParametersString().split("\n")};
     REQUIRE(lines.size() == 1);
+  }
+  SECTION("differenceMode") {
+    DialogOptimize dia(model);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
+    QTest::qWait(100); // Ensure the dialog is fully shown
+    // evolve params for 3secs
+    sendMouseClick(widgets.btnStartStop);
+    wait(3000);
+    sendMouseClick(widgets.btnStartStop);
+
+    REQUIRE(widgets.lblResult->isVisible() == true);
+    REQUIRE(widgets.lblTarget->isVisible() == true);
+    REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(dia.getDifferenceMode() == false);
+    widgets.differenceMode->setFocus(); // Ensure the checkbox has focus
+    sendMouseClick(widgets.differenceMode);
+
+    SPDLOG_CRITICAL("difference mode: {}", dia.getDifferenceMode());
+    REQUIRE(dia.getDifferenceMode() == true);
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+
+    REQUIRE(widgets.lblResultLabel->isVisible() == false);
+    REQUIRE(widgets.lblResult->isVisible() == false);
+    REQUIRE(widgets.lblTarget->isVisible() == true);
+    REQUIRE(widgets.lblTargetLabel->text() ==
+            "Difference between estimated and target image:");
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+  }
+
+  SECTION("visualization mode") {
+    DialogOptimize dia(model);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
+    // evolve params for 3secs
+    sendMouseClick(widgets.btnStartStop);
+    wait(3000);
+    sendMouseClick(widgets.btnStartStop);
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    REQUIRE(widgets.lblResult->isVisible() == true);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(widgets.lblTarget->isVisible() == true);
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+
+    widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
+
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
+    REQUIRE(widgets.lblResult->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == true);
+    REQUIRE(widgets.lblTarget->isVisible() == false);
+    REQUIRE(widgets.lblTarget3D->isVisible() == true);
+
+    // widgets.cmbMode->setCurrentIndex(0); // switch to 3D visualization
+
+    // REQUIRE(widgets.lblResult->isVisible() == true);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
   }
 }

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -7,6 +7,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSlider>
+#include <catch2/catch_test_macros.hpp>
+#include <qtabwidget.h>
 #include <qwidget.h>
 
 using namespace sme;
@@ -31,6 +33,7 @@ struct DialogOptimizeWidgets {
     GET_DIALOG_WIDGET(QWidget, lblDifference);
     GET_DIALOG_WIDGET(QWidget, lblDifference3D);
     GET_DIALOG_WIDGET(QLabel, lblDifferenceLabel);
+    GET_DIALOG_WIDGET(QTabWidget, tabWidget);
   }
   QComboBox *cmbTarget;
   QPushButton *btnSetup;
@@ -49,6 +52,7 @@ struct DialogOptimizeWidgets {
   QWidget *lblResult3D;
   QWidget *lblDifference;
   QWidget *lblDifference3D;
+  QTabWidget *tabWidget;
 };
 
 TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
@@ -72,14 +76,13 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
                                       0,
                                       {}});
   model.getOptimizeOptions() = optimizeOptions;
-
   SECTION("no optimizeOptions") {
     model.getOptimizeOptions() = {};
     DialogOptimize dia(model);
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
     QTest::qWait(100);
-    // // no valid initial optimize options
+    // no valid initial optimize options
     REQUIRE(widgets.btnStartStop->text() == "Start");
     REQUIRE(widgets.btnStartStop->isEnabled() == false);
     REQUIRE(widgets.btnSetup->isEnabled() == true);
@@ -90,48 +93,93 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
     QTest::qWait(100);
-    REQUIRE(3 == 3);
-
-    // // valid initial optimize options
-    // REQUIRE(widgets.btnStartStop->isEnabled() == true);
-    // REQUIRE(widgets.btnSetup->isEnabled() == true);
-    // // no initial parameters
-    // REQUIRE(dia.getParametersString().isEmpty());
-    // // evolve params for 3secs
-    // sendMouseClick(widgets.btnStartStop);
-    // wait(3000);
-    // sendMouseClick(widgets.btnStartStop);
-    // auto lines{dia.getParametersString().split("\n")};
-    // REQUIRE(lines.size() == 1);
+    // valid initial optimize options
+    REQUIRE(widgets.btnStartStop->isEnabled() == true);
+    REQUIRE(widgets.btnSetup->isEnabled() == true);
+    // no initial parameters
+    REQUIRE(dia.getParametersString().isEmpty());
+    // evolve params for 3secs
+    sendMouseClick(widgets.btnStartStop);
+    wait(3000);
+    sendMouseClick(widgets.btnStartStop);
+    auto lines{dia.getParametersString().split("\n")};
+    REQUIRE(lines.size() == 1);
   }
+  SECTION("visualization modes") {
+    DialogOptimize dia(model);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
+    // evolve params for 3secs
+    sendMouseClick(widgets.btnStartStop);
+    wait(3000);
+    sendMouseClick(widgets.btnStartStop);
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    REQUIRE(widgets.tabWidget->currentIndex() == 0);
+    REQUIRE(widgets.lblResult->isVisible() == true);
+    REQUIRE(widgets.lblTarget->isVisible() == true);
+    REQUIRE(widgets.zaxisValues->isVisible() == true);
+    REQUIRE(widgets.zlabelValues->isVisible() == true);
+    REQUIRE(widgets.lblDifference->isVisible() == false);
+    REQUIRE(widgets.zaxisDifference->isVisible() == false);
+    REQUIRE(widgets.zlabelDifference->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
 
-  // SECTION("visualization mode") {
-  //   DialogOptimize dia(model);
-  //   DialogOptimizeWidgets widgets(&dia);
-  //   dia.show();
-  //   // evolve params for 3secs
-  //   sendMouseClick(widgets.btnStartStop);
-  //   wait(3000);
-  //   sendMouseClick(widgets.btnStartStop);
-  //   REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-  //   REQUIRE(widgets.lblResult->isVisible() == true);
-  //   REQUIRE(widgets.lblResult3D->isVisible() == false);
-  //   REQUIRE(widgets.lblTarget->isVisible() == true);
-  //   REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // switch to difference tab
+    widgets.tabWidget->setCurrentIndex(1);
+    REQUIRE(widgets.tabWidget->currentIndex() == 1);
+    REQUIRE(widgets.lblResult->isVisible() == false);
+    REQUIRE(widgets.lblTarget->isVisible() == false);
+    REQUIRE(widgets.zaxisValues->isVisible() == false);
+    REQUIRE(widgets.zlabelValues->isVisible() == false);
+    REQUIRE(widgets.lblDifference->isVisible() == true);
+    REQUIRE(widgets.zaxisDifference->isVisible() == true);
+    REQUIRE(widgets.zlabelDifference->isVisible() == true);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
 
-  //   widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
+    widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
+    REQUIRE(widgets.tabWidget->currentIndex() == 1);
+    REQUIRE(widgets.lblResult->isVisible() == false);
+    REQUIRE(widgets.lblTarget->isVisible() == false);
+    REQUIRE(widgets.zaxisValues->isVisible() == false);
+    REQUIRE(widgets.zlabelValues->isVisible() == false);
+    REQUIRE(widgets.lblDifference->isVisible() == false);
+    REQUIRE(widgets.zaxisDifference->isVisible() == false);
+    REQUIRE(widgets.zlabelDifference->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblDifference3D->isVisible() == true);
 
-  //   REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
-  //   REQUIRE(widgets.lblResult->isVisible() == false);
-  //   REQUIRE(widgets.lblResult3D->isVisible() == true);
-  //   REQUIRE(widgets.lblTarget->isVisible() == false);
-  //   REQUIRE(widgets.lblTarget3D->isVisible() == true);
+    widgets.tabWidget->setCurrentIndex(0); // switch back to target/result tab
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
+    REQUIRE(widgets.tabWidget->currentIndex() == 0);
+    REQUIRE(widgets.lblResult->isVisible() == false);
+    REQUIRE(widgets.lblTarget->isVisible() == false);
+    REQUIRE(widgets.zaxisValues->isVisible() == false);
+    REQUIRE(widgets.zlabelValues->isVisible() == false);
+    REQUIRE(widgets.lblDifference->isVisible() == false);
+    REQUIRE(widgets.zaxisDifference->isVisible() == false);
+    REQUIRE(widgets.zlabelDifference->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == true);
+    REQUIRE(widgets.lblTarget3D->isVisible() == true);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
 
-  //   widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
-
-  //   REQUIRE(widgets.lblResult->isVisible() == true);
-  //   REQUIRE(widgets.lblResult3D->isVisible() == false);
-  //   REQUIRE(widgets.lblTarget->isVisible() == true);
-  //   REQUIRE(widgets.lblTarget3D->isVisible() == false);
-  // }
+    widgets.cmbMode->setCurrentIndex(0); // switch to 2D visualization again
+    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    REQUIRE(widgets.tabWidget->currentIndex() == 0);
+    REQUIRE(widgets.lblResult->isVisible() == true);
+    REQUIRE(widgets.lblTarget->isVisible() == true);
+    REQUIRE(widgets.zaxisValues->isVisible() == true);
+    REQUIRE(widgets.zlabelValues->isVisible() == true);
+    REQUIRE(widgets.lblDifference->isVisible() == false);
+    REQUIRE(widgets.zaxisDifference->isVisible() == false);
+    REQUIRE(widgets.zlabelDifference->isVisible() == false);
+    REQUIRE(widgets.lblResult3D->isVisible() == false);
+    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
+  }
 }

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -7,6 +7,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSlider>
+#include <qtabwidget.h>
+#include <qwidget.h>
 
 using namespace sme;
 using namespace sme::test;
@@ -16,7 +18,6 @@ struct DialogOptimizeWidgets {
     GET_DIALOG_WIDGET(QComboBox, cmbTarget);
     GET_DIALOG_WIDGET(QPushButton, btnSetup);
     GET_DIALOG_WIDGET(QPushButton, btnStartStop);
-    GET_DIALOG_WIDGET(QCheckBox, diffMode);
     GET_DIALOG_WIDGET(QComboBox, cmbMode);
     GET_DIALOG_WIDGET(QLabel, lblResultLabel);
     GET_DIALOG_WIDGET(QLabel, lblTargetLabel);
@@ -25,11 +26,15 @@ struct DialogOptimizeWidgets {
     GET_DIALOG_WIDGET(QWidget, lblResult);
     GET_DIALOG_WIDGET(QWidget, lblTarget3D);
     GET_DIALOG_WIDGET(QWidget, lblResult3D);
+    GET_DIALOG_WIDGET(QLabel, lblDifferenceLabel);
+    GET_DIALOG_WIDGET(QWidget, lblDifference);
+    GET_DIALOG_WIDGET(QWidget, lblDifference3D);
+    GET_DIALOG_WIDGET(QTabWidget, tabWidget);
   }
   QComboBox *cmbTarget;
+  QTabWidget *tabWidget;
   QPushButton *btnSetup;
   QPushButton *btnStartStop;
-  QCheckBox *diffMode;
   QComboBox *cmbMode;
   QLabel *lblResultLabel;
   QLabel *lblTargetLabel;
@@ -38,6 +43,9 @@ struct DialogOptimizeWidgets {
   QWidget *lblResult;
   QWidget *lblTarget3D;
   QWidget *lblResult3D;
+  QLabel *lblDifferenceLabel;
+  QWidget *lblDifference;
+  QWidget *lblDifference3D;
 };
 
 TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
@@ -92,37 +100,37 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     REQUIRE(lines.size() == 1);
   }
   SECTION("differenceMode") {
-    DialogOptimize dia(model);
-    DialogOptimizeWidgets widgets(&dia);
-    dia.show();
-    QTest::qWait(100); // Ensure the dialog is fully shown
-    REQUIRE(widgets.diffMode->isCheckable() == true);
-    // evolve params for 3secs
-    sendMouseClick(widgets.btnStartStop);
-    wait(3000);
-    sendMouseClick(widgets.btnStartStop);
+    // DialogOptimize dia(model);
+    // DialogOptimizeWidgets widgets(&dia);
+    // dia.show();
+    // QTest::qWait(100); // Ensure the dialog is fully shown
+    // REQUIRE(widgets.diffMode->isCheckable() == true);
+    // // evolve params for 3secs
+    // sendMouseClick(widgets.btnStartStop);
+    // wait(3000);
+    // sendMouseClick(widgets.btnStartStop);
 
-    REQUIRE(widgets.lblResult->isVisible() == true);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(dia.getDifferenceMode() == false);
-    REQUIRE(widgets.diffMode->isChecked() == false);
-    REQUIRE(widgets.diffMode->isEnabled() == true);
-    // TODO: check that the normal image is displayed
-    widgets.diffMode->click();
-    REQUIRE(widgets.diffMode->isChecked() == true);
-    REQUIRE(dia.getDifferenceMode() == true);
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    REQUIRE(widgets.lblResultLabel->isVisible() == false);
-    REQUIRE(widgets.lblResult->isVisible() == false);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTargetLabel->text() ==
-            "Difference between estimated and target image:");
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // TODO: check that the diff image is displayed
+    // REQUIRE(widgets.lblResult->isVisible() == true);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(dia.getDifferenceMode() == false);
+    // REQUIRE(widgets.diffMode->isChecked() == false);
+    // REQUIRE(widgets.diffMode->isEnabled() == true);
+    // // TODO: check that the normal image is displayed
+    // widgets.diffMode->click();
+    // REQUIRE(widgets.diffMode->isChecked() == true);
+    // REQUIRE(dia.getDifferenceMode() == true);
+    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    // REQUIRE(widgets.lblResultLabel->isVisible() == false);
+    // REQUIRE(widgets.lblResult->isVisible() == false);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTargetLabel->text() ==
+    //         "Difference between estimated and target image:");
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // // TODO: check that the diff image is displayed
   }
 
   SECTION("visualization mode") {
@@ -138,7 +146,8 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     REQUIRE(widgets.lblResult3D->isVisible() == false);
     REQUIRE(widgets.lblTarget->isVisible() == true);
     REQUIRE(widgets.lblTarget3D->isVisible() == false);
-
+    REQUIRE(widgets.lblDifference->isVisible() == true);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
     widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
 
     REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
@@ -146,62 +155,66 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     REQUIRE(widgets.lblResult3D->isVisible() == true);
     REQUIRE(widgets.lblTarget->isVisible() == false);
     REQUIRE(widgets.lblTarget3D->isVisible() == true);
-
+    REQUIRE(widgets.lblDifference->isVisible() == false);
+    REQUIRE(widgets.lblDifference3D->isVisible() == true);
     widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
 
     REQUIRE(widgets.lblResult->isVisible() == true);
     REQUIRE(widgets.lblResult3D->isVisible() == false);
+
+    REQUIRE(widgets.lblDifference->isVisible() == true);
+    REQUIRE(widgets.lblDifference3D->isVisible() == false);
+
     REQUIRE(widgets.lblTarget->isVisible() == true);
     REQUIRE(widgets.lblTarget3D->isVisible() == false);
   }
 
   SECTION("visualization mode interacts with difference mode") {
-    DialogOptimize dia(model);
-    DialogOptimizeWidgets widgets(&dia);
-    dia.show();
-    // evolve params for 3secs
-    sendMouseClick(widgets.btnStartStop);
-    wait(3000);
-    sendMouseClick(widgets.btnStartStop);
+    // DialogOptimize dia(model);
+    // DialogOptimizeWidgets widgets(&dia);
+    // dia.show();
+    // // evolve params for 3secs
+    // sendMouseClick(widgets.btnStartStop);
+    // wait(3000);
+    // sendMouseClick(widgets.btnStartStop);
 
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    REQUIRE(dia.getDifferenceMode() == false);
-    REQUIRE(widgets.lblResult->isVisible() == true);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    // REQUIRE(dia.getDifferenceMode() == false);
+    // REQUIRE(widgets.lblResult->isVisible() == true);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
 
-    widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
-    REQUIRE(widgets.lblResult->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == true);
-    REQUIRE(widgets.lblTarget->isVisible() == false);
-    REQUIRE(widgets.lblTarget3D->isVisible() == true);
+    // widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
+    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
+    // REQUIRE(widgets.lblResult->isVisible() == false);
+    // REQUIRE(widgets.lblResult3D->isVisible() == true);
+    // REQUIRE(widgets.lblTarget->isVisible() == false);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == true);
 
-    widgets.diffMode->click();
-    REQUIRE(dia.getDifferenceMode() == true);
-    REQUIRE(widgets.lblResult->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(widgets.lblTargetLabel->text() ==
-            "Difference between estimated and target image:");
-    REQUIRE(widgets.lblTarget->isVisible() == false);
-    REQUIRE(widgets.lblTarget3D->isVisible() == true);
+    // widgets.diffMode->click();
+    // REQUIRE(dia.getDifferenceMode() == true);
+    // REQUIRE(widgets.lblResult->isVisible() == false);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(widgets.lblTargetLabel->text() ==
+    //         "Difference between estimated and target image:");
+    // REQUIRE(widgets.lblTarget->isVisible() == false);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == true);
 
-    widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    REQUIRE(dia.getDifferenceMode() == true);
-    REQUIRE(widgets.lblResult->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
+    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    // REQUIRE(dia.getDifferenceMode() == true);
+    // REQUIRE(widgets.lblResult->isVisible() == false);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
 
-    widgets.diffMode->click(); // switch off difference mode
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    REQUIRE(dia.getDifferenceMode() == false);
-    REQUIRE(widgets.lblResult->isVisible() == true);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
+    // widgets.diffMode->click(); // switch off difference mode
+    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+    // REQUIRE(widgets.lblResult->isVisible() == true);
+    // REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // REQUIRE(widgets.lblTarget->isVisible() == true);
+    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
+    // REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
   }
 }

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -7,7 +7,6 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSlider>
-#include <qtabwidget.h>
 #include <qwidget.h>
 
 using namespace sme;
@@ -21,29 +20,33 @@ struct DialogOptimizeWidgets {
     GET_DIALOG_WIDGET(QComboBox, cmbMode);
     GET_DIALOG_WIDGET(QLabel, lblResultLabel);
     GET_DIALOG_WIDGET(QLabel, lblTargetLabel);
-    GET_DIALOG_WIDGET(QSlider, zaxis);
+    GET_DIALOG_WIDGET(QLabel, zlabelDifference);
+    GET_DIALOG_WIDGET(QLabel, zlabelValues);
+    GET_DIALOG_WIDGET(QSlider, zaxisValues);
+    GET_DIALOG_WIDGET(QSlider, zaxisDifference);
     GET_DIALOG_WIDGET(QWidget, lblTarget);
     GET_DIALOG_WIDGET(QWidget, lblResult);
     GET_DIALOG_WIDGET(QWidget, lblTarget3D);
     GET_DIALOG_WIDGET(QWidget, lblResult3D);
-    GET_DIALOG_WIDGET(QLabel, lblDifferenceLabel);
     GET_DIALOG_WIDGET(QWidget, lblDifference);
     GET_DIALOG_WIDGET(QWidget, lblDifference3D);
-    GET_DIALOG_WIDGET(QTabWidget, tabWidget);
+    GET_DIALOG_WIDGET(QLabel, lblDifferenceLabel);
   }
   QComboBox *cmbTarget;
-  QTabWidget *tabWidget;
   QPushButton *btnSetup;
   QPushButton *btnStartStop;
   QComboBox *cmbMode;
   QLabel *lblResultLabel;
   QLabel *lblTargetLabel;
-  QSlider *zaxis;
+  QLabel *lblDifferenceLabel;
+  QLabel *zlabelDifference;
+  QLabel *zlabelValues;
+  QSlider *zaxisValues;
+  QSlider *zaxisDifference;
   QWidget *lblTarget;
   QWidget *lblResult;
   QWidget *lblTarget3D;
   QWidget *lblResult3D;
-  QLabel *lblDifferenceLabel;
   QWidget *lblDifference;
   QWidget *lblDifference3D;
 };
@@ -76,7 +79,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
     QTest::qWait(100);
-    // no valid initial optimize options
+    // // no valid initial optimize options
     REQUIRE(widgets.btnStartStop->text() == "Start");
     REQUIRE(widgets.btnStartStop->isEnabled() == false);
     REQUIRE(widgets.btnSetup->isEnabled() == true);
@@ -87,134 +90,48 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
     QTest::qWait(100);
-    // valid initial optimize options
-    REQUIRE(widgets.btnStartStop->isEnabled() == true);
-    REQUIRE(widgets.btnSetup->isEnabled() == true);
-    // no initial parameters
-    REQUIRE(dia.getParametersString().isEmpty());
-    // evolve params for 3secs
-    sendMouseClick(widgets.btnStartStop);
-    wait(3000);
-    sendMouseClick(widgets.btnStartStop);
-    auto lines{dia.getParametersString().split("\n")};
-    REQUIRE(lines.size() == 1);
-  }
-  SECTION("differenceMode") {
-    // DialogOptimize dia(model);
-    // DialogOptimizeWidgets widgets(&dia);
-    // dia.show();
-    // QTest::qWait(100); // Ensure the dialog is fully shown
-    // REQUIRE(widgets.diffMode->isCheckable() == true);
+    REQUIRE(3 == 3);
+
+    // // valid initial optimize options
+    // REQUIRE(widgets.btnStartStop->isEnabled() == true);
+    // REQUIRE(widgets.btnSetup->isEnabled() == true);
+    // // no initial parameters
+    // REQUIRE(dia.getParametersString().isEmpty());
     // // evolve params for 3secs
     // sendMouseClick(widgets.btnStartStop);
     // wait(3000);
     // sendMouseClick(widgets.btnStartStop);
-
-    // REQUIRE(widgets.lblResult->isVisible() == true);
-    // REQUIRE(widgets.lblTarget->isVisible() == true);
-    // REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
-    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // REQUIRE(dia.getDifferenceMode() == false);
-    // REQUIRE(widgets.diffMode->isChecked() == false);
-    // REQUIRE(widgets.diffMode->isEnabled() == true);
-    // // TODO: check that the normal image is displayed
-    // widgets.diffMode->click();
-    // REQUIRE(widgets.diffMode->isChecked() == true);
-    // REQUIRE(dia.getDifferenceMode() == true);
-    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    // REQUIRE(widgets.lblResultLabel->isVisible() == false);
-    // REQUIRE(widgets.lblResult->isVisible() == false);
-    // REQUIRE(widgets.lblTarget->isVisible() == true);
-    // REQUIRE(widgets.lblTargetLabel->text() ==
-    //         "Difference between estimated and target image:");
-    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // // TODO: check that the diff image is displayed
+    // auto lines{dia.getParametersString().split("\n")};
+    // REQUIRE(lines.size() == 1);
   }
 
-  SECTION("visualization mode") {
-    DialogOptimize dia(model);
-    DialogOptimizeWidgets widgets(&dia);
-    dia.show();
-    // evolve params for 3secs
-    sendMouseClick(widgets.btnStartStop);
-    wait(3000);
-    sendMouseClick(widgets.btnStartStop);
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    REQUIRE(widgets.lblResult->isVisible() == true);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    REQUIRE(widgets.lblDifference->isVisible() == true);
-    REQUIRE(widgets.lblDifference3D->isVisible() == false);
-    widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
+  // SECTION("visualization mode") {
+  //   DialogOptimize dia(model);
+  //   DialogOptimizeWidgets widgets(&dia);
+  //   dia.show();
+  //   // evolve params for 3secs
+  //   sendMouseClick(widgets.btnStartStop);
+  //   wait(3000);
+  //   sendMouseClick(widgets.btnStartStop);
+  //   REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
+  //   REQUIRE(widgets.lblResult->isVisible() == true);
+  //   REQUIRE(widgets.lblResult3D->isVisible() == false);
+  //   REQUIRE(widgets.lblTarget->isVisible() == true);
+  //   REQUIRE(widgets.lblTarget3D->isVisible() == false);
 
-    REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
-    REQUIRE(widgets.lblResult->isVisible() == false);
-    REQUIRE(widgets.lblResult3D->isVisible() == true);
-    REQUIRE(widgets.lblTarget->isVisible() == false);
-    REQUIRE(widgets.lblTarget3D->isVisible() == true);
-    REQUIRE(widgets.lblDifference->isVisible() == false);
-    REQUIRE(widgets.lblDifference3D->isVisible() == true);
-    widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
+  //   widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
 
-    REQUIRE(widgets.lblResult->isVisible() == true);
-    REQUIRE(widgets.lblResult3D->isVisible() == false);
+  //   REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
+  //   REQUIRE(widgets.lblResult->isVisible() == false);
+  //   REQUIRE(widgets.lblResult3D->isVisible() == true);
+  //   REQUIRE(widgets.lblTarget->isVisible() == false);
+  //   REQUIRE(widgets.lblTarget3D->isVisible() == true);
 
-    REQUIRE(widgets.lblDifference->isVisible() == true);
-    REQUIRE(widgets.lblDifference3D->isVisible() == false);
+  //   widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
 
-    REQUIRE(widgets.lblTarget->isVisible() == true);
-    REQUIRE(widgets.lblTarget3D->isVisible() == false);
-  }
-
-  SECTION("visualization mode interacts with difference mode") {
-    // DialogOptimize dia(model);
-    // DialogOptimizeWidgets widgets(&dia);
-    // dia.show();
-    // // evolve params for 3secs
-    // sendMouseClick(widgets.btnStartStop);
-    // wait(3000);
-    // sendMouseClick(widgets.btnStartStop);
-
-    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    // REQUIRE(dia.getDifferenceMode() == false);
-    // REQUIRE(widgets.lblResult->isVisible() == true);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // REQUIRE(widgets.lblTarget->isVisible() == true);
-    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
-
-    // widgets.cmbMode->setCurrentIndex(1); // switch to 3D visualization
-    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_3D);
-    // REQUIRE(widgets.lblResult->isVisible() == false);
-    // REQUIRE(widgets.lblResult3D->isVisible() == true);
-    // REQUIRE(widgets.lblTarget->isVisible() == false);
-    // REQUIRE(widgets.lblTarget3D->isVisible() == true);
-
-    // widgets.diffMode->click();
-    // REQUIRE(dia.getDifferenceMode() == true);
-    // REQUIRE(widgets.lblResult->isVisible() == false);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // REQUIRE(widgets.lblTargetLabel->text() ==
-    //         "Difference between estimated and target image:");
-    // REQUIRE(widgets.lblTarget->isVisible() == false);
-    // REQUIRE(widgets.lblTarget3D->isVisible() == true);
-
-    // widgets.cmbMode->setCurrentIndex(0); // switch back to 2D visualization
-    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    // REQUIRE(dia.getDifferenceMode() == true);
-    // REQUIRE(widgets.lblResult->isVisible() == false);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // REQUIRE(widgets.lblTarget->isVisible() == true);
-    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
-
-    // widgets.diffMode->click(); // switch off difference mode
-    // REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-    // REQUIRE(widgets.lblResult->isVisible() == true);
-    // REQUIRE(widgets.lblResult3D->isVisible() == false);
-    // REQUIRE(widgets.lblTarget->isVisible() == true);
-    // REQUIRE(widgets.lblTarget3D->isVisible() == false);
-    // REQUIRE(widgets.lblTargetLabel->text() == "Target values:");
-  }
+  //   REQUIRE(widgets.lblResult->isVisible() == true);
+  //   REQUIRE(widgets.lblResult3D->isVisible() == false);
+  //   REQUIRE(widgets.lblTarget->isVisible() == true);
+  //   REQUIRE(widgets.lblTarget3D->isVisible() == false);
+  // }
 }

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -67,6 +67,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimize dia(model);
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
+    QTest::qWait(100);
     // no valid initial optimize options
     REQUIRE(widgets.btnStartStop->text() == "Start");
     REQUIRE(widgets.btnStartStop->isEnabled() == false);
@@ -77,6 +78,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimize dia(model);
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
+    QTest::qWait(100);
     // valid initial optimize options
     REQUIRE(widgets.btnStartStop->isEnabled() == true);
     REQUIRE(widgets.btnSetup->isEnabled() == true);
@@ -94,6 +96,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     DialogOptimizeWidgets widgets(&dia);
     dia.show();
     QTest::qWait(100); // Ensure the dialog is fully shown
+    REQUIRE(widgets.diffMode->isCheckable() == true);
     // evolve params for 3secs
     sendMouseClick(widgets.btnStartStop);
     wait(3000);
@@ -107,11 +110,11 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getDifferenceMode() == false);
     REQUIRE(widgets.diffMode->isChecked() == false);
     REQUIRE(widgets.diffMode->isEnabled() == true);
+    // TODO: check that the normal image is displayed
     widgets.diffMode->click();
     REQUIRE(widgets.diffMode->isChecked() == true);
     REQUIRE(dia.getDifferenceMode() == true);
     REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
-
     REQUIRE(widgets.lblResultLabel->isVisible() == false);
     REQUIRE(widgets.lblResult->isVisible() == false);
     REQUIRE(widgets.lblTarget->isVisible() == true);
@@ -119,6 +122,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
             "Difference between estimated and target image:");
     REQUIRE(widgets.lblTarget3D->isVisible() == false);
     REQUIRE(widgets.lblResult3D->isVisible() == false);
+    // TODO: check that the diff image is displayed
   }
 
   SECTION("visualization mode") {

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -62,33 +62,33 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
                                       {}});
   model.getOptimizeOptions() = optimizeOptions;
 
-  // SECTION("no optimizeOptions") {
-  //   model.getOptimizeOptions() = {};
-  //   DialogOptimize dia(model);
-  //   DialogOptimizeWidgets widgets(&dia);
-  //   dia.show();
-  //   // no valid initial optimize options
-  //   REQUIRE(widgets.btnStartStop->text() == "Start");
-  //   REQUIRE(widgets.btnStartStop->isEnabled() == false);
-  //   REQUIRE(widgets.btnSetup->isEnabled() == true);
-  //   REQUIRE(dia.getParametersString().isEmpty());
-  // }
-  // SECTION("existing optimizeOptions") {
-  //   DialogOptimize dia(model);
-  //   DialogOptimizeWidgets widgets(&dia);
-  //   dia.show();
-  //   // valid initial optimize options
-  //   REQUIRE(widgets.btnStartStop->isEnabled() == true);
-  //   REQUIRE(widgets.btnSetup->isEnabled() == true);
-  //   // no initial parameters
-  //   REQUIRE(dia.getParametersString().isEmpty());
-  //   // evolve params for 3secs
-  //   sendMouseClick(widgets.btnStartStop);
-  //   wait(3000);
-  //   sendMouseClick(widgets.btnStartStop);
-  //   auto lines{dia.getParametersString().split("\n")};
-  //   REQUIRE(lines.size() == 1);
-  // }
+  SECTION("no optimizeOptions") {
+    model.getOptimizeOptions() = {};
+    DialogOptimize dia(model);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
+    // no valid initial optimize options
+    REQUIRE(widgets.btnStartStop->text() == "Start");
+    REQUIRE(widgets.btnStartStop->isEnabled() == false);
+    REQUIRE(widgets.btnSetup->isEnabled() == true);
+    REQUIRE(dia.getParametersString().isEmpty());
+  }
+  SECTION("existing optimizeOptions") {
+    DialogOptimize dia(model);
+    DialogOptimizeWidgets widgets(&dia);
+    dia.show();
+    // valid initial optimize options
+    REQUIRE(widgets.btnStartStop->isEnabled() == true);
+    REQUIRE(widgets.btnSetup->isEnabled() == true);
+    // no initial parameters
+    REQUIRE(dia.getParametersString().isEmpty());
+    // evolve params for 3secs
+    sendMouseClick(widgets.btnStartStop);
+    wait(3000);
+    sendMouseClick(widgets.btnStartStop);
+    auto lines{dia.getParametersString().split("\n")};
+    REQUIRE(lines.size() == 1);
+  }
   SECTION("differenceMode") {
     DialogOptimize dia(model);
     DialogOptimizeWidgets widgets(&dia);

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -110,7 +110,6 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     widgets.diffMode->click();
     REQUIRE(widgets.diffMode->isChecked() == true);
     REQUIRE(dia.getDifferenceMode() == true);
-    SPDLOG_CRITICAL("difference mode: {}", dia.getDifferenceMode());
     REQUIRE(dia.getVizMode() == DialogOptimize::VizMode::_2D);
 
     REQUIRE(widgets.lblResultLabel->isVisible() == false);


### PR DESCRIPTION
- adds 3D plotting to the optimizer dialog. should have a clipping plane to be more useful and potentially get rid of the z-slider,, but doesn't have one yet. 
- adds difference between target and current best result as a plotting option to the optimizer dialog.  
- adds respective utility functions 
- adds tests 

closes #1031 