### PR TITLE
Add clipping planes to MeshRenderer and VoxelRenderer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
       - id: check-github-workflows
       - id: check-readthedocs
   - repo: https://github.com/google/yamlfmt
-    rev: v0.17.1
+    rev: v0.17.2
     hooks:
       - id: yamlfmt

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -331,9 +331,7 @@ void DialogOptimize::updateResultImage() {
   }
 
   if (vizMode == VizMode::_2D) {
-    auto z = ui->zaxisValues->value();
     ui->lblResult->setImage(m_opt->getCurrentBestResultImage());
-    // ui->lblResult->setZIndex(z);
   } else {
     SPDLOG_DEBUG("Updating result image for 3D visualization  2D visible? {}, "
                  "3d visible? {}",

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -100,6 +100,8 @@ MainWindow::MainWindow(const QString &filename, QWidget *parent)
     : QMainWindow(parent), ui{std::make_unique<Ui::MainWindow>()} {
   ui->setupUi(this);
   ui->lblGeometry->setZSlider(ui->slideGeometryZIndex);
+  ui->voxGeometry->setClippingPlaneNormalCombobox(ui->cmbClippingPlaneNormal);
+  ui->voxGeometry->setClippingPlaneOriginSlider(ui->slideClippingPlaneOrigin);
   Q_INIT_RESOURCE(resources);
 
   statusBarPermanentMessage = makeStatusBarPermanentMessage(this);
@@ -640,12 +642,7 @@ void MainWindow::actionGeometry_scale_triggered(bool checked) {
 }
 
 void MainWindow::action3d_render_triggered(bool checked) {
-  if (checked) {
-    ui->stackGeometry->setCurrentIndex(1);
-    ui->voxGeometry->setImage(model.getGeometry().getImages());
-    return;
-  }
-  ui->stackGeometry->setCurrentIndex(0);
+  ui->stackGeometry->setCurrentIndex(checked ? 1 : 0);
 }
 
 void MainWindow::actionInvert_y_axis_triggered(bool checked) {

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -30,117 +30,181 @@
        <bool>false</bool>
       </property>
       <widget class="QWidget" name="gridLayoutWidget">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="1">
-         <widget class="QSlider" name="slideGeometryZIndex">
-          <property name="maximum">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QStackedWidget" name="stackGeometry">
+          <property name="currentIndex">
            <number>0</number>
           </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="invertedControls">
-           <bool>false</bool>
-          </property>
-          <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
-          </property>
-          <property name="tickInterval">
-           <number>1</number>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QSpinBox" name="spinGeometryZoom">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximum">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="4">
-         <widget class="QStackedWidget" name="stackGeometry">
-          <widget class="QWidget" name="page1">
+          <widget class="QWidget" name="geom2d">
            <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
-             <widget class="QScrollArea" name="scrollGeometry">
-              <property name="widgetResizable">
-               <bool>true</bool>
-              </property>
-              <widget class="QWidget" name="scrollGeometryContents">
-               <property name="geometry">
-                <rect>
-                 <x>0</x>
-                 <y>0</y>
-                 <width>723</width>
-                 <height>567</height>
-                </rect>
-               </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_3">
-                <item>
-                 <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <item>
+               <layout class="QGridLayout" name="gridLayout_3">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblZIndexLabel">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
-&lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
-                  </property>
-                  <property name="text" stdset="0">
-                   <string/>
+                  <property name="text">
+                   <string>z-slice</string>
                   </property>
                  </widget>
                 </item>
+                <item row="0" column="1">
+                 <widget class="QSlider" name="slideGeometryZIndex">
+                  <property name="maximum">
+                   <number>0</number>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="invertedControls">
+                   <bool>false</bool>
+                  </property>
+                  <property name="tickPosition">
+                   <enum>QSlider::TicksBothSides</enum>
+                  </property>
+                  <property name="tickInterval">
+                   <number>1</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QLabel" name="lblGeometryZoomLabel">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>zoom:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QSpinBox" name="spinGeometryZoom">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximum">
+                   <number>10</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0" colspan="4">
+                 <widget class="QScrollArea" name="scrollGeometry">
+                  <property name="widgetResizable">
+                   <bool>true</bool>
+                  </property>
+                  <widget class="QWidget" name="scrollGeometryContents">
+                   <property name="geometry">
+                    <rect>
+                     <x>0</x>
+                     <y>0</y>
+                     <width>743</width>
+                     <height>578</height>
+                    </rect>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_9">
+                    <item>
+                     <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="whatsThis">
+                       <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
+&lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
+                      </property>
+                      <property name="text" stdset="0">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </widget>
+                </item>
                </layout>
-              </widget>
-             </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </widget>
-          <widget class="QWidget" name="page2">
+          <widget class="QWidget" name="geom3d">
            <layout class="QHBoxLayout" name="horizontalLayout_8">
             <item>
-             <widget class="QVoxelRenderer" name="voxGeometry"/>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="0">
+               <widget class="QLabel" name="lblClippingPlaneNormalLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>clip-plane</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QSlider" name="slideClippingPlaneOrigin">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="invertedControls">
+                 <bool>false</bool>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBothSides</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>1</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="3">
+               <widget class="QVoxelRenderer" name="voxGeometry">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="cmbClippingPlaneNormal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="currentText">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </widget>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="lblGeometryStatus">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Z index</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="lblGeometryZoomLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Zoom:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
          </widget>
         </item>
        </layout>
@@ -240,7 +304,7 @@
      <x>0</x>
      <y>0</y>
      <width>1400</width>
-     <height>22</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -347,14 +411,6 @@
    <addaction name="menu_Help"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
-  <widget class="QToolBar" name="mainToolBar">
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-  </widget>
   <action name="actionE_xit">
    <property name="text">
     <string>E&amp;xit</string>

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -91,6 +91,7 @@ TabGeometry::TabGeometry(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
   connect(ui->listMembranes, &QListWidget::itemSelectionChanged, this,
           &TabGeometry::listMembranes_itemSelectionChanged);
   ui->mshCompMesh->syncCamera(voxGeometry);
+  ui->mshCompMesh->syncClippingPlane(voxGeometry);
 }
 
 TabGeometry::~TabGeometry() = default;

--- a/gui/widgets/qmeshrenderer.hpp
+++ b/gui/widgets/qmeshrenderer.hpp
@@ -6,12 +6,16 @@
 #include <QMouseEvent>
 #include <vtkActor.h>
 #include <vtkCellArray.h>
+#include <vtkClipDataSet.h>
 #include <vtkDataSetMapper.h>
 #include <vtkExtractEdges.h>
 #include <vtkNew.h>
+#include <vtkPlane.h>
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
 #include <vtkUnstructuredGrid.h>
+
+class QVoxelRenderer;
 
 class QMeshRenderer : public SmeVtkWidget {
   Q_OBJECT
@@ -24,6 +28,7 @@ public:
   explicit QMeshRenderer(QWidget *parent = nullptr);
   void setMesh(const sme::mesh::Mesh3d &mesh, std::size_t compartmentIndex,
                bool resetCamera = true);
+  void syncClippingPlane(QVoxelRenderer *qVoxelRenderer);
   void setCompartmentIndex(std::size_t compartmentIndex);
   void setMembraneIndex(std::size_t membraneIndex);
   void setColors(std::vector<QRgb> newColors);
@@ -39,6 +44,7 @@ protected:
 
 private:
   void updateAndRender();
+  vtkPlane *clippingPlane = nullptr;
   QPoint lastMouseClickPos{};
   std::size_t currentCompartmentIndex{0};
   RenderMode renderMode{RenderMode::Solid};
@@ -46,7 +52,10 @@ private:
   std::vector<vtkNew<vtkUnstructuredGrid>> grids{};
   std::vector<vtkNew<vtkCellArray>> triangles{};
   std::vector<vtkNew<vtkPolyData>> membranes{};
+  std::vector<vtkNew<vtkClipDataSet>> clippedMembranes{};
+  std::vector<vtkNew<vtkClipDataSet>> clippedTetrahedrons{};
   std::vector<vtkNew<vtkExtractEdges>> edges{};
+  std::vector<vtkNew<vtkClipDataSet>> clippedEdges{};
   std::vector<vtkNew<vtkDataSetMapper>> solidMappers{};
   std::vector<vtkNew<vtkDataSetMapper>> wireframeMappers{};
   std::vector<vtkNew<vtkActor>> solidActors{};

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -2,11 +2,14 @@
 
 #include "sme/image_stack.hpp"
 #include "smevtkwidget.hpp"
+#include <QComboBox>
+#include <QSlider>
 #include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
+#include <vtkPlane.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkVolume.h>
 #include <vtkVolumeProperty.h>
@@ -16,6 +19,10 @@ class QVoxelRenderer : public SmeVtkWidget {
 public:
   explicit QVoxelRenderer(QWidget *parent = nullptr);
   void setImage(const sme::common::ImageStack &img);
+  void setClippingPlaneOriginSlider(QSlider *slider);
+  void setClippingPlaneNormalCombobox(QComboBox *combobox);
+  void renderOnClippingPaneChange(SmeVtkWidget *smeVtkWidget);
+  inline vtkPlane *getClippingPlane() { return clippingPlane.Get(); }
 
 signals:
   void mouseClicked(QRgb col, sme::common::Voxel voxel);
@@ -29,5 +36,12 @@ private:
   vtkNew<vtkPiecewiseFunction> opacityTransferFunction;
   vtkNew<vtkImageData> imageData;
   vtkNew<vtkUnsignedCharArray> imageDataArray;
+  vtkNew<vtkPlane> clippingPlane;
   QString lengthUnits{};
+  SmeVtkWidget *smeVtkWidgetToRenderOnClippingPlaneChange{nullptr};
+  double maxClippingPlaneOrigin{0.0};
+  QSlider *slideClippingPlaneOrigin{nullptr};
+  QComboBox *cmbClippingPlaneNormal{nullptr};
+  void slideClippingPlaneOrigin_valueChanged(int value);
+  void cmbClippingPlaneNormal_currentTextChanged(const QString &text);
 };

--- a/gui/widgets/smevtkwidget.cpp
+++ b/gui/widgets/smevtkwidget.cpp
@@ -35,6 +35,8 @@ void SmeVtkWidget::syncCamera(SmeVtkWidget *smeVtkWidget) {
   smeVtkWidget->renderOnInteractorModified(renderWindow->GetInteractor());
 }
 
+void SmeVtkWidget::vtkRender() { renderWindow->Render(); }
+
 void SmeVtkWidget::renderOnInteractorModified(
     vtkRenderWindowInteractor *interactor) {
   interactor->AddObserver(vtkCommand::ModifiedEvent, renderWindow.Get(),

--- a/gui/widgets/smevtkwidget.hpp
+++ b/gui/widgets/smevtkwidget.hpp
@@ -13,6 +13,7 @@ class SmeVtkWidget : public QVTKOpenGLNativeWidget {
 public:
   explicit SmeVtkWidget(QWidget *parent = nullptr);
   void syncCamera(SmeVtkWidget *smeVtkWidget);
+  void vtkRender();
 
 protected:
   vtkNew<vtkRenderer> renderer;

--- a/gui/widgets/smevtkwidget_t.cpp
+++ b/gui/widgets/smevtkwidget_t.cpp
@@ -18,28 +18,53 @@ TEST_CASE("SmeVtkWidget",
   QVoxelRenderer voxelRenderer;
   voxelRenderer.show();
   voxelRenderer.resize(200, 200);
+  QSlider slider;
+  slider.show();
+  QComboBox comboBox;
+  comboBox.show();
   auto model = sme::test::getExampleModel(Mod::VerySimpleModel3D);
   meshRenderer.setMesh(*model.getGeometry().getMesh3d(), 0);
   voxelRenderer.setImage(model.getGeometry().getImages());
   wait(delay_ms);
   // mouse interactions with two independent SmeVtkWidgets
-  sendMouseDrag(&meshRenderer, {100, 100}, {120, 120});
+  sendMouseDrag(&meshRenderer, {100, 100}, {105, 108});
   wait(delay_ms);
-  sendMouseDrag(&voxelRenderer, {110, 120}, {80, 90});
+  sendMouseDrag(&voxelRenderer, {110, 120}, {100, 110});
   wait(delay_ms);
   meshRenderer.syncCamera(&voxelRenderer);
-  // mouse interactions with two synced SmeVtkWidgets
-  sendMouseDrag(&meshRenderer, {100, 100}, {150, 150});
+  // mouse interactions with two synced camera SmeVtkWidgets
+  sendMouseDrag(&meshRenderer, {100, 100}, {110, 106});
   wait(delay_ms);
-  sendMouseDrag(&voxelRenderer, {160, 160}, {80, 50});
+  sendMouseDrag(&voxelRenderer, {160, 160}, {150, 152});
   wait(delay_ms);
   // change physical size of a voxel
   model.getGeometry().setVoxelSize({1.0, 1.5, 2.0});
   voxelRenderer.setImage(model.getGeometry().getImages());
   meshRenderer.setMesh(*model.getGeometry().getMesh3d(), 0);
   wait(delay_ms);
-  sendMouseDrag(&meshRenderer, {100, 100}, {150, 150});
+  sendMouseDrag(&meshRenderer, {100, 100}, {110, 112});
   wait(delay_ms);
-  sendMouseDrag(&voxelRenderer, {160, 160}, {80, 50});
+  sendMouseDrag(&voxelRenderer, {160, 160}, {150, 151});
+  wait(delay_ms);
+  // connect a slider and combobox to control the voxelRenderer clipping plane
+  voxelRenderer.setClippingPlaneOriginSlider(&slider);
+  voxelRenderer.setClippingPlaneNormalCombobox(&comboBox);
+  // sync the clipping plane with the meshRenderer
+  meshRenderer.syncClippingPlane(&voxelRenderer);
+  voxelRenderer.setImage(model.getGeometry().getImages());
+  meshRenderer.setMesh(*model.getGeometry().getMesh3d(), 0);
+  QStringList pageUpPageDown{"PgUp",   "PgUp",   "PgUp",   "PgUp",   "PgUp",
+                             "PgUp",   "PgUp",   "PgDown", "PgDown", "PgDown",
+                             "PgDown", "PgDown", "PgDown", "PgDown"};
+  // clip in the z-direction
+  sendKeyEvents(&slider, pageUpPageDown);
+  wait(delay_ms);
+  // clip in the y-direction
+  sendKeyEvents(&comboBox, {"Up"});
+  sendKeyEvents(&slider, pageUpPageDown);
+  wait(delay_ms);
+  // clip in the x-direction
+  sendKeyEvents(&comboBox, {"Up"});
+  sendKeyEvents(&slider, pageUpPageDown);
   wait(delay_ms);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ SME_LOG_LEVEL = "OFF"
 build-verbosity = 3
 test-extras = "test"
 test-command = "python -m pytest {project}/sme/test -v"
-skip = '*-manylinux_i686 *-musllinux* pp*-* *-win32'
+skip = '*-manylinux_i686 *-musllinux* *-win32'


### PR DESCRIPTION
- for VoxelRenderer we can simply add the clipping plane to the volume mapper
- for MeshRenderer we need to include a vtkClipDataSet in the pipeline to remove elements before they are mapped
- sync clipping plane between meshrenderer and voxelrenderer
- MainWindow
  - add x/y/z clipping plane and plane origin slider when 3d render is displayed
  - make mainwindow z-slice slider only visible when 2d render is displayed
- also: always update VoxelRender image even when not visible, otherwise when 3d is enabled the displayed image is not correct
- resolves #972
